### PR TITLE
operation-aware logging and OTEL tracing across all operations

### DIFF
--- a/api/logger/logger.go
+++ b/api/logger/logger.go
@@ -4,15 +4,16 @@
 // written to a configurable io.Writer (stdout by default). The log collector
 // worker reads from the pipe and emits LogEntry events to the event bus.
 //
-// The Logger carries a source tag (e.g. "server", "gobservability") and
-// supports operation-scoped logging via Op* methods that include the
-// operation ID and redacted operation context in the JSON output.
+// The default log methods (Trace, Debug, Info, Warn, Error) require an
+// operation context. Use TraceNoCtx, DebugNoCtx, etc. for the rare cases
+// where no operation is active (early startup, plugin loading).
 package logger
 
 import (
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 
 	ops "gocache/api/operations"
 
@@ -34,41 +35,26 @@ func New(w io.Writer, source, level string) *Logger {
 	return &Logger{zl: zl}
 }
 
-// --- Standard log methods (no operation context) ---
+// --- Default log methods (WITH operation context) ---
+// These are the standard methods. Every log call should pass an operation.
+// The operation may be nil — context is simply omitted in that case.
 
-func (l *Logger) Trace() *zerolog.Event { return l.zl.Trace() }
-func (l *Logger) Debug() *zerolog.Event { return l.zl.Debug() }
-func (l *Logger) Info() *zerolog.Event  { return l.zl.Info() }
-func (l *Logger) Warn() *zerolog.Event  { return l.zl.Warn() }
-func (l *Logger) Error() *zerolog.Event { return l.zl.Error() }
-func (l *Logger) Fatal() *zerolog.Event { return l.zl.Fatal() }
+func (l *Logger) Trace(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Trace(), op: op} }
+func (l *Logger) Debug(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Debug(), op: op} }
+func (l *Logger) Info(op *ops.Operation) *OpEvent  { return &OpEvent{event: l.zl.Info(), op: op} }
+func (l *Logger) Warn(op *ops.Operation) *OpEvent  { return &OpEvent{event: l.zl.Warn(), op: op} }
+func (l *Logger) Error(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Error(), op: op} }
 
-// --- Operation-scoped log methods ---
+// --- NoCtx methods (WITHOUT operation context) ---
+// For the rare cases where no operation is active: early startup, plugin loading,
+// shutdown after operations are cleaned up.
 
-// OpTrace logs at Trace level with operation context.
-func (l *Logger) OpTrace(op *ops.Operation) *OpEvent {
-	return &OpEvent{event: l.zl.Trace(), op: op}
-}
-
-// OpDebug logs at Debug level with operation context.
-func (l *Logger) OpDebug(op *ops.Operation) *OpEvent {
-	return &OpEvent{event: l.zl.Debug(), op: op}
-}
-
-// OpInfo logs at Info level with operation context.
-func (l *Logger) OpInfo(op *ops.Operation) *OpEvent {
-	return &OpEvent{event: l.zl.Info(), op: op}
-}
-
-// OpWarn logs at Warn level with operation context.
-func (l *Logger) OpWarn(op *ops.Operation) *OpEvent {
-	return &OpEvent{event: l.zl.Warn(), op: op}
-}
-
-// OpError logs at Error level with operation context.
-func (l *Logger) OpError(op *ops.Operation) *OpEvent {
-	return &OpEvent{event: l.zl.Error(), op: op}
-}
+func (l *Logger) TraceNoCtx() *zerolog.Event { return l.zl.Trace() }
+func (l *Logger) DebugNoCtx() *zerolog.Event { return l.zl.Debug() }
+func (l *Logger) InfoNoCtx() *zerolog.Event  { return l.zl.Info() }
+func (l *Logger) WarnNoCtx() *zerolog.Event  { return l.zl.Warn() }
+func (l *Logger) ErrorNoCtx() *zerolog.Event { return l.zl.Error() }
+func (l *Logger) FatalNoCtx() *zerolog.Event { return l.zl.Fatal() }
 
 // OpEvent wraps a zerolog.Event with an optional operation.
 // On Msg/Msgf, the operation's ID and redacted context are injected into JSON.
@@ -102,6 +88,11 @@ func (e *OpEvent) Strs(key string, vals []string) *OpEvent {
 	return e
 }
 
+func (e *OpEvent) Dur(key string, val time.Duration) *OpEvent {
+	e.event = e.event.Dur(key, val)
+	return e
+}
+
 func (e *OpEvent) Interface(key string, val interface{}) *OpEvent {
 	e.event = e.event.Interface(key, val)
 	return e
@@ -130,13 +121,17 @@ func (e *OpEvent) injectContext() {
 
 // --- Default logger (server uses this, writes to stdout) ---
 
-var (
-	defaultLogger atomic.Pointer[Logger]
-)
+var defaultLogger atomic.Pointer[Logger]
 
 // Init initializes the default server logger writing to stdout.
 func Init(level string) {
 	defaultLogger.Store(New(os.Stdout, "server", level))
+}
+
+// InitWithWriter initializes the default server logger writing to a custom writer.
+// Used by main.go to pipe logs through the log collector while teeing to stderr.
+func InitWithWriter(w io.Writer, level string) {
+	defaultLogger.Store(New(w, "server", level))
 }
 
 // Default returns the default logger. Thread-safe.
@@ -144,17 +139,24 @@ func Default() *Logger {
 	if l := defaultLogger.Load(); l != nil {
 		return l
 	}
-	// Lazy init for tests that don't call Init().
 	l := New(os.Stdout, "server", "info")
 	defaultLogger.CompareAndSwap(nil, l)
 	return defaultLogger.Load()
 }
 
-// --- Package-level convenience functions (delegate to Default()) ---
+// --- Package-level convenience functions (WITH context, delegate to Default()) ---
 
-func Trace() *zerolog.Event { return Default().Trace() }
-func Debug() *zerolog.Event { return Default().Debug() }
-func Info() *zerolog.Event  { return Default().Info() }
-func Warn() *zerolog.Event  { return Default().Warn() }
-func Error() *zerolog.Event { return Default().Error() }
-func Fatal() *zerolog.Event { return Default().Fatal() }
+func Trace(op *ops.Operation) *OpEvent { return Default().Trace(op) }
+func Debug(op *ops.Operation) *OpEvent { return Default().Debug(op) }
+func Info(op *ops.Operation) *OpEvent  { return Default().Info(op) }
+func Warn(op *ops.Operation) *OpEvent  { return Default().Warn(op) }
+func Error(op *ops.Operation) *OpEvent { return Default().Error(op) }
+
+// --- Package-level convenience functions (NO context, delegate to Default()) ---
+
+func TraceNoCtx() *zerolog.Event { return Default().TraceNoCtx() }
+func DebugNoCtx() *zerolog.Event { return Default().DebugNoCtx() }
+func InfoNoCtx() *zerolog.Event  { return Default().InfoNoCtx() }
+func WarnNoCtx() *zerolog.Event  { return Default().WarnNoCtx() }
+func ErrorNoCtx() *zerolog.Event { return Default().ErrorNoCtx() }
+func FatalNoCtx() *zerolog.Event { return Default().FatalNoCtx() }

--- a/api/operations/operations.go
+++ b/api/operations/operations.go
@@ -26,6 +26,7 @@ const (
 	TypeCleanup      Type = "cleanup"
 	TypeSnapshot     Type = "snapshot"
 	TypeStartup      Type = "startup"
+	TypeShutdown     Type = "shutdown"
 	TypeConfigReload Type = "config_reload"
 	TypePluginStart  Type = "plugin_start"
 	TypePluginStop   Type = "plugin_stop"
@@ -38,6 +39,7 @@ var typePrefixes = map[Type]string{
 	TypeCleanup:      "cleanup",
 	TypeSnapshot:     "snap",
 	TypeStartup:      "boot",
+	TypeShutdown:     "shut",
 	TypeConfigReload: "cfg",
 	TypePluginStart:  "pstart",
 	TypePluginStop:   "pstop",

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"sync/atomic"
@@ -11,11 +12,13 @@ import (
 
 	"gocache/api/events"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 	"gocache/pkg/blocking"
 	"gocache/pkg/cache"
 	"gocache/pkg/config"
 	"gocache/pkg/engine"
 	serverEvents "gocache/pkg/events"
+	"gocache/pkg/logcollector"
 	serverOps "gocache/pkg/operations"
 	"gocache/pkg/persistence"
 	"gocache/pkg/plugin/cmdhooks"
@@ -55,7 +58,7 @@ func main() {
 	if err != nil {
 		// Initialize logger with default level for fatal message
 		logger.Init("info")
-		logger.Fatal().Err(err).Msg("failed to load configuration")
+		logger.FatalNoCtx().Err(err).Msg("failed to load configuration")
 	}
 
 	// Wrap the config in an atomic.Pointer so the fsnotify callback goroutine
@@ -64,63 +67,147 @@ func main() {
 	cfgPtr.Store(initialCfg)
 	cfg := initialCfg
 
-	// Initialize structured logging
-	logger.Init(cfg.Server.LogLevel)
-
-	logger.Info().Str("version", version.String()).Msg("starting gocache server")
-	if cfgFile := v.ConfigFileUsed(); cfgFile != "" {
-		logger.Info().Str("file", cfgFile).Msg("config loaded")
+	// Capture server logs via pipe for the log collector.
+	// Logs go to both the pipe (for event emission) and stderr (for console).
+	logPipeR, logPipeW, err := os.Pipe()
+	if err != nil {
+		logger.Init("info")
+		logger.FatalNoCtx().Err(err).Msg("failed to create log pipe")
 	}
-	logger.Info().Str("addr", cfg.Server.GetAddr()).Msg("listening on")
+	logWriter := io.MultiWriter(logPipeW, os.Stderr)
+	logger.InitWithWriter(logWriter, cfg.Server.LogLevel)
 
-	// Initialize core components
+	logger.InfoNoCtx().Str("version", version.String()).Msg("starting gocache server")
+	if cfgFile := v.ConfigFileUsed(); cfgFile != "" {
+		logger.InfoNoCtx().Str("file", cfgFile).Msg("config loaded")
+	}
+	logger.InfoNoCtx().Str("addr", cfg.Server.GetAddr()).Msg("listening on")
+
+	// Initialize core components (no operations yet — infrastructure setup).
 	cacheInstance := cache.NewWithConfig(
 		cfg.Memory.MaxMemoryMB,
 		cache.ParseEvictionPolicy(cfg.Memory.EvictionPolicy),
 	)
 	engineInstance := engine.New(cacheInstance)
+	blockingRegistry := blocking.NewRegistry()
+	watchManager := watch.NewManager()
+	cacheInstance.OnMutate = watchManager.NotifyMutation
+	cacheInstance.OnMutateAll = watchManager.NotifyAll
 
-	// Load snapshot if configured
+	// Initialize infrastructure: tracker + event bus + log collector.
+	tracker := serverOps.NewTracker()
+	eventBus := serverEvents.NewBus()
+	logCollector := logcollector.New(eventBus)
+	logCollector.AddSource("server", logPipeR)
+
+	// Initialize the server (before plugins so we have CoreCommandNames).
+	srv := server.New(cfg.Server.GetAddr(), cacheInstance, engineInstance, cfg.Persistence.SnapshotFile, cfg.Server.RequirePass, blockingRegistry, watchManager)
+	srv.SetEmitter(eventBus)
+	srv.SetTracker(tracker)
+
+	// Set up signal handling.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// --- Plugin loading (NOT an operation — plugins must be ready before operations can be hooked) ---
+	var pluginManager *pluginmgr.Manager
+	var opHookExec *ophooks.Executor
+	if cfg.Plugins.Enabled {
+		pluginManager = pluginmgr.NewManager(cfg.Plugins, srv.CoreCommandNames(), srv)
+		pluginManager.SetLogCollector(logCollector)
+		if err := pluginManager.Start(ctx); err != nil {
+			logger.FatalNoCtx().Err(err).Msg("failed to start plugin manager")
+		}
+		pluginManager.SetEventBus(eventBus)
+		srv.SetPluginRouter(pluginManager.Router())
+		srv.SetHookExecutor(cmdhooks.NewExecutor(pluginManager.HookRegistry(), cfg.Plugins.ShutdownTimeout))
+		opHookExec = ophooks.NewExecutor(pluginManager.OpHookRegistry(), cfg.Plugins.ShutdownTimeout)
+		srv.SetOpHookExecutor(opHookExec)
+	}
+
+	// --- ServerBootstrap operation (after plugins, so operation hooks can enrich) ---
+	bootOp := tracker.Start(ops.TypeStartup, "")
+	bootOp.Enrich("_version", version.String())
+	bootOp.Enrich("_addr", cfg.Server.GetAddr())
+	if opHookExec != nil && opHookExec.HasAny() {
+		opHookExec.RunStartHooks(ctx, bootOp)
+	}
+	eventBus.Emit(events.NewOperationStart(bootOp.ID, string(bootOp.Type), "", bootOp.ContextSnapshot(false)))
+
+	// LoadSnapshot operation.
 	if cfg.Persistence.LoadOnStartup {
+		snapOp := tracker.Start(ops.TypeSnapshot, bootOp.ID)
+		snapOp.Enrich("_file", cfg.Persistence.SnapshotFile)
+		snapOp.Enrich("_trigger", "startup")
+		if opHookExec != nil && opHookExec.HasAny() {
+			opHookExec.RunStartHooks(ctx, snapOp)
+		}
+		eventBus.Emit(events.NewOperationStart(snapOp.ID, string(snapOp.Type), bootOp.ID, snapOp.ContextSnapshot(false)))
 		if err := persistence.LoadSnapshot(cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
-			logger.Warn().Err(err).Msg("failed to load snapshot")
+			logger.Warn(snapOp).Err(err).Msg("failed to load snapshot")
+			snapOp.Fail(err.Error())
+			if opHookExec != nil {
+				opHookExec.RunCompleteHooks(snapOp)
+			}
+			eventBus.Emit(events.NewOperationComplete(snapOp.ID, string(snapOp.Type), uint64(snapOp.Duration().Nanoseconds()), "failed", err.Error(), snapOp.ContextSnapshot(false)))
+			tracker.Fail(snapOp.ID, err.Error())
 		} else {
-			logger.Info().Str("file", cfg.Persistence.SnapshotFile).Msg("snapshot loaded")
+			logger.Info(snapOp).Str("file", cfg.Persistence.SnapshotFile).Msg("snapshot loaded")
+			snapOp.Complete()
+			if opHookExec != nil {
+				opHookExec.RunCompleteHooks(snapOp)
+			}
+			eventBus.Emit(events.NewOperationComplete(snapOp.ID, string(snapOp.Type), uint64(snapOp.Duration().Nanoseconds()), "completed", "", snapOp.ContextSnapshot(false)))
+			tracker.Complete(snapOp.ID)
 		}
 	}
 
-	// Start engine loop
+	// Start engine.
 	go engineInstance.Run()
 
-	// Initialize and start workers
+	// Initialize and start workers.
 	snapshotWorker := workers.NewSnapshotWorker(
 		cacheInstance, engineInstance,
 		cfg.Persistence.SnapshotInterval,
 		cfg.Persistence.SnapshotFile,
 	)
 	cleanupWorker := workers.NewCleanupWorker(cacheInstance, engineInstance, cfg.Workers.CleanupInterval)
+	snapshotWorker.SetTracker(tracker)
+	snapshotWorker.SetEmitter(eventBus)
+	if opHookExec != nil {
+		snapshotWorker.SetOpHookExecutor(opHookExec)
+		cleanupWorker.SetOpHookExecutor(opHookExec)
+	}
+	cleanupWorker.SetTracker(tracker)
+	cleanupWorker.SetEmitter(eventBus)
 	snapshotWorker.Start()
 	cleanupWorker.Start()
 
-	// Initialize server-wide event bus (before hot reload callback which captures it).
-	eventBus := serverEvents.NewBus()
-
-	// Hot reload: watch config file for changes and apply live-reloadable fields.
-	// The callback runs in the fsnotify goroutine, so config swaps use
-	// atomic.Pointer to avoid races with the main goroutine.
+	// Hot reload: config changes create config_reload operations.
 	v.WatchConfig()
 	v.OnConfigChange(func(e fsnotify.Event) {
+		reloadOp := tracker.Start(ops.TypeConfigReload, "")
+		reloadOp.Enrich("_file", e.Name)
+		if opHookExec != nil && opHookExec.HasAny() {
+			opHookExec.RunStartHooks(context.Background(), reloadOp)
+		}
+
 		newCfg, err := config.Reload(v)
 		if err != nil {
-			logger.Warn().Err(err).Msg("failed to parse updated config")
+			logger.Warn(reloadOp).Err(err).Msg("failed to parse updated config")
+			reloadOp.Fail(err.Error())
+			if opHookExec != nil {
+				opHookExec.RunCompleteHooks(reloadOp)
+			}
+			eventBus.Emit(events.NewOperationComplete(reloadOp.ID, string(reloadOp.Type), uint64(reloadOp.Duration().Nanoseconds()), "failed", err.Error(), reloadOp.ContextSnapshot(false)))
+			tracker.Fail(reloadOp.ID, err.Error())
 			return
 		}
-		logger.Info().Str("file", e.Name).Msg("config reloaded")
-		eventBus.Emit(events.NewConfigReloaded(e.Name))
+		logger.Info(reloadOp).Str("file", e.Name).Msg("config reloaded")
 
 		prev := cfgPtr.Load()
 		if newCfg.Server.GetAddr() != prev.Server.GetAddr() {
-			logger.Warn().Msg("server address/port changes require a restart")
+			logger.Warn(reloadOp).Msg("server address/port changes require a restart")
 		}
 
 		snapshotWorker.UpdateInterval(newCfg.Persistence.SnapshotInterval)
@@ -132,56 +219,29 @@ func main() {
 		)
 
 		cfgPtr.Store(newCfg)
+		reloadOp.Complete()
+		if opHookExec != nil {
+			opHookExec.RunCompleteHooks(reloadOp)
+		}
+		eventBus.Emit(events.NewOperationComplete(reloadOp.ID, string(reloadOp.Type), uint64(reloadOp.Duration().Nanoseconds()), "completed", "", reloadOp.ContextSnapshot(false)))
+		tracker.Complete(reloadOp.ID)
 	})
 
-	// Initialize blocking registry for BLPOP/BRPOP
-	blockingRegistry := blocking.NewRegistry()
-
-	// Initialize watch manager for WATCH/UNWATCH optimistic locking
-	watchManager := watch.NewManager()
-
-	// Wire mutation notifications from cache to watch manager
-	cacheInstance.OnMutate = watchManager.NotifyMutation
-	cacheInstance.OnMutateAll = watchManager.NotifyAll
-
-	// Initialize operation tracker.
-	tracker := serverOps.NewTracker()
-
-	// Initialize the server
-	srv := server.New(cfg.Server.GetAddr(), cacheInstance, engineInstance, cfg.Persistence.SnapshotFile, cfg.Server.RequirePass, blockingRegistry, watchManager)
-	srv.SetEmitter(eventBus)
-	srv.SetTracker(tracker)
-
-	// Set up signal handling for graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Initialize plugin system (optional — disabled by default)
-	var pluginManager *pluginmgr.Manager
-	if cfg.Plugins.Enabled {
-		pluginManager = pluginmgr.NewManager(cfg.Plugins, srv.CoreCommandNames(), srv)
-		if err := pluginManager.Start(ctx); err != nil {
-			logger.Fatal().Err(err).Msg("failed to start plugin manager")
-		}
-		pluginManager.SetEventBus(eventBus)
-		srv.SetPluginRouter(pluginManager.Router())
-		srv.SetHookExecutor(cmdhooks.NewExecutor(pluginManager.HookRegistry(), cfg.Plugins.ShutdownTimeout))
-		srv.SetOpHookExecutor(ophooks.NewExecutor(pluginManager.OpHookRegistry(), cfg.Plugins.ShutdownTimeout))
+	// ServerBootstrap complete.
+	bootOp.Complete()
+	if opHookExec != nil {
+		opHookExec.RunCompleteHooks(bootOp)
 	}
-
-	// Wire tracker and emitter to workers so background tasks become operations.
-	snapshotWorker.SetTracker(tracker)
-	snapshotWorker.SetEmitter(eventBus)
-	cleanupWorker.SetTracker(tracker)
-	cleanupWorker.SetEmitter(eventBus)
+	eventBus.Emit(events.NewOperationComplete(bootOp.ID, string(bootOp.Type), uint64(bootOp.Duration().Nanoseconds()), "completed", "", bootOp.ContextSnapshot(false)))
+	tracker.Complete(bootOp.ID)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 
-	// Start server in a goroutine
+	// Start server in a goroutine.
 	serverErrChan := make(chan error, 1)
 	go func() {
-		logger.Info().Msg("server ready to accept connections")
+		logger.InfoNoCtx().Msg("server ready to accept connections")
 		if err := srv.Start(ctx); err != nil && err != context.Canceled {
 			serverErrChan <- err
 		}
@@ -190,13 +250,17 @@ func main() {
 	// Wait for shutdown signal or server error
 	select {
 	case sig := <-sigChan:
-		logger.Info().Str("signal", sig.String()).Msg("received signal")
-		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager)
+		logger.InfoNoCtx().Str("signal", sig.String()).Msg("received signal")
+		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, sig.String())
 	case err := <-serverErrChan:
-		logger.Error().Err(err).Msg("server error")
-		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager)
+		logger.ErrorNoCtx().Err(err).Msg("server error")
+		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, "error: "+err.Error())
 		os.Exit(1)
 	}
+
+	// Close the log pipe so the collector reader gets EOF.
+	logPipeW.Close()
+	logCollector.Wait()
 }
 
 func handleShutdown(
@@ -208,39 +272,67 @@ func handleShutdown(
 	cfg *config.Config,
 	blockingRegistry *blocking.Registry,
 	pluginManager *pluginmgr.Manager,
+	tracker *serverOps.Tracker,
+	eventBus *serverEvents.Bus,
+	opHookExec *ophooks.Executor,
+	reason string,
 ) {
-	logger.Info().Msg("starting graceful shutdown sequence")
-	srv.EmitEvent(events.NewServerShutdown("signal"))
+	// Create shutdown operation — plugins see this via operation hooks
+	// before they are shut down.
+	var shutdownOp *ops.Operation
+	if tracker != nil {
+		shutdownOp = tracker.Start(ops.TypeShutdown, "")
+		shutdownOp.Enrich("_reason", reason)
+		if opHookExec != nil && opHookExec.HasAny() {
+			opHookExec.RunStartHooks(context.Background(), shutdownOp)
+		}
+		eventBus.Emit(events.NewServerShutdown(reason).WithOperationID(shutdownOp.ID))
+	}
+
+	logger.Info(shutdownOp).Msg("starting graceful shutdown sequence")
 
 	// Unblock all waiting BLPOP/BRPOP clients first so their connections can close.
 	blockingRegistry.Shutdown()
 
 	shutdownTimeout := 10 * time.Second
-	logger.Info().Str("step", "1/6").Dur("timeout", shutdownTimeout).Msg("shutting down server")
+	logger.Info(shutdownOp).Str("step", "1/6").Dur("timeout", shutdownTimeout).Msg("shutting down server")
 	if err := srv.Shutdown(shutdownTimeout); err != nil {
-		logger.Warn().Err(err).Msg("server shutdown error")
+		logger.Warn(shutdownOp).Err(err).Msg("server shutdown error")
 	}
 
-	// Shutdown plugins before workers so plugin hooks can still fire.
+	// Fire operation complete hooks BEFORE shutting down plugins
+	// so gobservability can finalize the shutdown span.
+	if shutdownOp != nil && opHookExec != nil {
+		opHookExec.RunCompleteHooks(shutdownOp)
+	}
+
+	// Shutdown plugins.
 	if pluginManager != nil {
-		logger.Info().Str("step", "2/6").Msg("shutting down plugins")
+		logger.Info(shutdownOp).Str("step", "2/6").Msg("shutting down plugins")
 		pluginManager.Shutdown(cfg.Plugins.ShutdownTimeout)
 	}
 
-	logger.Info().Str("step", "3/6").Msg("stopping background workers")
+	logger.Info(shutdownOp).Str("step", "3/6").Msg("stopping background workers")
 	snapshotWorker.Stop()
 	cleanupWorker.Stop()
 
-	logger.Info().Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
+	logger.Info(shutdownOp).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
 	if err := persistence.SaveSnapshot(cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
-		logger.Warn().Err(err).Msg("failed to save final snapshot")
+		logger.Warn(shutdownOp).Err(err).Msg("failed to save final snapshot")
 	} else {
-		logger.Info().Msg("final snapshot saved successfully")
+		logger.Info(shutdownOp).Msg("final snapshot saved successfully")
 	}
 
-	logger.Info().Str("step", "5/6").Msg("stopping engine")
+	logger.Info(shutdownOp).Str("step", "5/6").Msg("stopping engine")
 	engineInstance.Stop()
 
-	logger.Info().Str("step", "6/6").Msg("shutdown complete")
-	logger.Info().Msg("gocache server stopped gracefully")
+	if shutdownOp != nil {
+		shutdownOp.Complete()
+		if eventBus != nil {
+			eventBus.Emit(events.NewOperationComplete(shutdownOp.ID, string(shutdownOp.Type), uint64(shutdownOp.Duration().Nanoseconds()), "completed", "", shutdownOp.ContextSnapshot(false)))
+		}
+		tracker.Complete(shutdownOp.ID)
+	}
+
+	logger.Info(shutdownOp).Str("step", "6/6").Msg("shutdown complete")
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -130,7 +130,7 @@ func (c *Cache) SetMemoryLimit(maxMemoryMB int64, policy EvictionPolicy) {
 		c.maxBytes = 0
 	}
 	c.evictionPolicy = policy
-	logger.Info().Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
+	logger.InfoNoCtx().Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
 
 	// Evict if the new limit is below current usage.
 	if c.maxBytes > 0 && c.usedBytes > c.maxBytes && c.evictionPolicy == EvictionLRU {
@@ -177,7 +177,7 @@ func (c *Cache) RawSet(key string, value interface{}, expiration int64) error {
 			case EvictionLRU:
 				c.evictLRU(delta)
 			case EvictionNone:
-				logger.Warn().Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
+				logger.WarnNoCtx().Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
 				return ErrOutOfMemory
 			}
 		}
@@ -249,7 +249,7 @@ func (c *Cache) evictLRU(delta int64) {
 			break
 		}
 		evictKey := elem.Value.(string)
-		logger.Debug().Str("key", evictKey).Msg("lru eviction")
+		logger.DebugNoCtx().Str("key", evictKey).Msg("lru eviction")
 		c.delete(evictKey)
 	}
 }
@@ -315,7 +315,7 @@ func (c *Cache) RawTTL(key string) int64 {
 }
 
 func (c *Cache) Clear() {
-	logger.Info().Int("items", len(c.items)).Msg("cache cleared")
+	logger.InfoNoCtx().Int("items", len(c.items)).Msg("cache cleared")
 	c.items = make(map[string]*Entry)
 	c.ttl = make(map[string]int64)
 	c.lruList.Init()

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -27,7 +27,7 @@ func New(c *cache.Cache) *Engine {
 }
 
 func (e *Engine) Run() {
-	logger.Info().Msg("engine dispatch loop started")
+	logger.InfoNoCtx().Msg("engine dispatch loop started")
 	for {
 		select {
 		case cmd := <-e.cmdChan:
@@ -43,7 +43,7 @@ func (e *Engine) Run() {
 
 func (e *Engine) Stop() {
 	e.stopOnce.Do(func() {
-		logger.Info().Msg("engine stop signal received")
+		logger.InfoNoCtx().Msg("engine stop signal received")
 		close(e.stopChan)
 	})
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -80,6 +80,7 @@ func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br 
 		requirePass:        requirePass,
 		blockingRegistry:   br,
 		watchManager:       wm,
+		tracker:            serverOps.NewTracker(),
 	}
 	b.registerAll()
 	return b
@@ -149,7 +150,7 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 		if b.pluginRouter != nil && b.pluginRouter.HasCommand(op) {
 			return b.routeToPlugin(ctx, op, args)
 		}
-		logger.Debug().Str("command", op).Msg("unknown command")
+		logger.DebugNoCtx().Str("command", op).Msg("unknown command")
 		return command.Result{Value: resp.ErrUnknown(strings.ToLower(op))}
 	}
 
@@ -173,55 +174,33 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 		}
 	}
 
-	// --- Operation lifecycle ---
-	// When tracker is set, create a command operation that subsumes hookCtx.
-	// When tracker is nil, fall back to the existing hookCtx construction.
-	var (
-		cmdOp   *ops.Operation
-		hookCtx map[string]string
-		startNs int64
-	)
+	// --- Create command operation ---
+	cmdOp := b.tracker.Start(ops.TypeCommand, ctx.OperationID)
+	startNs := cmdOp.StartTime.UnixNano()
 
-	if b.tracker != nil {
-		// Determine parent operation ID from the connection context.
-		parentID := ""
-		if ctx.OperationID != "" {
-			parentID = ctx.OperationID
+	// Inject server context into operation.
+	cmdOp.Enrich(command.StartNs, strconv.FormatInt(startNs, 10))
+	cmdOp.Enrich(command.OperationID, cmdOp.ID)
+	cmdOp.Enrich("_command", op)
+	cmdOp.Enrich("_arg_count", strconv.Itoa(len(args)))
+
+	// Inject REX metadata into operation context.
+	if ctx.RexMeta != nil || len(ctx.CmdMeta) > 0 {
+		metadata := rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)
+		for k, v := range metadata {
+			cmdOp.Enrich(rex.Prefix+k, v)
 		}
-		cmdOp = b.tracker.Start(ops.TypeCommand, parentID)
-		startNs = cmdOp.StartTime.UnixNano()
+	}
 
-		// Inject server context into operation.
-		cmdOp.Enrich(command.StartNs, strconv.FormatInt(startNs, 10))
-		cmdOp.Enrich(command.OperationID, cmdOp.ID)
-		cmdOp.Enrich("_command", op)
-		cmdOp.Enrich("_arg_count", strconv.Itoa(len(args)))
+	// Fire operation start hooks (synchronous — enriches context before work).
+	if b.opHookExecutor != nil && b.opHookExecutor.HasAny() {
+		b.opHookExecutor.RunStartHooks(context.Background(), cmdOp)
+	}
 
-		// Inject REX metadata into operation context.
-		if ctx.RexMeta != nil || len(ctx.CmdMeta) > 0 {
-			metadata := rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)
-			for k, v := range metadata {
-				cmdOp.Enrich(rex.Prefix+k, v)
-			}
-		}
-
-		// Fire operation start hooks (synchronous — enriches context before work).
-		if b.opHookExecutor != nil && b.opHookExecutor.HasAny() {
-			b.opHookExecutor.RunStartHooks(context.Background(), cmdOp)
-		}
-
-		// Emit operation.start event.
-		if b.emitter != nil {
-			b.emitter.Emit(events.NewOperationStart(cmdOp.ID, string(cmdOp.Type), cmdOp.ParentID, cmdOp.ContextSnapshot(false)))
-		}
-
-		// Emit command.pre event with operation_id.
-		if b.emitter != nil {
-			b.emitter.Emit(events.NewCommandPre(op, args, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)).WithOperationID(cmdOp.ID))
-		}
-	} else if b.emitter != nil {
-		// No tracker — emit command.pre event without operation_id.
-		b.emitter.Emit(events.NewCommandPre(op, args, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)))
+	// Emit operation.start + command.pre events.
+	if b.emitter != nil {
+		b.emitter.Emit(events.NewOperationStart(cmdOp.ID, string(cmdOp.Type), cmdOp.ParentID, cmdOp.ContextSnapshot(false)))
+		b.emitter.Emit(events.NewCommandPre(op, args, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)).WithOperationID(cmdOp.ID))
 	}
 
 	cmdCtx := &command.Context{
@@ -240,40 +219,23 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 	}
 
 	// --- Command hooks (pre) ---
-	// Hook context is derived from operation context (if available) or built standalone.
+	var hookCtx map[string]string
 	hasHooks := b.hookExecutor != nil && b.hookExecutor.HasAny()
 	if hasHooks {
-		if cmdOp != nil {
-			// Derive hookCtx from operation context (filtered per plugin happens in executor).
-			hookCtx = cmdOp.ContextSnapshot(false)
-		} else {
-			// Fallback: build hookCtx manually (no operations).
-			startNs = time.Now().UnixNano()
-			hookCtx = command.NewHookCtx()
-			hookCtx[command.StartNs] = strconv.FormatInt(startNs, 10)
-			if ctx.RexMeta != nil || len(ctx.CmdMeta) > 0 {
-				rex.InjectIntoHookCtx(hookCtx, ctx.RexMeta, ctx.CmdMeta)
-			}
-		}
+		hookCtx = cmdOp.ContextSnapshot(false)
 
 		if pre := b.hookExecutor.RunPreHooks(context.Background(), op, args, hookCtx); pre != nil {
 			if pre.Denied {
-				// Denied — clean up operation if active.
-				if cmdOp != nil {
-					cmdOp.Fail("denied: " + pre.DenyReason)
-					if b.opHookExecutor != nil {
-						b.opHookExecutor.RunCompleteHooks(cmdOp)
-					}
-					b.tracker.Fail(cmdOp.ID, "denied: "+pre.DenyReason)
+				cmdOp.Fail("denied: " + pre.DenyReason)
+				if b.opHookExecutor != nil {
+					b.opHookExecutor.RunCompleteHooks(cmdOp)
 				}
+				b.tracker.Fail(cmdOp.ID, "denied: "+pre.DenyReason)
 				return command.Result{Value: resp.MarshalError("DENIED " + pre.DenyReason)}
 			}
 			hookCtx = pre.Context
-			// Merge pre-hook enrichments back into operation.
-			if cmdOp != nil {
-				for k, v := range hookCtx {
-					cmdOp.Enrich(k, v)
-				}
+			for k, v := range hookCtx {
+				cmdOp.Enrich(k, v)
 			}
 		}
 	}
@@ -290,42 +252,26 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 	}
 
 	// --- Complete operation ---
-	if cmdOp != nil {
-		cmdOp.Complete()
-		elapsedNs := uint64(cmdOp.Duration().Nanoseconds())
-		resultVal, resultErr := resultToHookStrings(result)
+	cmdOp.Complete()
+	elapsedNs := uint64(cmdOp.Duration().Nanoseconds())
+	resultVal, resultErr := resultToHookStrings(result)
 
-		// Inject final timing into context.
-		cmdOp.Enrich(command.ElapsedNs, strconv.FormatUint(elapsedNs, 10))
-		cmdOp.Enrich("_result", resultVal)
-		if resultErr != "" {
-			cmdOp.Enrich("_error", resultErr)
-		}
-
-		// Fire operation complete hooks (async).
-		if b.opHookExecutor != nil && b.opHookExecutor.HasAny() {
-			b.opHookExecutor.RunCompleteHooks(cmdOp)
-		}
-
-		// Emit events with operation_id.
-		if b.emitter != nil {
-			status := "completed"
-			failReason := ""
-			b.emitter.Emit(events.NewCommandPost(op, args, elapsedNs, resultVal, resultErr, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)).WithOperationID(cmdOp.ID))
-			b.emitter.Emit(events.NewOperationComplete(cmdOp.ID, string(cmdOp.Type), elapsedNs, status, failReason, cmdOp.ContextSnapshot(false)))
-		}
-
-		b.tracker.Complete(cmdOp.ID)
-	} else if b.emitter != nil {
-		// No tracker — emit command.post event without operation_id.
-		var elapsedNs uint64
-		if startNs > 0 {
-			elapsedNs = uint64(time.Now().UnixNano() - startNs)
-		}
-		resultVal, resultErr := resultToHookStrings(result)
-		b.emitter.Emit(events.NewCommandPost(op, args, elapsedNs, resultVal, resultErr, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)))
+	cmdOp.Enrich(command.ElapsedNs, strconv.FormatUint(elapsedNs, 10))
+	cmdOp.Enrich("_result", resultVal)
+	if resultErr != "" {
+		cmdOp.Enrich("_error", resultErr)
 	}
 
+	if b.opHookExecutor != nil && b.opHookExecutor.HasAny() {
+		b.opHookExecutor.RunCompleteHooks(cmdOp)
+	}
+
+	if b.emitter != nil {
+		b.emitter.Emit(events.NewCommandPost(op, args, elapsedNs, resultVal, resultErr, rex.BuildMetadata(ctx.RexMeta, ctx.CmdMeta)).WithOperationID(cmdOp.ID))
+		b.emitter.Emit(events.NewOperationComplete(cmdOp.ID, string(cmdOp.Type), elapsedNs, "completed", "", cmdOp.ContextSnapshot(false)))
+	}
+
+	b.tracker.Complete(cmdOp.ID)
 	return result
 }
 

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -19,14 +19,16 @@ import (
 
 // --- Test helpers ---
 
-func newTestEvaluator() (*BaseEvaluator, *engine.Engine) {
+func newTestEvaluator() (*BaseEvaluator, *engine.Engine, *serverOps.Tracker) {
 	c := cache.New()
 	e := engine.New(c)
 	go e.Run()
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
 	eval := New(c, e, "test.dat", "", br, wm).(*BaseEvaluator)
-	return eval, e
+	tracker := serverOps.NewTracker()
+	eval.SetTracker(tracker)
+	return eval, e, tracker
 }
 
 // mockHookExecutor implements command.HookExecutor for testing.
@@ -79,11 +81,10 @@ func (m *mockEmitter) Emit(evt apiEvents.Event) {
 
 // --- Tests ---
 
-func TestEvaluate_NilTracker_Fallback(t *testing.T) {
-	eval, e := newTestEvaluator()
+func TestEvaluate_BasicCommand(t *testing.T) {
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
 
-	// No tracker set — should work exactly like before.
 	ctx := clientctx.New()
 	result := eval.Evaluate(ctx, "PING", nil)
 	if result.Value != "PONG" {
@@ -92,11 +93,8 @@ func TestEvaluate_NilTracker_Fallback(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_CreatesOperation(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	ctx := clientctx.New()
 	result := eval.Evaluate(ctx, "PING", nil)
@@ -111,11 +109,8 @@ func TestEvaluate_WithTracker_CreatesOperation(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_OperationHasContext(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	// Use a mock op hook executor that captures the operation.
 	opHook := &mockOpHookExecutor{hasAny: true}
@@ -146,11 +141,8 @@ func TestEvaluate_WithTracker_OperationHasContext(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_ParentID(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -166,11 +158,8 @@ func TestEvaluate_WithTracker_ParentID(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_REXMetadataInContext(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -195,11 +184,8 @@ func TestEvaluate_WithTracker_REXMetadataInContext(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_OpHookEnrichment(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	// Op hook enriches with traceparent during start.
 	opHook := &mockOpHookExecutor{
@@ -222,11 +208,8 @@ func TestEvaluate_WithTracker_OpHookEnrichment(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_EmitsEvents(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	emitter := &mockEmitter{}
 	eval.SetEmitter(emitter)
@@ -274,11 +257,8 @@ func TestEvaluate_WithTracker_EmitsEvents(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_CmdHooksDeriveFromOpContext(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	// Op hook enriches operation context.
 	opHook := &mockOpHookExecutor{
@@ -315,11 +295,8 @@ func TestEvaluate_WithTracker_CmdHooksDeriveFromOpContext(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_PreHookDeny_FailsOperation(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -353,11 +330,8 @@ func TestEvaluate_WithTracker_PreHookDeny_FailsOperation(t *testing.T) {
 }
 
 func TestEvaluate_WithTracker_PreHookEnrichmentFlowsToOperation(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -387,70 +361,9 @@ func TestEvaluate_WithTracker_PreHookEnrichmentFlowsToOperation(t *testing.T) {
 	}
 }
 
-func TestEvaluate_NilTracker_WithHooks_Fallback(t *testing.T) {
-	eval, e := newTestEvaluator()
-	defer e.Stop()
-
-	// No tracker, but hooks are set — should use legacy hookCtx path.
-	cmdHook := &mockHookExecutor{
-		hasAny:    true,
-		preResult: &command.PreHookResult{Denied: false},
-	}
-	eval.SetHookExecutor(cmdHook)
-
-	ctx := clientctx.New()
-	ctx.CmdMeta = map[string]string{"traceparent": "00-abc-def-01"}
-
-	result := eval.Evaluate(ctx, "PING", nil)
-	if result.Value != "PONG" {
-		t.Errorf("expected PONG, got %v", result.Value)
-	}
-
-	// Hook context should have been built via legacy path.
-	if cmdHook.lastHookCtx == nil {
-		t.Fatal("expected hook context")
-	}
-	if cmdHook.lastHookCtx[command.StartNs] == "" {
-		t.Error("legacy path should inject _start_ns")
-	}
-	// REX metadata should be injected.
-	if cmdHook.lastHookCtx["shared.rex.traceparent"] != "00-abc-def-01" {
-		t.Error("legacy path should inject REX metadata")
-	}
-}
-
-func TestEvaluate_NilTracker_WithEmitter_EmitsEvents(t *testing.T) {
-	eval, e := newTestEvaluator()
-	defer e.Stop()
-
-	emitter := &mockEmitter{}
-	eval.SetEmitter(emitter)
-
-	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
-
-	// Should emit command.pre and command.post (no operation events).
-	if len(emitter.events) != 2 {
-		t.Fatalf("expected 2 events without tracker, got %d", len(emitter.events))
-	}
-	if emitter.events[0].Proto.Type != string(apiEvents.CommandPre) {
-		t.Errorf("expected command.pre, got %s", emitter.events[0].Proto.Type)
-	}
-	if emitter.events[1].Proto.Type != string(apiEvents.CommandPost) {
-		t.Errorf("expected command.post, got %s", emitter.events[1].Proto.Type)
-	}
-	// No operation_id without tracker.
-	if emitter.events[0].Proto.OperationId != "" {
-		t.Error("expected empty operation_id without tracker")
-	}
-}
-
 func TestEvaluate_UnknownCommand(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	ctx := clientctx.New()
 	result := eval.Evaluate(ctx, "NOSUCHCMD", nil)
@@ -463,11 +376,8 @@ func TestEvaluate_UnknownCommand(t *testing.T) {
 }
 
 func TestEvaluate_TransactionQueued(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	ctx := clientctx.New()
 	ctx.InTransaction = true
@@ -484,11 +394,8 @@ func TestEvaluate_TransactionQueued(t *testing.T) {
 }
 
 func TestEvaluate_ConcurrentCommands(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -521,11 +428,8 @@ func TestEvaluate_ConcurrentCommands(t *testing.T) {
 }
 
 func TestEvaluate_OperationTimingAccuracy(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	emitter := &mockEmitter{}
 	eval.SetEmitter(emitter)
@@ -553,11 +457,8 @@ func TestEvaluate_OperationTimingAccuracy(t *testing.T) {
 }
 
 func TestEvaluate_OperationContextHasElapsed(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, _ := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	opHook := &mockOpHookExecutor{hasAny: true}
 	eval.SetOpHookExecutor(opHook)
@@ -577,11 +478,8 @@ func TestEvaluate_OperationContextHasElapsed(t *testing.T) {
 }
 
 func TestEvaluate_ArgValidation_NoOperation(t *testing.T) {
-	eval, e := newTestEvaluator()
+	eval, e, tracker := newTestEvaluator()
 	defer e.Stop()
-
-	tracker := serverOps.NewTracker()
-	eval.SetTracker(tracker)
 
 	ctx := clientctx.New()
 	// SET requires 2 args.

--- a/pkg/events/bus.go
+++ b/pkg/events/bus.go
@@ -51,7 +51,7 @@ func (b *Bus) Subscribe(name string, types []apiEvents.Type, handler Handler) {
 		Handler: handler,
 	}
 
-	logger.Info().Str("subscriber", name).Int("types", len(types)).Msg("event subscription registered")
+	logger.InfoNoCtx().Str("subscriber", name).Int("types", len(types)).Msg("event subscription registered")
 }
 
 // Unsubscribe removes a subscriber.
@@ -89,13 +89,21 @@ func (b *Bus) Emit(evt apiEvents.Event) {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					logger.Error().Str("subscriber", s.Name).Str("event", string(evtType)).
+					logger.ErrorNoCtx().Str("subscriber", s.Name).Str("event", string(evtType)).
 						Interface("panic", r).Msg("event handler panicked")
 				}
 			}()
 			s.Handler(evt)
 		}()
 	}
+}
+
+// HasSubscriber returns true if a subscriber with the given name is registered.
+func (b *Bus) HasSubscriber(name string) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.subscribers[name]
+	return ok
 }
 
 // HasSubscribers returns true if any subscribers are registered. Zero-cost guard.

--- a/pkg/logcollector/collector.go
+++ b/pkg/logcollector/collector.go
@@ -1,0 +1,153 @@
+// Package logcollector reads JSON log lines from multiple sources (server pipe,
+// plugin stdout pipes) and emits LogEntry events to the event bus.
+//
+// This is the single point that converts log output → events. The logger package
+// writes JSON to stdout, plugins write JSON to their stdout, and this collector
+// reads all pipes, parses JSON, and emits structured LogEntry events.
+package logcollector
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+
+	"gocache/api/events"
+)
+
+// Collector reads JSON log lines from multiple sources and emits LogEntry events.
+type Collector struct {
+	emitter events.Emitter
+	wg      sync.WaitGroup
+}
+
+// New creates a log collector that emits events to the given emitter.
+func New(emitter events.Emitter) *Collector {
+	return &Collector{
+		emitter: emitter,
+	}
+}
+
+// AddSource registers an io.Reader as a log source and starts a goroutine
+// to read from it. The source name is used for logging if parse errors occur.
+// Safe to call concurrently and after Start.
+func (c *Collector) AddSource(name string, r io.Reader) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		c.readSource(name, r)
+	}()
+}
+
+// Wait blocks until all source readers have finished (EOF or error).
+func (c *Collector) Wait() {
+	c.wg.Wait()
+}
+
+// readSource reads JSON lines from a single source and emits LogEntry events.
+func (c *Collector) readSource(sourceName string, r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	// Increase buffer for long log lines (e.g. large _ctx).
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		c.parseLine(sourceName, line)
+	}
+	// Scanner error is expected on pipe close — not logged.
+}
+
+// parseLine parses a single JSON log line and emits a LogEntry event.
+func (c *Collector) parseLine(sourceName string, line []byte) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		// Not JSON — could be a plain text line from a plugin.
+		// Emit as a raw log entry with no structured fields.
+		c.emitter.Emit(events.NewLogEntry("info", string(line), "", map[string]string{
+			"_source": sourceName,
+			"_raw":    "true",
+		}))
+		return
+	}
+
+	// Extract well-known fields.
+	level := stringField(raw, "level")
+	message := stringField(raw, "message")
+	source := stringField(raw, "source")
+	if source == "" {
+		source = sourceName
+	}
+	operationID := stringField(raw, "_operation_id")
+
+	// Extract _ctx (redacted operation context written by the logger).
+	var ctxFields map[string]string
+	if ctxRaw, ok := raw["_ctx"]; ok {
+		if ctxMap, ok := ctxRaw.(map[string]interface{}); ok {
+			ctxFields = make(map[string]string, len(ctxMap))
+			for k, v := range ctxMap {
+				if s, ok := v.(string); ok {
+					ctxFields[k] = s
+				}
+			}
+		}
+	}
+
+	// Build fields from remaining keys (exclude well-known).
+	fields := make(map[string]string)
+	fields["_source"] = source
+	for k, v := range raw {
+		switch k {
+		case "level", "message", "time", "source", "_operation_id", "_ctx":
+			continue
+		default:
+			switch val := v.(type) {
+			case string:
+				fields[k] = val
+			case float64:
+				// JSON numbers are float64.
+				if val == float64(int64(val)) {
+					fields[k] = json.Number(fmt.Sprintf("%d", int64(val))).String()
+				} else {
+					fields[k] = json.Number(fmt.Sprintf("%g", val)).String()
+				}
+			case bool:
+				if val {
+					fields[k] = "true"
+				} else {
+					fields[k] = "false"
+				}
+			default:
+				if b, err := json.Marshal(val); err == nil {
+					fields[k] = string(b)
+				}
+			}
+		}
+	}
+
+	// Merge _ctx fields into the event fields. The _ctx contains the redacted
+	// operation context (shared.traceparent, _command, etc.). These flow through
+	// to the LogEntry event so subscribers can correlate.
+	for k, v := range ctxFields {
+		fields[k] = v
+	}
+
+	evt := events.NewLogEntry(level, message, "", fields)
+	if operationID != "" {
+		evt = evt.WithOperationID(operationID)
+	}
+
+	c.emitter.Emit(evt)
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/pkg/logcollector/collector_test.go
+++ b/pkg/logcollector/collector_test.go
@@ -1,0 +1,271 @@
+package logcollector
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	apiEvents "gocache/api/events"
+)
+
+type mockEmitter struct {
+	mu     sync.Mutex
+	events []apiEvents.Event
+}
+
+func (m *mockEmitter) Emit(evt apiEvents.Event) {
+	m.mu.Lock()
+	m.events = append(m.events, evt)
+	m.mu.Unlock()
+}
+
+func (m *mockEmitter) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.events)
+}
+
+func (m *mockEmitter) get(i int) apiEvents.Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.events[i]
+}
+
+func TestCollector_BasicJSONLine(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader(`{"level":"info","source":"server","message":"hello world","time":"2026-01-01T00:00:00Z"}` + "\n")
+	c.AddSource("server", r)
+	c.Wait()
+
+	if em.count() != 1 {
+		t.Fatalf("expected 1 event, got %d", em.count())
+	}
+
+	evt := em.get(0)
+	data := evt.Proto.GetLogEntry()
+	if data == nil {
+		t.Fatal("expected LogEntryEventV1")
+	}
+	if data.Level != "info" {
+		t.Errorf("expected level info, got %q", data.Level)
+	}
+	if data.Message != "hello world" {
+		t.Errorf("expected 'hello world', got %q", data.Message)
+	}
+	if data.Fields["_source"] != "server" {
+		t.Errorf("expected source server, got %q", data.Fields["_source"])
+	}
+}
+
+func TestCollector_OperationID(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader(`{"level":"info","message":"cache hit","_operation_id":"cmd_42","source":"server"}` + "\n")
+	c.AddSource("server", r)
+	c.Wait()
+
+	evt := em.get(0)
+	if evt.Proto.OperationId != "cmd_42" {
+		t.Errorf("expected operation_id cmd_42, got %q", evt.Proto.OperationId)
+	}
+}
+
+func TestCollector_ContextPassthrough(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader(`{"level":"info","message":"test","_operation_id":"cmd_1","_ctx":{"shared.traceparent":"00-abc-def-01","_command":"SET","shared.username":"john"},"source":"server"}` + "\n")
+	c.AddSource("server", r)
+	c.Wait()
+
+	evt := em.get(0)
+	data := evt.Proto.GetLogEntry()
+
+	// _ctx fields should be merged into the event fields.
+	if data.Fields["shared.traceparent"] != "00-abc-def-01" {
+		t.Errorf("expected traceparent in fields, got %v", data.Fields)
+	}
+	if data.Fields["_command"] != "SET" {
+		t.Errorf("expected _command in fields, got %v", data.Fields)
+	}
+	if data.Fields["shared.username"] != "john" {
+		t.Errorf("expected username in fields, got %v", data.Fields)
+	}
+}
+
+func TestCollector_ExtraFields(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader(`{"level":"warn","message":"slow","key":"user:123","elapsed_ms":500,"source":"server"}` + "\n")
+	c.AddSource("server", r)
+	c.Wait()
+
+	data := em.get(0).Proto.GetLogEntry()
+	if data.Fields["key"] != "user:123" {
+		t.Errorf("expected key field, got %v", data.Fields)
+	}
+	if data.Fields["elapsed_ms"] != "500" {
+		t.Errorf("expected elapsed_ms=500, got %q", data.Fields["elapsed_ms"])
+	}
+}
+
+func TestCollector_NonJSON(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader("this is not json\n")
+	c.AddSource("plugin-x", r)
+	c.Wait()
+
+	if em.count() != 1 {
+		t.Fatalf("expected 1 event for non-JSON, got %d", em.count())
+	}
+	data := em.get(0).Proto.GetLogEntry()
+	if data.Message != "this is not json" {
+		t.Errorf("expected raw message, got %q", data.Message)
+	}
+	if data.Fields["_source"] != "plugin-x" {
+		t.Errorf("expected source plugin-x, got %q", data.Fields["_source"])
+	}
+	if data.Fields["_raw"] != "true" {
+		t.Error("expected _raw=true for non-JSON")
+	}
+}
+
+func TestCollector_EmptyLines(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r := strings.NewReader("\n\n" + `{"level":"info","message":"hi"}` + "\n\n")
+	c.AddSource("server", r)
+	c.Wait()
+
+	if em.count() != 1 {
+		t.Fatalf("expected 1 event (empty lines skipped), got %d", em.count())
+	}
+}
+
+func TestCollector_MultipleSources(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	r1 := strings.NewReader(`{"level":"info","message":"from server","source":"server"}` + "\n")
+	r2 := strings.NewReader(`{"level":"info","message":"from plugin","source":"gobservability"}` + "\n")
+
+	c.AddSource("server", r1)
+	c.AddSource("gobservability", r2)
+	c.Wait()
+
+	if em.count() != 2 {
+		t.Fatalf("expected 2 events, got %d", em.count())
+	}
+}
+
+func TestCollector_SourceFallback(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	// No "source" field in JSON — should use the source name from AddSource.
+	r := strings.NewReader(`{"level":"info","message":"hello"}` + "\n")
+	c.AddSource("my-plugin", r)
+	c.Wait()
+
+	data := em.get(0).Proto.GetLogEntry()
+	if data.Fields["_source"] != "my-plugin" {
+		t.Errorf("expected fallback source my-plugin, got %q", data.Fields["_source"])
+	}
+}
+
+func TestCollector_PipeSimulation(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	// Simulate a pipe: writer writes lines, reader reads them.
+	pr, pw := io.Pipe()
+
+	c.AddSource("server", pr)
+
+	go func() {
+		pw.Write([]byte(`{"level":"info","message":"line1","source":"server"}` + "\n"))
+		pw.Write([]byte(`{"level":"warn","message":"line2","source":"server"}` + "\n"))
+		pw.Close()
+	}()
+
+	c.Wait()
+
+	if em.count() != 2 {
+		t.Fatalf("expected 2 events from pipe, got %d", em.count())
+	}
+}
+
+func TestCollector_ConcurrentWrites(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	// Multiple sources writing concurrently.
+	const n = 10
+	var writers []*io.PipeWriter
+	for i := 0; i < n; i++ {
+		pr, pw := io.Pipe()
+		writers = append(writers, pw)
+		c.AddSource("source", pr)
+	}
+
+	var wg sync.WaitGroup
+	for _, pw := range writers {
+		wg.Add(1)
+		go func(w *io.PipeWriter) {
+			defer wg.Done()
+			w.Write([]byte(`{"level":"info","message":"concurrent"}` + "\n"))
+			w.Close()
+		}(pw)
+	}
+
+	wg.Wait()
+	c.Wait()
+
+	if em.count() != n {
+		t.Errorf("expected %d events, got %d", n, em.count())
+	}
+}
+
+func TestCollector_LargeContext(t *testing.T) {
+	em := &mockEmitter{}
+	c := New(em)
+
+	// Build a large _ctx.
+	var buf bytes.Buffer
+	buf.WriteString(`{"level":"info","message":"big ctx","_operation_id":"cmd_1","_ctx":{`)
+	for i := 0; i < 100; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(`"key_`)
+		buf.WriteString(fmt.Sprintf("%d", i))
+		buf.WriteString(`":"value_`)
+		buf.WriteString(fmt.Sprintf("%d", i))
+		buf.WriteByte('"')
+	}
+	buf.WriteString("}}\n")
+
+	c.AddSource("server", &buf)
+	c.Wait()
+
+	if em.count() != 1 {
+		t.Fatalf("expected 1 event, got %d", em.count())
+	}
+	data := em.get(0).Proto.GetLogEntry()
+	if data.Fields["key_0"] != "value_0" {
+		t.Error("expected _ctx fields to be merged")
+	}
+	if data.Fields["key_99"] != "value_99" {
+		t.Error("expected all 100 _ctx fields")
+	}
+}

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -32,7 +32,7 @@ func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
 	dir := filepath.Dir(filename)
 	tmp, err := os.CreateTemp(dir, ".snapshot-*.tmp")
 	if err != nil {
-		logger.Error().Err(err).Str("file", filename).Msg("failed to create snapshot temp file")
+		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("failed to create snapshot temp file")
 		return fmt.Errorf("create snapshot temp %s: %w", filename, err)
 	}
 	tmpName := tmp.Name()
@@ -58,13 +58,13 @@ func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
 	// Write count header first so the decoder knows exactly how many entries follow.
 	if err := encoder.Encode(len(entries)); err != nil {
 		_ = tmp.Close()
-		logger.Error().Err(err).Str("file", filename).Msg("snapshot encode error")
+		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot encode error")
 		return fmt.Errorf("encode snapshot %s: %w", filename, err)
 	}
 	for _, e := range entries {
 		if err := encoder.Encode(e); err != nil {
 			_ = tmp.Close()
-			logger.Error().Err(err).Str("file", filename).Msg("snapshot encode error")
+			logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot encode error")
 			return fmt.Errorf("encode snapshot %s: %w", filename, err)
 		}
 	}
@@ -83,7 +83,7 @@ func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
 		return fmt.Errorf("rename snapshot %s: %w", filename, err)
 	}
 
-	logger.Info().Str("file", filename).Int("entries", len(entries)).Msg("snapshot saved")
+	logger.InfoNoCtx().Str("file", filename).Int("entries", len(entries)).Msg("snapshot saved")
 	return nil
 }
 
@@ -91,10 +91,10 @@ func LoadSnapshot(filename string, cacheInstance *cache.Cache) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.Debug().Str("file", filename).Msg("snapshot file not found, skipping")
+			logger.DebugNoCtx().Str("file", filename).Msg("snapshot file not found, skipping")
 			return nil
 		}
-		logger.Error().Err(err).Str("file", filename).Msg("failed to open snapshot file")
+		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("failed to open snapshot file")
 		return fmt.Errorf("open snapshot %s: %w", filename, err)
 	}
 	defer file.Close()
@@ -104,7 +104,7 @@ func LoadSnapshot(filename string, cacheInstance *cache.Cache) error {
 
 	var count int
 	if err := decoder.Decode(&count); err != nil {
-		logger.Error().Err(err).Str("file", filename).Msg("snapshot decode error")
+		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot decode error")
 		return fmt.Errorf("decode snapshot %s: %w", filename, err)
 	}
 
@@ -112,18 +112,18 @@ func LoadSnapshot(filename string, cacheInstance *cache.Cache) error {
 	for i := 0; i < count; i++ {
 		var e SnapshotEntry
 		if err := decoder.Decode(&e); err != nil {
-			logger.Error().Err(err).Str("file", filename).Msg("snapshot decode error")
+			logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot decode error")
 			return fmt.Errorf("decode snapshot %s: %w", filename, err)
 		}
 
 		if e.Expiration > 0 && e.Expiration < time.Now().UnixNano() {
-			logger.Trace().Str("key", e.Key).Msg("skipped expired entry during load")
+			logger.TraceNoCtx().Str("key", e.Key).Msg("skipped expired entry during load")
 			continue
 		}
 		cacheInstance.RawLoad(e.Key, e.Value, e.Expiration)
 		loaded++
 	}
 
-	logger.Info().Str("file", filename).Int("entries", loaded).Msg("snapshot loaded")
+	logger.InfoNoCtx().Str("file", filename).Int("entries", loaded).Msg("snapshot loaded")
 	return nil
 }

--- a/pkg/plugin/cmdhooks/executor.go
+++ b/pkg/plugin/cmdhooks/executor.go
@@ -64,7 +64,7 @@ func (e *Executor) RunPreHooks(ctx context.Context, command string, args []strin
 		}
 		result, err := e.sendCriticalHook(ctx, h, gcpc.HookPhaseV1_HOOK_PHASE_PRE, command, args, "", "", cmd.FilterHookCtx(hookCtx, h.PluginName), metadata)
 		if err != nil {
-			logger.Warn().Str("plugin", h.PluginName).Str("command", command).Err(err).Msg("critical pre-hook failed, allowing command")
+			logger.WarnNoCtx().Str("plugin", h.PluginName).Str("command", command).Err(err).Msg("critical pre-hook failed, allowing command")
 			continue
 		}
 		if result.Deny {
@@ -104,7 +104,7 @@ func (e *Executor) RunPostHooks(ctx context.Context, command string, args []stri
 		}
 		_, err := e.sendCriticalHook(ctx, h, gcpc.HookPhaseV1_HOOK_PHASE_POST, command, args, resultValue, resultError, cmd.FilterHookCtx(hookCtx, h.PluginName), metadata)
 		if err != nil {
-			logger.Warn().Str("plugin", h.PluginName).Str("command", command).Err(err).Msg("critical post-hook failed")
+			logger.WarnNoCtx().Str("plugin", h.PluginName).Str("command", command).Err(err).Msg("critical post-hook failed")
 		}
 	}
 }

--- a/pkg/plugin/manager/it_gcpc_test.go
+++ b/pkg/plugin/manager/it_gcpc_test.go
@@ -1,0 +1,462 @@
+package manager
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	opctx "gocache/api/context"
+	apiEvents "gocache/api/events"
+	gcpc "gocache/api/gcpc/v1"
+	ops "gocache/api/operations"
+	"gocache/api/transport"
+	serverEvents "gocache/pkg/events"
+	serverOps "gocache/pkg/operations"
+	"gocache/pkg/plugin"
+)
+
+// testPlugin connects to the manager via GCPC and exercises all message types.
+type testPlugin struct {
+	t    *testing.T
+	conn *transport.Conn
+}
+
+func newTestPlugin(t *testing.T, sockPath string) *testPlugin {
+	t.Helper()
+	raw, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial plugin socket: %v", err)
+	}
+	tc := transport.NewConn(raw)
+	t.Cleanup(func() { tc.Close() })
+	return &testPlugin{t: t, conn: tc}
+}
+
+func (p *testPlugin) register(name string, scopes []string, hooks []*gcpc.HookDeclV1, opHooks []*gcpc.OperationHookDeclV1) *gcpc.RegisterAckV1 {
+	p.t.Helper()
+	reg := &gcpc.RegisterV1{
+		Name:            name,
+		Version:         "0.1.0-test",
+		Critical:        false,
+		RequestedScopes: scopes,
+		Hooks:           hooks,
+		OperationHooks:  opHooks,
+	}
+	env := &gcpc.EnvelopeV1{
+		Version: gcpc.ProtocolVersion,
+		Payload: &gcpc.EnvelopeV1_Register{Register: reg},
+	}
+	if err := p.conn.Send(env); err != nil {
+		p.t.Fatalf("send register: %v", err)
+	}
+	ackEnv, err := p.conn.Recv()
+	if err != nil {
+		p.t.Fatalf("recv ack: %v", err)
+	}
+	ack := ackEnv.GetRegisterAck()
+	if ack == nil {
+		p.t.Fatal("expected RegisterAck")
+	}
+	return ack
+}
+
+func (p *testPlugin) recv() *gcpc.EnvelopeV1 {
+	p.t.Helper()
+	env, err := p.conn.Recv()
+	if err != nil {
+		p.t.Fatalf("recv: %v", err)
+	}
+	return env
+}
+
+func (p *testPlugin) send(env *gcpc.EnvelopeV1) {
+	p.t.Helper()
+	if err := p.conn.Send(env); err != nil {
+		p.t.Fatalf("send: %v", err)
+	}
+}
+
+// waitForSubscription polls the event bus until the named subscriber appears
+// or the timeout expires. Avoids flaky time.Sleep-based synchronization with
+// the async subscription registration in the manager's readLoop.
+func waitForSubscription(t *testing.T, bus *serverEvents.Bus, name string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.HasSubscriber(name) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("subscription %q not registered within timeout", name)
+}
+
+// setupManager creates a manager with a temp socket and returns it ready for connections.
+func setupManager(t *testing.T) (*Manager, *serverEvents.Bus, *serverOps.Tracker, string) {
+	t.Helper()
+
+	sockPath := t.TempDir() + "/test.sock"
+	cfg := plugin.PluginsConfig{
+		Enabled:         true,
+		SocketPath:      sockPath,
+		HealthInterval:  60 * time.Second, // long so it doesn't interfere with tests
+		ShutdownTimeout: 5 * time.Second,
+		MaxRestarts:     0,
+		ConnectTimeout:  5 * time.Second,
+	}
+
+	tracker := serverOps.NewTracker()
+	eventBus := serverEvents.NewBus()
+
+	mgr := NewManager(cfg, []string{"GET", "SET", "PING"}, &mockState{})
+	mgr.SetEventBus(eventBus)
+
+	// Set the context (normally done by Start()).
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr.ctx = ctx
+	mgr.cancel = cancel
+	t.Cleanup(cancel)
+
+	// Pre-register a plugin entry so the manager accepts the connection.
+	mgr.registry.Add(&PluginInstance{
+		Name:        "test-plugin",
+		MaxRestarts: 0,
+	})
+
+	// Start the IPC listener.
+	listener, err := transport.NewListener(sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	// Accept connections in background.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go mgr.handleConnection(conn)
+		}
+	}()
+
+	return mgr, eventBus, tracker, sockPath
+}
+
+type mockState struct{}
+
+func (m *mockState) IsShuttingDown() bool   { return false }
+func (m *mockState) StartTime() time.Time   { return time.Now() }
+func (m *mockState) ActiveConnections() int { return 0 }
+func (m *mockState) CacheKeys() int         { return 0 }
+func (m *mockState) CacheUsedBytes() int64  { return 0 }
+func (m *mockState) CacheMaxBytes() int64   { return 0 }
+
+// --- Integration Tests ---
+
+func TestGCPC_Registration_Accepted(t *testing.T) {
+	_, _, _, sockPath := setupManager(t)
+	p := newTestPlugin(t, sockPath)
+
+	ack := p.register("test-plugin", []string{"read"}, nil, nil)
+
+	if !ack.Accepted {
+		t.Fatalf("expected accepted, got rejected: %s", ack.Reason)
+	}
+	if len(ack.GrantedScopes) == 0 {
+		t.Error("expected granted scopes")
+	}
+}
+
+func TestGCPC_Registration_UnknownPlugin(t *testing.T) {
+	_, _, _, sockPath := setupManager(t)
+	p := newTestPlugin(t, sockPath)
+
+	ack := p.register("nonexistent", []string{"read"}, nil, nil)
+
+	if ack.Accepted {
+		t.Error("expected rejection for unknown plugin")
+	}
+}
+
+func TestGCPC_Registration_PartialScopeGrant(t *testing.T) {
+	_, _, _, sockPath := setupManager(t)
+	p := newTestPlugin(t, sockPath)
+
+	// Request scopes beyond what's allowed (default allows "read" only).
+	ack := p.register("test-plugin", []string{"read", "write", "admin", "operation:hook"}, nil, nil)
+
+	if !ack.Accepted {
+		t.Fatalf("expected accepted with partial grant, got rejected: %s", ack.Reason)
+	}
+	// Only "read" should be granted (default allowlist).
+	granted := make(map[string]bool)
+	for _, s := range ack.GrantedScopes {
+		granted[s] = true
+	}
+	if !granted["read"] {
+		t.Error("expected read scope granted")
+	}
+}
+
+func TestGCPC_OperationHook_Registration(t *testing.T) {
+	mgr, _, _, sockPath := setupManager(t)
+	mgr.cfg.Overrides = map[string]plugin.PluginOverride{
+		"test-plugin": {Scopes: []string{"read", "operation:hook"}},
+	}
+	p := newTestPlugin(t, sockPath)
+
+	ack := p.register("test-plugin", []string{"read", "operation:hook"}, nil,
+		[]*gcpc.OperationHookDeclV1{{Type: "*", Priority: 10}})
+
+	if !ack.Accepted {
+		t.Fatalf("registration rejected: %s", ack.Reason)
+	}
+
+	// Verify operation hooks were registered.
+	if !mgr.opHookRegistry.HasAny() {
+		t.Fatal("expected operation hooks registered")
+	}
+
+	// Verify wildcard match works.
+	matches := mgr.opHookRegistry.Match(ops.TypeCommand)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].PluginName != "test-plugin" {
+		t.Errorf("expected test-plugin, got %s", matches[0].PluginName)
+	}
+}
+
+func TestGCPC_OperationHook_DeniedWithoutScope(t *testing.T) {
+	mgr, _, _, sockPath := setupManager(t)
+	// Default scopes — no operation:hook.
+	p := newTestPlugin(t, sockPath)
+
+	p.register("test-plugin", []string{"read"}, nil,
+		[]*gcpc.OperationHookDeclV1{{Type: "*", Priority: 10}})
+
+	// Hooks should NOT be registered.
+	if mgr.opHookRegistry.HasAny() {
+		t.Error("operation hooks should not be registered without scope")
+	}
+}
+
+func TestGCPC_EventSubscription(t *testing.T) {
+	mgr, eventBus, _, sockPath := setupManager(t)
+	mgr.cfg.Overrides = map[string]plugin.PluginOverride{
+		"test-plugin": {Scopes: []string{"read", "events"}},
+	}
+	p := newTestPlugin(t, sockPath)
+
+	ack := p.register("test-plugin", []string{"read", "events"}, nil, nil)
+	if !ack.Accepted {
+		t.Fatalf("rejected: %s", ack.Reason)
+	}
+
+	// Subscribe to command.post events.
+	p.send(gcpc.NewEventSubscribe([]string{"command.post"}))
+	waitForSubscription(t, eventBus, "plugin:test-plugin")
+
+	// Emit a command.post event.
+	eventBus.Emit(apiEvents.NewCommandPost("SET", []string{"key", "val"}, 1000, "OK", "", nil).WithOperationID("cmd_1"))
+
+	// Plugin should receive it.
+	env := p.recv()
+	evt := env.GetEvent()
+	if evt == nil {
+		t.Fatal("expected EventV1")
+	}
+	if evt.Type != "command.post" {
+		t.Errorf("expected command.post, got %q", evt.Type)
+	}
+	if evt.OperationId != "cmd_1" {
+		t.Errorf("expected operation_id cmd_1, got %q", evt.OperationId)
+	}
+
+	cmdPost := evt.GetCommandPost()
+	if cmdPost == nil {
+		t.Fatal("expected CommandPostEventV1")
+	}
+	if cmdPost.Command != "SET" {
+		t.Errorf("expected SET, got %q", cmdPost.Command)
+	}
+	if cmdPost.ElapsedNs != 1000 {
+		t.Errorf("expected elapsed 1000, got %d", cmdPost.ElapsedNs)
+	}
+}
+
+func TestGCPC_EventSubscription_ContextFiltered(t *testing.T) {
+	mgr, eventBus, _, sockPath := setupManager(t)
+	mgr.cfg.Overrides = map[string]plugin.PluginOverride{
+		"test-plugin": {Scopes: []string{"read", "events"}},
+	}
+	p := newTestPlugin(t, sockPath)
+
+	p.register("test-plugin", []string{"read", "events"}, nil, nil)
+	p.send(gcpc.NewEventSubscribe([]string{"operation.complete"}))
+	waitForSubscription(t, eventBus, "plugin:test-plugin")
+
+	// Emit operation.complete with context containing private keys.
+	ctx := map[string]string{
+		"_start_ns":            "12345",
+		"shared.traceparent":   "00-abc-def-01",
+		"other-plugin.private": "should-be-hidden",
+		"test-plugin.own":      "should-be-visible",
+	}
+	eventBus.Emit(apiEvents.NewOperationComplete("cmd_1", "command", 5000, "completed", "", ctx))
+
+	env := p.recv()
+	evt := env.GetEvent()
+	opComplete := evt.GetOperationComplete()
+	if opComplete == nil {
+		t.Fatal("expected OperationCompleteEventV1")
+	}
+
+	// Context should be filtered for test-plugin.
+	if opComplete.Context["_start_ns"] != "12345" {
+		t.Error("expected _start_ns (server key)")
+	}
+	if opComplete.Context["shared.traceparent"] != "00-abc-def-01" {
+		t.Error("expected shared.traceparent")
+	}
+	if opComplete.Context["test-plugin.own"] != "should-be-visible" {
+		t.Error("expected own key visible")
+	}
+	if _, ok := opComplete.Context["other-plugin.private"]; ok {
+		t.Error("should NOT see other-plugin.private")
+	}
+}
+
+func TestGCPC_EventSubscription_DeniedWithoutScope(t *testing.T) {
+	_, eventBus, _, sockPath := setupManager(t)
+	p := newTestPlugin(t, sockPath)
+
+	// Register without events scope.
+	ack := p.register("test-plugin", []string{"read"}, nil, nil)
+	if !ack.Accepted {
+		t.Fatalf("rejected: %s", ack.Reason)
+	}
+
+	// Try to subscribe — should be silently denied.
+	p.send(gcpc.NewEventSubscribe([]string{"command.post"}))
+
+	// Poll briefly to let the manager process the subscribe message, then
+	// assert the subscription was NOT registered on the bus.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if eventBus.HasSubscriber("plugin:test-plugin") {
+			t.Fatal("subscription should have been denied but was registered")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestGCPC_ServerQuery(t *testing.T) {
+	mgr, _, _, sockPath := setupManager(t)
+	mgr.cfg.Overrides = map[string]plugin.PluginOverride{
+		"test-plugin": {Scopes: []string{"read", "server:query"}},
+	}
+	p := newTestPlugin(t, sockPath)
+
+	ack := p.register("test-plugin", []string{"read", "server:query"}, nil, nil)
+	if !ack.Accepted {
+		t.Fatalf("rejected: %s", ack.Reason)
+	}
+
+	// Query health topic.
+	p.send(gcpc.NewServerQuery("q-1", "health"))
+
+	env := p.recv()
+	queryResp := env.GetServerQueryResponse()
+	if queryResp == nil {
+		t.Fatal("expected ServerQueryResponseV1")
+	}
+	if queryResp.RequestId != "q-1" {
+		t.Errorf("expected request_id q-1, got %q", queryResp.RequestId)
+	}
+	if queryResp.Error != "" {
+		t.Errorf("unexpected error: %s", queryResp.Error)
+	}
+	if queryResp.Data["status"] != "ok" {
+		t.Errorf("expected status ok, got %q", queryResp.Data["status"])
+	}
+}
+
+func TestGCPC_ServerQuery_DeniedScope(t *testing.T) {
+	_, _, _, sockPath := setupManager(t)
+	p := newTestPlugin(t, sockPath)
+
+	// Register without server:query scope.
+	ack := p.register("test-plugin", []string{"read"}, nil, nil)
+	if !ack.Accepted {
+		t.Fatalf("rejected: %s", ack.Reason)
+	}
+
+	// Query should be denied.
+	p.send(gcpc.NewServerQuery("q-2", "health"))
+
+	env := p.recv()
+	queryResp := env.GetServerQueryResponse()
+	if queryResp == nil {
+		t.Fatal("expected ServerQueryResponseV1")
+	}
+	if queryResp.Error == "" {
+		t.Error("expected permission denied error")
+	}
+}
+
+func TestGCPC_ServerQuery_Plugins(t *testing.T) {
+	mgr, _, _, sockPath := setupManager(t)
+	mgr.cfg.Overrides = map[string]plugin.PluginOverride{
+		"test-plugin": {Scopes: []string{"read", "server:query"}},
+	}
+	p := newTestPlugin(t, sockPath)
+
+	p.register("test-plugin", []string{"read", "server:query"}, nil, nil)
+
+	// Query plugins topic.
+	p.send(gcpc.NewServerQuery("q-3", "plugins"))
+
+	env := p.recv()
+	queryResp := env.GetServerQueryResponse()
+	if queryResp.Error != "" {
+		t.Fatalf("unexpected error: %s", queryResp.Error)
+	}
+	// Should show test-plugin as running.
+	if queryResp.Data["test-plugin.state"] != "running" {
+		t.Errorf("expected test-plugin running, got %q", queryResp.Data["test-plugin.state"])
+	}
+}
+
+func TestGCPC_SecretRedaction_InContextSnapshot(t *testing.T) {
+	// Verify that RedactSecrets works across all namespaces.
+	ctx := map[string]string{
+		"_start_ns":           "123",
+		"_secret.session":     "tok",
+		"shared.username":     "john",
+		"shared.secret.jwt":   "eyJ...",
+		"auth.cache_hit":      "true",
+		"auth.secret.api_key": "key123",
+	}
+
+	redacted := opctx.RedactSecrets(ctx)
+
+	if _, ok := redacted["_secret.session"]; ok {
+		t.Error("_secret.session should be redacted")
+	}
+	if _, ok := redacted["shared.secret.jwt"]; ok {
+		t.Error("shared.secret.jwt should be redacted")
+	}
+	if _, ok := redacted["auth.secret.api_key"]; ok {
+		t.Error("auth.secret.api_key should be redacted")
+	}
+	if redacted["_start_ns"] != "123" {
+		t.Error("non-secret should survive")
+	}
+	if redacted["shared.username"] != "john" {
+		t.Error("non-secret should survive")
+	}
+}

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -3,12 +3,14 @@ package manager
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
 
+	opctx "gocache/api/context"
 	"gocache/api/events"
 	gcpcv1 "gocache/api/gcpc/v1"
 	"gocache/api/logger"
@@ -23,6 +25,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// LogCollector is the interface for adding log sources.
+// Defined here to avoid importing pkg/logcollector from the manager.
+type LogCollector interface {
+	AddSource(name string, r io.Reader)
+}
+
 // Manager handles plugin lifecycle: discovery, fork/exec, registration,
 // health monitoring, restart, and graceful shutdown.
 type Manager struct {
@@ -35,6 +43,7 @@ type Manager struct {
 	scopeRegistry  *permissions.Registry
 	queryRegistry  *QueryRegistry
 	eventBus       *serverEvents.Bus
+	logCollector   LogCollector
 	ctx            context.Context
 	cancel         context.CancelFunc
 	wg             sync.WaitGroup
@@ -89,6 +98,11 @@ func (m *Manager) SetEventBus(bus *serverEvents.Bus) {
 	m.eventBus = bus
 }
 
+// SetLogCollector sets the log collector. Plugin stdout will be piped to it.
+func (m *Manager) SetLogCollector(lc LogCollector) {
+	m.logCollector = lc
+}
+
 // EventBus returns the event bus.
 func (m *Manager) EventBus() *serverEvents.Bus {
 	return m.eventBus
@@ -105,7 +119,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		return fmt.Errorf("discover plugins: %w", err)
 	}
 	if len(entries) == 0 {
-		logger.Info().Msg("no plugins discovered")
+		logger.InfoNoCtx().Msg("no plugins discovered")
 		return nil
 	}
 
@@ -114,7 +128,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("create plugin listener: %w", err)
 	}
-	logger.Info().Str("socket", m.cfg.SocketPath).Int("plugins", len(entries)).Msg("plugin listener started")
+	logger.InfoNoCtx().Str("socket", m.cfg.SocketPath).Int("plugins", len(entries)).Msg("plugin listener started")
 
 	// Register discovered plugins and launch them.
 	for _, entry := range entries {
@@ -143,7 +157,7 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 		return
 	}
 
-	logger.Info().Dur("timeout", timeout).Msg("shutting down plugins")
+	logger.InfoNoCtx().Dur("timeout", timeout).Msg("shutting down plugins")
 
 	// Close listener to stop accepting new connections.
 	_ = m.listener.Close()
@@ -157,7 +171,7 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 		}
 		if inst.Conn != nil {
 			if err := inst.Conn.Send(gcpcv1.NewShutdown(deadline)); err != nil {
-				logger.Warn().Str("plugin", inst.Name).Err(err).Msg("failed to send shutdown")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("failed to send shutdown")
 			}
 		}
 	}
@@ -178,7 +192,7 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 
 	select {
 	case <-done:
-		logger.Info().Msg("all plugins shut down gracefully")
+		logger.InfoNoCtx().Msg("all plugins shut down gracefully")
 	case <-timer.C:
 		// Force-kill remaining plugins.
 		for _, inst := range m.registry.All() {
@@ -186,7 +200,7 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 				continue
 			}
 			if inst.Cmd != nil && inst.Cmd.Process != nil {
-				logger.Warn().Str("plugin", inst.Name).Msg("force killing plugin")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Msg("force killing plugin")
 				_ = syscall.Kill(-inst.Cmd.Process.Pid, syscall.SIGKILL)
 			}
 		}
@@ -210,20 +224,45 @@ func (m *Manager) launchPlugin(inst *PluginInstance) {
 
 	cmd := exec.CommandContext(m.ctx, inst.BinPath)
 	cmd.Env = append(os.Environ(), "GOCACHE_PLUGIN_SOCK="+m.cfg.SocketPath)
-	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
+	// Pipe plugin stdout to the log collector (if set), otherwise to os.Stdout.
+	var logPipeR, logPipeW *os.File
+	if m.logCollector != nil {
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			logger.ErrorNoCtx().Str("plugin", inst.Name).Err(err).Msg("failed to create stdout pipe")
+			cmd.Stdout = os.Stdout // fallback
+		} else {
+			cmd.Stdout = pw
+			logPipeR, logPipeW = pr, pw
+		}
+	} else {
+		cmd.Stdout = os.Stdout
+	}
+
 	if err := cmd.Start(); err != nil {
-		logger.Error().Str("plugin", inst.Name).Err(err).Msg("failed to start plugin")
+		logger.ErrorNoCtx().Str("plugin", inst.Name).Err(err).Msg("failed to start plugin")
+		// Pipe not handed to collector yet — close both ends to avoid leaking fds/goroutines.
+		if logPipeW != nil {
+			_ = logPipeW.Close()
+			_ = logPipeR.Close()
+		}
 		if inst.Critical {
-			logger.Fatal().Str("plugin", inst.Name).Msg("critical plugin failed to start")
+			logger.FatalNoCtx().Str("plugin", inst.Name).Msg("critical plugin failed to start")
 		}
 		return
 	}
 
+	// Start succeeded — hand the read end to the collector and close our copy of the write end.
+	if logPipeR != nil {
+		m.logCollector.AddSource(inst.Name, logPipeR)
+		_ = logPipeW.Close()
+	}
+
 	inst.Cmd = cmd
-	logger.Info().Str("plugin", inst.Name).Int("pid", cmd.Process.Pid).Msg("plugin process started")
+	logger.InfoNoCtx().Str("plugin", inst.Name).Int("pid", cmd.Process.Pid).Msg("plugin process started")
 
 	// Monitor process exit in background.
 	m.wg.Add(1)
@@ -233,7 +272,7 @@ func (m *Manager) launchPlugin(inst *PluginInstance) {
 		if m.ctx.Err() != nil {
 			return // shutting down, ignore
 		}
-		logger.Warn().Str("plugin", inst.Name).Err(err).Msg("plugin process exited unexpectedly")
+		logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("plugin process exited unexpectedly")
 		m.handlePluginExit(inst)
 	}()
 }
@@ -248,7 +287,7 @@ func (m *Manager) acceptLoop() {
 			if m.ctx.Err() != nil {
 				return // shutting down
 			}
-			logger.Error().Err(err).Msg("plugin accept error")
+			logger.ErrorNoCtx().Err(err).Msg("plugin accept error")
 			continue
 		}
 
@@ -265,14 +304,14 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 	// Expect Register as first message.
 	env, err := conn.Recv()
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to read register message")
+		logger.ErrorNoCtx().Err(err).Msg("failed to read register message")
 		_ = conn.Close()
 		return
 	}
 
 	reg := env.GetRegister()
 	if reg == nil {
-		logger.Error().Msg("first message was not Register")
+		logger.ErrorNoCtx().Msg("first message was not Register")
 		_ = conn.Send(gcpcv1.NewRegisterAck(false, "expected Register message", nil))
 		_ = conn.Close()
 		return
@@ -281,7 +320,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 	// Match to known plugin.
 	inst, ok := m.registry.Get(reg.Name)
 	if !ok {
-		logger.Warn().Str("name", reg.Name).Msg("unknown plugin tried to register")
+		logger.WarnNoCtx().Str("name", reg.Name).Msg("unknown plugin tried to register")
 		_ = conn.Send(gcpcv1.NewRegisterAck(false, "unknown plugin", nil))
 		_ = conn.Close()
 		return
@@ -300,7 +339,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 	// --- Scope validation ---
 	grantedScopes, err := m.validateScopes(reg.Name, reg.RequestedScopes)
 	if err != nil {
-		logger.Error().Str("plugin", reg.Name).Err(err).Msg("scope validation failed")
+		logger.ErrorNoCtx().Str("plugin", reg.Name).Err(err).Msg("scope validation failed")
 		_ = conn.Send(gcpcv1.NewRegisterAck(false, "scope validation failed: "+err.Error(), nil))
 		_ = conn.Close()
 		return
@@ -311,7 +350,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 	// Register plugin commands with the router.
 	if len(reg.Commands) > 0 {
 		if err := m.router.RegisterPlugin(reg.Name, conn, reg.Commands); err != nil {
-			logger.Error().Str("plugin", reg.Name).Err(err).Msg("command registration failed")
+			logger.ErrorNoCtx().Str("plugin", reg.Name).Err(err).Msg("command registration failed")
 			m.scopeRegistry.Unregister(reg.Name)
 			_ = conn.Send(gcpcv1.NewRegisterAck(false, "command registration failed: "+err.Error(), nil))
 			_ = conn.Close()
@@ -331,7 +370,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 			m.hookRegistry.Register(reg.Name, int(reg.Priority), inst.Critical, pc, filteredHooks)
 		}
 		if dropped := len(reg.Hooks) - len(filteredHooks); dropped > 0 {
-			logger.Warn().Str("plugin", reg.Name).Int("dropped", dropped).Msg("hooks dropped due to missing scope")
+			logger.WarnNoCtx().Str("plugin", reg.Name).Int("dropped", dropped).Msg("hooks dropped due to missing scope")
 		}
 	}
 
@@ -352,7 +391,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 		}
 		m.opHookRegistry.Register(reg.Name, priority, pc, patterns)
 	} else if len(reg.OperationHooks) > 0 {
-		logger.Warn().Str("plugin", reg.Name).Int("dropped", len(reg.OperationHooks)).
+		logger.WarnNoCtx().Str("plugin", reg.Name).Int("dropped", len(reg.OperationHooks)).
 			Msg("operation hooks dropped due to missing 'operation:hook' scope")
 	}
 
@@ -360,7 +399,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 
 	grantedStrings := permissions.ScopeStrings(grantedScopes)
 	if err := conn.Send(gcpcv1.NewRegisterAck(true, "", grantedStrings)); err != nil {
-		logger.Error().Str("plugin", reg.Name).Err(err).Msg("failed to send register ack")
+		logger.ErrorNoCtx().Str("plugin", reg.Name).Err(err).Msg("failed to send register ack")
 		m.router.UnregisterPlugin(reg.Name)
 		m.scopeRegistry.Unregister(reg.Name)
 		_ = conn.Close()
@@ -368,7 +407,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 	}
 
 	m.registry.SetState(reg.Name, StateRunning)
-	logger.Info().Str("plugin", reg.Name).Str("version", reg.Version).Bool("critical", inst.Critical).Int("commands", len(reg.Commands)).Strs("scopes", grantedStrings).Msg("plugin registered")
+	logger.InfoNoCtx().Str("plugin", reg.Name).Str("version", reg.Version).Bool("critical", inst.Critical).Int("commands", len(reg.Commands)).Strs("scopes", grantedStrings).Msg("plugin registered")
 
 	if m.eventBus != nil {
 		m.eventBus.Emit(events.NewPluginRegistered(reg.Name, reg.Version, inst.Critical))
@@ -414,7 +453,7 @@ func (m *Manager) validateScopes(pluginName string, requested []string) ([]permi
 
 	granted, denied := permissions.ValidateRequest(requestedScopes, allowed)
 	if len(denied) > 0 {
-		logger.Warn().Str("plugin", pluginName).Strs("denied", permissions.ScopeStrings(denied)).
+		logger.WarnNoCtx().Str("plugin", pluginName).Strs("denied", permissions.ScopeStrings(denied)).
 			Msg("some requested scopes were denied — plugin will operate with reduced capabilities")
 	}
 
@@ -463,7 +502,7 @@ func (m *Manager) healthLoop(inst *PluginInstance) {
 				return
 			}
 			if err := inst.Conn.Send(gcpcv1.NewHealthCheck()); err != nil {
-				logger.Warn().Str("plugin", inst.Name).Err(err).Msg("health check send failed")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("health check send failed")
 				m.registry.SetState(inst.Name, StateUnhealthy)
 				return
 			}
@@ -480,7 +519,7 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 				return // shutting down
 			}
 			if inst.State == StateRunning {
-				logger.Warn().Str("plugin", inst.Name).Err(err).Msg("plugin connection lost")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("plugin connection lost")
 				m.router.UnregisterPlugin(inst.Name)
 				m.hookRegistry.Unregister(inst.Name)
 				m.opHookRegistry.Unregister(inst.Name)
@@ -502,22 +541,22 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 			if resp.Ok {
 				inst.LastHealth = time.Now()
 			} else {
-				logger.Warn().Str("plugin", inst.Name).Str("status", resp.Status).Msg("plugin reported unhealthy")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Str("status", resp.Status).Msg("plugin reported unhealthy")
 				m.registry.SetState(inst.Name, StateUnhealthy)
 				return
 			}
 		case *gcpcv1.EnvelopeV1_ShutdownAck:
-			logger.Info().Str("plugin", inst.Name).Msg("plugin acknowledged shutdown")
+			logger.InfoNoCtx().Str("plugin", inst.Name).Msg("plugin acknowledged shutdown")
 			m.registry.SetState(inst.Name, StateShutdown)
 			return
 		case *gcpcv1.EnvelopeV1_EventSubscribe:
 			sub := env.GetEventSubscribe()
 			if !m.scopeRegistry.HasScope(inst.Name, permissions.ScopeEvents) {
-				logger.Warn().Str("plugin", inst.Name).Msg("event subscription denied: missing 'events' scope")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Msg("event subscription denied: missing 'events' scope")
 				continue
 			}
 			if m.eventBus == nil {
-				logger.Warn().Str("plugin", inst.Name).Msg("event subscription failed: event bus not set")
+				logger.WarnNoCtx().Str("plugin", inst.Name).Msg("event subscription failed: event bus not set")
 				continue
 			}
 			types := make([]events.Type, len(sub.Types))
@@ -525,11 +564,15 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 				types[i] = events.Type(t)
 			}
 			// Bridge: subscribe on the server bus with a handler that forwards via GCPC.
+			// Context in events is filtered per plugin visibility before forwarding.
 			pluginConn := inst.Conn
+			pluginName := inst.Name
 			m.eventBus.Subscribe("plugin:"+inst.Name, types, func(evt events.Event) {
+				cloned := proto.Clone(evt.Proto).(*gcpcv1.EventV1)
+				filterEventContext(cloned, pluginName)
 				gcpcEnv := &gcpcv1.EnvelopeV1{
 					Version: gcpcv1.ProtocolVersion,
-					Payload: &gcpcv1.EnvelopeV1_Event{Event: proto.Clone(evt.Proto).(*gcpcv1.EventV1)},
+					Payload: &gcpcv1.EnvelopeV1_Event{Event: cloned},
 				}
 				_ = pluginConn.Send(gcpcEnv)
 			})
@@ -548,7 +591,7 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 			}
 			_ = inst.Conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, data, errMsg))
 		default:
-			logger.Debug().Str("plugin", inst.Name).Msg("unexpected message from plugin")
+			logger.DebugNoCtx().Str("plugin", inst.Name).Msg("unexpected message from plugin")
 		}
 	}
 }
@@ -568,18 +611,18 @@ func (m *Manager) handlePluginExit(inst *PluginInstance) {
 	}
 
 	if inst.Critical {
-		logger.Fatal().Str("plugin", inst.Name).Msg("critical plugin crashed — shutting down server")
+		logger.FatalNoCtx().Str("plugin", inst.Name).Msg("critical plugin crashed — shutting down server")
 		return
 	}
 
 	if inst.Restarts >= inst.MaxRestarts {
-		logger.Error().Str("plugin", inst.Name).Int("restarts", inst.Restarts).Msg("max restarts exceeded, giving up")
+		logger.ErrorNoCtx().Str("plugin", inst.Name).Int("restarts", inst.Restarts).Msg("max restarts exceeded, giving up")
 		m.registry.SetState(inst.Name, StateShutdown)
 		return
 	}
 
 	inst.Restarts++
-	logger.Info().Str("plugin", inst.Name).Int("attempt", inst.Restarts).Msg("restarting non-critical plugin")
+	logger.InfoNoCtx().Str("plugin", inst.Name).Int("attempt", inst.Restarts).Msg("restarting non-critical plugin")
 	m.registry.SetState(inst.Name, StateRestarting)
 
 	if inst.Conn != nil {
@@ -588,4 +631,32 @@ func (m *Manager) handlePluginExit(inst *PluginInstance) {
 	}
 
 	m.launchPlugin(inst)
+}
+
+// filterEventContext filters context maps in event data per plugin visibility.
+// Events carrying context (operation start/complete, command post, log entry) have
+// their context filtered so plugins only see _*, shared.*, and their own namespace.
+func filterEventContext(evt *gcpcv1.EventV1, pluginName string) {
+	switch d := evt.Data.(type) {
+	case *gcpcv1.EventV1_OperationStart:
+		if d.OperationStart != nil {
+			d.OperationStart.Context = opctx.FilterForPlugin(d.OperationStart.Context, pluginName)
+		}
+	case *gcpcv1.EventV1_OperationComplete:
+		if d.OperationComplete != nil {
+			d.OperationComplete.Context = opctx.FilterForPlugin(d.OperationComplete.Context, pluginName)
+		}
+	case *gcpcv1.EventV1_CommandPost:
+		if d.CommandPost != nil {
+			d.CommandPost.Metadata = opctx.FilterForPlugin(d.CommandPost.Metadata, pluginName)
+		}
+	case *gcpcv1.EventV1_CommandPre:
+		if d.CommandPre != nil {
+			d.CommandPre.Metadata = opctx.FilterForPlugin(d.CommandPre.Metadata, pluginName)
+		}
+	case *gcpcv1.EventV1_LogEntry:
+		if d.LogEntry != nil {
+			d.LogEntry.Fields = opctx.FilterForPlugin(d.LogEntry.Fields, pluginName)
+		}
+	}
 }

--- a/pkg/plugin/ophooks/executor.go
+++ b/pkg/plugin/ophooks/executor.go
@@ -48,7 +48,7 @@ func (e *Executor) RunStartHooks(ctx context.Context, op *ops.Operation) {
 		respCh, err := h.Conn.Send(hookCtx, env, reqID)
 		if err != nil {
 			cancel()
-			logger.Warn().Str("plugin", h.PluginName).Str("op", op.ID).Err(err).
+			logger.WarnNoCtx().Str("plugin", h.PluginName).Str("op", op.ID).Err(err).
 				Msg("operation start hook send failed, continuing")
 			continue
 		}
@@ -69,7 +69,7 @@ func (e *Executor) RunStartHooks(ctx context.Context, op *ops.Operation) {
 		case <-hookCtx.Done():
 			cancel()
 			h.Conn.DeletePending(reqID)
-			logger.Warn().Str("plugin", h.PluginName).Str("op", op.ID).
+			logger.WarnNoCtx().Str("plugin", h.PluginName).Str("op", op.ID).
 				Msg("operation start hook timed out, continuing")
 		}
 	}

--- a/pkg/plugin/router/router.go
+++ b/pkg/plugin/router/router.go
@@ -118,7 +118,7 @@ func (pc *PluginConn) readLoop() {
 			select {
 			case <-pc.done:
 			default:
-				logger.Debug().Str("plugin", pc.Name).Err(err).Msg("plugin conn read error")
+				logger.DebugNoCtx().Str("plugin", pc.Name).Err(err).Msg("plugin conn read error")
 			}
 			return
 		}
@@ -264,7 +264,7 @@ func (r *Router) RegisterPlugin(name string, conn *transport.Conn, decls []*gcpc
 	}
 	r.pluginRoutes[name] = keys
 
-	logger.Info().Str("plugin", name).Int("commands", len(toAdd)).Msg("plugin commands registered")
+	logger.InfoNoCtx().Str("plugin", name).Int("commands", len(toAdd)).Msg("plugin commands registered")
 	return nil
 }
 
@@ -287,7 +287,7 @@ func (r *Router) UnregisterPlugin(name string) {
 	}
 
 	if len(keys) > 0 {
-		logger.Info().Str("plugin", name).Int("commands", len(keys)).Msg("plugin commands unregistered")
+		logger.InfoNoCtx().Str("plugin", name).Int("commands", len(keys)).Msg("plugin commands unregistered")
 	}
 }
 

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -20,7 +20,7 @@ func HandleSnapshot(cmdCtx *command.Context) command.Result {
 	}
 	res := command.Dispatch(cmdCtx, executeFn)
 	if res.Err != nil {
-		logger.Error().Err(res.Err).Msg("snapshot command failed")
+		logger.ErrorNoCtx().Err(res.Err).Msg("snapshot command failed")
 	}
 	return res
 }
@@ -45,7 +45,7 @@ func HandleLoadSnapshot(cmdCtx *command.Context) command.Result {
 	}
 	res := command.Dispatch(cmdCtx, executeFn)
 	if res.Err != nil {
-		logger.Error().Err(res.Err).Str("file", filename).Msg("loadsnapshot command failed")
+		logger.ErrorNoCtx().Err(res.Err).Str("file", filename).Msg("loadsnapshot command failed")
 	}
 	return res
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,17 +49,21 @@ type Server struct {
 }
 
 func New(addr string, c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *Server {
+	tracker := serverOps.NewTracker()
+	ev := evaluator.New(c, e, snapshotFile, requirePass, br, wm)
+	ev.SetTracker(tracker)
 	return &Server{
 		addr:             addr,
 		cache:            c,
 		engine:           e,
-		evaluator:        evaluator.New(c, e, snapshotFile, requirePass, br, wm),
+		evaluator:        ev,
 		shutdownChan:     make(chan struct{}),
 		requirePass:      requirePass,
 		blockingRegistry: br,
 		watchManager:     wm,
 		startTime:        time.Now(),
 		emitter:          events.NoopEmitter{},
+		tracker:          tracker,
 	}
 }
 
@@ -123,7 +127,7 @@ func (srv *Server) Start(ctx context.Context) error {
 	}
 	srv.listener = listener
 
-	logger.Info().Str("addr", srv.addr).Msg("server listening")
+	logger.InfoNoCtx().Str("addr", srv.addr).Msg("server listening")
 
 	// Accept connections in a goroutine
 	go srv.acceptConnections()
@@ -150,7 +154,7 @@ func (srv *Server) acceptConnections() {
 			if shuttingDown {
 				return
 			}
-			logger.Error().Err(err).Msg("failed to accept connection")
+			logger.ErrorNoCtx().Err(err).Msg("failed to accept connection")
 			continue
 		}
 
@@ -163,7 +167,7 @@ func (srv *Server) acceptConnections() {
 func (srv *Server) Shutdown(timeout time.Duration) error {
 	var err error
 	srv.shutdownOnce.Do(func() {
-		logger.Info().Msg("initiating graceful shutdown")
+		logger.InfoNoCtx().Msg("initiating graceful shutdown")
 
 		// Mark as shutting down
 		srv.mu.Lock()
@@ -173,7 +177,7 @@ func (srv *Server) Shutdown(timeout time.Duration) error {
 		// Stop accepting new connections
 		if srv.listener != nil {
 			if err := srv.listener.Close(); err != nil {
-				logger.Warn().Err(err).Msg("listener close error")
+				logger.WarnNoCtx().Err(err).Msg("listener close error")
 			}
 		}
 
@@ -186,9 +190,9 @@ func (srv *Server) Shutdown(timeout time.Duration) error {
 
 		select {
 		case <-done:
-			logger.Info().Msg("all connections closed gracefully")
+			logger.InfoNoCtx().Msg("all connections closed gracefully")
 		case <-time.After(timeout):
-			logger.Warn().Msg("shutdown timeout reached, forcing close")
+			logger.WarnNoCtx().Msg("shutdown timeout reached, forcing close")
 		}
 
 		// Signal shutdown complete
@@ -204,23 +208,16 @@ func (srv *Server) handleConnection(conn net.Conn) {
 	remoteAddr := conn.RemoteAddr().String()
 	connStart := time.Now()
 
-	// Create connection operation if tracker is set.
-	var connOp *ops.Operation
-	if srv.tracker != nil {
-		connOp = srv.tracker.Start(ops.TypeConnection, "")
-		connOp.Enrich("_remote_addr", remoteAddr)
-		if srv.opHookExecutor != nil {
-			srv.opHookExecutor.RunStartHooks(context.Background(), connOp)
-		}
-		srv.emitter.Emit(events.NewConnectionOpen(remoteAddr).WithOperationID(connOp.ID))
-	} else {
-		srv.emitter.Emit(events.NewConnectionOpen(remoteAddr))
+	// Create connection operation.
+	connOp := srv.tracker.Start(ops.TypeConnection, "")
+	connOp.Enrich("_remote_addr", remoteAddr)
+	if srv.opHookExecutor != nil {
+		srv.opHookExecutor.RunStartHooks(context.Background(), connOp)
 	}
+	srv.emitter.Emit(events.NewConnectionOpen(remoteAddr).WithOperationID(connOp.ID))
 
 	ctx := clientctx.New()
-	if connOp != nil {
-		ctx.OperationID = connOp.ID
-	}
+	ctx.OperationID = connOp.ID
 
 	defer func() {
 		if srv.watchManager != nil {
@@ -228,16 +225,12 @@ func (srv *Server) handleConnection(conn net.Conn) {
 		}
 		conn.Close()
 		srv.connectionWg.Done()
-		if connOp != nil {
-			connOp.Complete()
-			if srv.opHookExecutor != nil {
-				srv.opHookExecutor.RunCompleteHooks(connOp)
-			}
-			srv.emitter.Emit(events.NewConnectionClose(remoteAddr, uint64(time.Since(connStart).Nanoseconds())).WithOperationID(connOp.ID))
-			srv.tracker.Complete(connOp.ID)
-		} else {
-			srv.emitter.Emit(events.NewConnectionClose(remoteAddr, uint64(time.Since(connStart).Nanoseconds())))
+		connOp.Complete()
+		if srv.opHookExecutor != nil {
+			srv.opHookExecutor.RunCompleteHooks(connOp)
 		}
+		srv.emitter.Emit(events.NewConnectionClose(remoteAddr, uint64(time.Since(connStart).Nanoseconds())).WithOperationID(connOp.ID))
+		srv.tracker.Complete(connOp.ID)
 	}()
 
 	reader := resp.NewReader(conn)
@@ -262,7 +255,7 @@ func (srv *Server) handleConnection(conn net.Conn) {
 		val, err := reader.Read()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
-				logger.Debug().Err(err).Msg("connection read error")
+				logger.DebugNoCtx().Err(err).Msg("connection read error")
 			}
 			return
 		}
@@ -330,7 +323,7 @@ func (srv *Server) handleConnection(conn net.Conn) {
 		// Auth gate: block commands until authenticated
 		if srv.requirePass != "" && !ctx.Authenticated {
 			if op != "AUTH" && op != "HELLO" {
-				srv.emitter.Emit(events.NewAuthFailed(remoteAddr, op))
+				srv.emitter.Emit(events.NewAuthFailed(remoteAddr, op).WithOperationID(ctx.OperationID))
 				if err := writer.Write(resp.MarshalError("NOAUTH Authentication required.")); err != nil {
 					return
 				}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,14 +2,16 @@ package server
 
 import (
 	"context"
-	"gocache/pkg/blocking"
-	"gocache/pkg/cache"
-	"gocache/pkg/engine"
-	"gocache/pkg/resp"
-	"gocache/pkg/watch"
 	"net"
 	"testing"
 	"time"
+
+	"gocache/pkg/blocking"
+	"gocache/pkg/cache"
+	"gocache/pkg/engine"
+	serverOps "gocache/pkg/operations"
+	"gocache/pkg/resp"
+	"gocache/pkg/watch"
 )
 
 func startTestServer(t *testing.T, requirePass string) (*Server, string) {
@@ -24,6 +26,7 @@ func startTestServer(t *testing.T, requirePass string) (*Server, string) {
 	c.OnMutate = wm.NotifyMutation
 
 	srv := New("127.0.0.1:0", c, e, "", requirePass, br, wm)
+	srv.SetTracker(serverOps.NewTracker())
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -154,6 +157,7 @@ func TestServer_Shutdown(t *testing.T) {
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
 	srv := New("127.0.0.1:0", c, e, "", "", br, wm)
+	srv.SetTracker(serverOps.NewTracker())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -151,10 +151,10 @@ func (w *SnapshotWorker) Start() {
 				}
 				w.engine.Dispatch(func() {
 					if err := persistence.SaveSnapshot(file, w.cache); err != nil {
-						logger.Warn().Err(err).Msg("snapshot save failed")
+						logger.WarnNoCtx().Err(err).Msg("snapshot save failed")
 						w.failOp(op, err.Error())
 					} else {
-						logger.Debug().Str("file", file).Msg("snapshot saved")
+						logger.DebugNoCtx().Str("file", file).Msg("snapshot saved")
 						w.completeOp(op)
 					}
 				})
@@ -204,7 +204,7 @@ func (w *CleanupWorker) Start() {
 						}
 						return true
 					})
-					logger.Debug().Msg("cleanup sweep completed")
+					logger.DebugNoCtx().Msg("cleanup sweep completed")
 					w.completeOp(op)
 				})
 			case d := <-w.intervalChan:

--- a/plugins/dummy/main.go
+++ b/plugins/dummy/main.go
@@ -23,7 +23,7 @@ func (d *dummyPlugin) OnHealthCheck(_ context.Context) error {
 }
 
 func (d *dummyPlugin) OnShutdown(_ context.Context) error {
-	d.log.Info().Msg("shutting down")
+	d.log.InfoNoCtx().Msg("shutting down")
 	return nil
 }
 
@@ -34,7 +34,7 @@ func main() {
 	defer cancel()
 
 	if err := pluginsdk.Run(ctx, &dummyPlugin{log: plog}); err != nil {
-		plog.Error().Err(err).Msg("plugin error")
+		plog.ErrorNoCtx().Err(err).Msg("plugin error")
 		os.Exit(1)
 	}
 }

--- a/plugins/gobservability/main.go
+++ b/plugins/gobservability/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gocache/api/command"
+	gcpc "gocache/api/gcpc/v1"
 	apilogger "gocache/api/logger"
 	"gocache/sdk/pluginsdk"
 )
@@ -39,16 +40,16 @@ func (p *gobservabilityPlugin) OnHealthCheck(_ context.Context) error {
 }
 
 func (p *gobservabilityPlugin) OnShutdown(ctx context.Context) error {
-	p.log.Info().Msg("shutting down")
+	p.log.InfoNoCtx().Msg("shutting down")
 	if p.tracer != nil {
 		if err := p.tracer.Shutdown(ctx); err != nil {
-			p.log.Error().Err(err).Msg("tracer shutdown error")
+			p.log.ErrorNoCtx().Err(err).Msg("tracer shutdown error")
 		}
 	}
 	return p.server.Shutdown(ctx)
 }
 
-// HookPlugin interface.
+// HookPlugin interface — Prometheus metrics only (no OTEL spans).
 
 func (p *gobservabilityPlugin) Hooks() []pluginsdk.HookDecl {
 	return []pluginsdk.HookDecl{
@@ -69,16 +70,71 @@ func (p *gobservabilityPlugin) HandleHook(_ context.Context, req *pluginsdk.Hook
 	isError := req.ResultError != ""
 	p.collector.Record(req.Command, elapsedNs, isError)
 
-	// Create OTEL span if tracer is enabled.
-	if p.tracer != nil {
-		var startNs uint64
-		if v, ok := req.Context[command.StartNs]; ok {
-			startNs, _ = strconv.ParseUint(v, 10, 64)
-		}
-		p.tracer.RecordCommand(req.Command, req.Args, elapsedNs, startNs, isError, req.ResultError, req.Metadata)
+	return nil
+}
+
+// OperationHookPlugin interface — OTEL tracing for ALL operations.
+
+func (p *gobservabilityPlugin) OperationHooks() []pluginsdk.OperationHookDecl {
+	return []pluginsdk.OperationHookDecl{
+		{Type: "*", Priority: 10},
+	}
+}
+
+func (p *gobservabilityPlugin) HandleOperationHook(_ context.Context, req *pluginsdk.OperationHookRequest) *pluginsdk.OperationHookResponse {
+	if req.Phase == "start" {
+		return p.onOperationStart(req)
+	}
+	p.onOperationComplete(req)
+	return nil
+}
+
+func (p *gobservabilityPlugin) onOperationStart(req *pluginsdk.OperationHookRequest) *pluginsdk.OperationHookResponse {
+	if p.tracer == nil {
+		return nil
 	}
 
-	return nil
+	// Start a span — tracer reads traceparent from context or generates one.
+	traceparent := p.tracer.StartOperation(req.OperationID, req.OperationType, req.Context)
+
+	// Write the canonical traceparent back so all downstream sees it.
+	return &pluginsdk.OperationHookResponse{
+		ContextValues: map[string]string{
+			"shared.traceparent": traceparent,
+		},
+	}
+}
+
+func (p *gobservabilityPlugin) onOperationComplete(req *pluginsdk.OperationHookRequest) {
+	if p.tracer == nil {
+		return
+	}
+
+	status := "completed"
+	failReason := ""
+	if v, ok := req.Context["_error"]; ok && v != "" {
+		status = "failed"
+		failReason = v
+	}
+
+	p.tracer.CompleteOperation(req.OperationID, status, failReason, req.Context)
+}
+
+// EventPlugin interface — subscribe to log.entry events for OTEL log export.
+
+func (p *gobservabilityPlugin) EventTypes() []string {
+	return []string{"log.entry"}
+}
+
+func (p *gobservabilityPlugin) HandleEvent(_ context.Context, evt *gcpc.EventV1) {
+	if p.tracer == nil {
+		return
+	}
+	logEntry := evt.GetLogEntry()
+	if logEntry == nil {
+		return
+	}
+	p.tracer.RecordLog(evt.OperationId, logEntry.Level, logEntry.Message, logEntry.Fields)
 }
 
 // QueryPlugin interface.
@@ -90,7 +146,13 @@ func (p *gobservabilityPlugin) SetSession(s *pluginsdk.Session) {
 // ScopePlugin interface.
 
 func (p *gobservabilityPlugin) Scopes() []string {
-	return []string{"hook:post", "server:query:health", "server:query:plugins"}
+	return []string{
+		"hook:post",
+		"operation:hook",
+		"events",
+		"server:query:health",
+		"server:query:plugins",
+	}
 }
 
 func main() {
@@ -114,12 +176,12 @@ func main() {
 		if serviceName == "" {
 			serviceName = "gocache"
 		}
-		tracer, err := NewTracer(otlpEndpoint, serviceName)
+		tracer, err := NewTracer(otlpEndpoint, serviceName, plog)
 		if err != nil {
-			plog.Error().Err(err).Msg("failed to initialize OTEL tracer")
+			plog.ErrorNoCtx().Err(err).Msg("failed to initialize OTEL tracer")
 		} else {
 			plugin.tracer = tracer
-			plog.Info().Str("endpoint", otlpEndpoint).Msg("OTEL tracing enabled")
+			plog.InfoNoCtx().Str("endpoint", otlpEndpoint).Msg("OTEL tracing enabled")
 		}
 	}
 
@@ -136,9 +198,9 @@ func main() {
 	}
 
 	go func() {
-		plog.Info().Str("addr", port).Msg("metrics server listening")
+		plog.InfoNoCtx().Str("addr", port).Msg("metrics server listening")
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			plog.Error().Err(err).Msg("metrics server error")
+			plog.ErrorNoCtx().Err(err).Msg("metrics server error")
 		}
 	}()
 
@@ -148,7 +210,7 @@ func main() {
 	defer cancel()
 
 	if err := pluginsdk.Run(ctx, plugin); err != nil {
-		plog.Error().Err(err).Msg("plugin error")
+		plog.ErrorNoCtx().Err(err).Msg("plugin error")
 		os.Exit(1)
 	}
 }

--- a/plugins/gobservability/tracer.go
+++ b/plugins/gobservability/tracer.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"strings"
+	"sync"
 	"time"
+
+	opctx "gocache/api/context"
+	apilogger "gocache/api/logger"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -17,20 +21,28 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Tracer wraps an OTEL TracerProvider and creates spans from command hook data.
+// Tracer wraps an OTEL TracerProvider and manages operation-based spans.
 type Tracer struct {
 	provider *sdktrace.TracerProvider
 	tracer   trace.Tracer
+	log      *apilogger.Logger
+
+	mu       sync.Mutex
+	inflight map[string]inflightSpan // operationID → span data
+}
+
+type inflightSpan struct {
+	span      trace.Span
+	startTime time.Time
 }
 
 // NewTracer creates a Tracer with an OTLP HTTP exporter.
-func NewTracer(endpoint, serviceName string) (*Tracer, error) {
+func NewTracer(endpoint, serviceName string, log *apilogger.Logger) (*Tracer, error) {
 	ctx := context.Background()
 
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(endpoint),
 	}
-	// If endpoint doesn't start with https, use insecure.
 	if !strings.HasPrefix(endpoint, "https") {
 		opts = append(opts, otlptracehttp.WithInsecure())
 	}
@@ -58,47 +70,124 @@ func NewTracer(endpoint, serviceName string) (*Tracer, error) {
 	return &Tracer{
 		provider: tp,
 		tracer:   tp.Tracer("gocache.gobservability"),
+		log:      log,
+		inflight: make(map[string]inflightSpan),
 	}, nil
 }
 
-// RecordCommand creates a span from a post-hook invocation.
-// If metadata contains a W3C traceparent, the span is created as a child.
-// Timing is reconstructed from _start_ns and _elapsed_ns.
-func (t *Tracer) RecordCommand(command string, args []string, elapsedNs uint64, startNs uint64, isError bool, resultError string, metadata map[string]string) {
+// StartOperation creates a span for an operation. Reads traceparent from
+// context (shared.traceparent or shared.rex.traceparent), or generates one.
+// Returns the traceparent string to write back into the operation context.
+func (t *Tracer) StartOperation(opID, opType string, opContext map[string]string) string {
 	if t == nil {
-		return
+		return ""
 	}
 
 	ctx := context.Background()
 
-	// Parse traceparent from metadata if present.
-	if tp, ok := metadata["traceparent"]; ok {
-		if sc, valid := parseTraceparent(tp); valid {
+	// Look for existing traceparent: shared.traceparent (canonical) then shared.rex.traceparent (REX fallback).
+	traceparent := opContext["shared.traceparent"]
+	if traceparent == "" {
+		traceparent = opContext["shared.rex.traceparent"]
+	}
+
+	if traceparent != "" {
+		if sc, valid := parseTraceparent(traceparent); valid {
 			ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
 		}
 	}
 
-	// Reconstruct timing.
-	startTime := time.Unix(0, int64(startNs))
-	endTime := startTime.Add(time.Duration(elapsedNs))
-
-	_, span := t.tracer.Start(ctx, "gocache "+command,
-		trace.WithTimestamp(startTime),
+	_, span := t.tracer.Start(ctx, "gocache."+opType,
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			semconv.DBSystemKey.String("gocache"),
-			semconv.DBOperationName(command),
-			attribute.Int("gocache.arg_count", len(args)),
+			attribute.String("gocache.operation.id", opID),
+			attribute.String("gocache.operation.type", opType),
 		),
 	)
 
-	if isError {
-		span.SetStatus(codes.Error, resultError)
+	t.mu.Lock()
+	t.inflight[opID] = inflightSpan{span: span, startTime: time.Now()}
+	t.mu.Unlock()
+
+	// Generate traceparent from the new span if none existed.
+	sc := span.SpanContext()
+	return fmt.Sprintf("00-%s-%s-01", sc.TraceID().String(), sc.SpanID().String())
+}
+
+// CompleteOperation finalizes the span for an operation.
+// Context is redacted (secrets stripped) before adding as attributes.
+func (t *Tracer) CompleteOperation(opID, status, failReason string, opContext map[string]string) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	entry, ok := t.inflight[opID]
+	if ok {
+		delete(t.inflight, opID)
+	}
+	t.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	span := entry.span
+
+	// Add non-secret context as span attributes.
+	redacted := opctx.RedactSecrets(opContext)
+	for k, v := range redacted {
+		// Skip internal keys that are already set or too noisy.
+		if strings.HasPrefix(k, "_") && k != "_command" {
+			continue
+		}
+		span.SetAttributes(attribute.String(k, v))
+	}
+
+	if status == "failed" {
+		span.SetStatus(codes.Error, failReason)
 	} else {
 		span.SetStatus(codes.Ok, "")
 	}
 
-	span.End(trace.WithTimestamp(endTime))
+	span.End()
+}
+
+// RecordLog attaches a log entry as a span event to the inflight operation span.
+// If no inflight span exists for the operation, the log is dropped (the operation
+// may have already completed).
+func (t *Tracer) RecordLog(operationID, level, message string, fields map[string]string) {
+	if t == nil || operationID == "" {
+		return
+	}
+
+	t.mu.Lock()
+	entry, ok := t.inflight[operationID]
+	t.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	// Redact secrets from fields before attaching to span.
+	redacted := opctx.RedactSecrets(fields)
+	attrs := []attribute.KeyValue{
+		attribute.String("log.level", level),
+	}
+	for k, v := range redacted {
+		attrs = append(attrs, attribute.String(k, v))
+	}
+
+	entry.span.AddEvent(message, trace.WithAttributes(attrs...))
+}
+
+// GenerateTraceparent creates a new W3C traceparent string.
+func GenerateTraceparent() string {
+	var traceID [16]byte
+	var spanID [8]byte
+	rand.Read(traceID[:])
+	rand.Read(spanID[:])
+	return fmt.Sprintf("00-%s-%s-01", hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:]))
 }
 
 // Shutdown flushes pending spans and shuts down the exporter.
@@ -110,14 +199,11 @@ func (t *Tracer) Shutdown(ctx context.Context) error {
 }
 
 // parseTraceparent parses a W3C traceparent header.
-// Format: version-traceid-spanid-flags (e.g. "00-abc123...-def456...-01")
 func parseTraceparent(tp string) (trace.SpanContext, bool) {
 	parts := strings.Split(tp, "-")
 	if len(parts) != 4 {
 		return trace.SpanContext{}, false
 	}
-
-	// version must be "00"
 	if parts[0] != "00" {
 		return trace.SpanContext{}, false
 	}
@@ -126,7 +212,6 @@ func parseTraceparent(tp string) (trace.SpanContext, bool) {
 	spanIDHex := parts[2]
 	flagsHex := parts[3]
 
-	// Trace ID must be 32 hex chars (16 bytes).
 	if len(traceIDHex) != 32 {
 		return trace.SpanContext{}, false
 	}
@@ -137,7 +222,6 @@ func parseTraceparent(tp string) (trace.SpanContext, bool) {
 	var traceID trace.TraceID
 	copy(traceID[:], traceIDBytes)
 
-	// Span ID must be 16 hex chars (8 bytes).
 	if len(spanIDHex) != 16 {
 		return trace.SpanContext{}, false
 	}
@@ -148,7 +232,6 @@ func parseTraceparent(tp string) (trace.SpanContext, bool) {
 	var spanID trace.SpanID
 	copy(spanID[:], spanIDBytes)
 
-	// Flags: 1 byte hex.
 	if len(flagsHex) != 2 {
 		return trace.SpanContext{}, false
 	}
@@ -166,7 +249,6 @@ func parseTraceparent(tp string) (trace.SpanContext, bool) {
 
 	sc := trace.NewSpanContext(cfg)
 	if !sc.IsValid() {
-		log.Printf("gobservability: invalid span context from traceparent %q", tp)
 		return trace.SpanContext{}, false
 	}
 

--- a/plugins/gobservability/tracer_test.go
+++ b/plugins/gobservability/tracer_test.go
@@ -2,25 +2,28 @@ package main
 
 import (
 	"context"
+	"os"
 	"testing"
-	"time"
 
-	"go.opentelemetry.io/otel/attribute"
+	apilogger "gocache/api/logger"
+
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// newTestTracer creates a Tracer backed by an in-memory exporter.
 func newTestTracer() (*Tracer, *tracetest.InMemoryExporter) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exporter),
 	)
+	log := apilogger.New(os.Stderr, "test", "debug")
 	return &Tracer{
 		provider: tp,
 		tracer:   tp.Tracer("test"),
+		log:      log,
+		inflight: make(map[string]inflightSpan),
 	}, exporter
 }
 
@@ -35,7 +38,7 @@ func TestParseTraceparent_Valid(t *testing.T) {
 		{"wrong version", "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", false},
 		{"short trace id", "00-4bf92f-00f067aa0ba902b7-01", false},
 		{"short span id", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067-01", false},
-		{"bad hex in trace id", "00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-00f067aa0ba902b7-01", false},
+		{"bad hex", "00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-00f067aa0ba902b7-01", false},
 		{"too few parts", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7", false},
 		{"empty", "", false},
 		{"all zeros trace id", "00-00000000000000000000000000000000-00f067aa0ba902b7-01", false},
@@ -43,55 +46,28 @@ func TestParseTraceparent_Valid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, valid := parseTraceparent(tt.input)
+			_, valid := parseTraceparent(tt.input)
 			if valid != tt.want {
 				t.Errorf("parseTraceparent(%q) valid=%v, want %v", tt.input, valid, tt.want)
-			}
-			if valid {
-				if !sc.HasTraceID() {
-					t.Error("expected valid trace ID")
-				}
-				if !sc.HasSpanID() {
-					t.Error("expected valid span ID")
-				}
-				if !sc.IsRemote() {
-					t.Error("expected remote span context")
-				}
 			}
 		})
 	}
 }
 
-func TestParseTraceparent_Fields(t *testing.T) {
-	sc, valid := parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
-	if !valid {
-		t.Fatal("expected valid")
-	}
-
-	if sc.TraceID().String() != "4bf92f3577b34da6a3ce929d0e0e4736" {
-		t.Errorf("trace id: got %s", sc.TraceID().String())
-	}
-	if sc.SpanID().String() != "00f067aa0ba902b7" {
-		t.Errorf("span id: got %s", sc.SpanID().String())
-	}
-	if !sc.IsSampled() {
-		t.Error("expected sampled flag set")
-	}
-}
-
-func TestRecordCommand_WithTraceparent(t *testing.T) {
+func TestStartOperation_WithTraceparent(t *testing.T) {
 	tracer, exporter := newTestTracer()
 	defer tracer.Shutdown(context.Background())
 
-	now := time.Now()
-	startNs := uint64(now.UnixNano())
-	elapsedNs := uint64(5 * time.Millisecond)
-
-	metadata := map[string]string{
-		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	ctx := map[string]string{
+		"shared.traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 	}
 
-	tracer.RecordCommand("SET", []string{"key", "value"}, elapsedNs, startNs, false, "", metadata)
+	tp := tracer.StartOperation("cmd_1", "command", ctx)
+	if tp == "" {
+		t.Fatal("expected non-empty traceparent")
+	}
+
+	tracer.CompleteOperation("cmd_1", "completed", "", ctx)
 
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {
@@ -99,73 +75,70 @@ func TestRecordCommand_WithTraceparent(t *testing.T) {
 	}
 
 	span := spans[0]
-	if span.Name != "gocache SET" {
-		t.Errorf("expected name 'gocache SET', got %q", span.Name)
+	if span.Name != "gocache.command" {
+		t.Errorf("expected span name gocache.command, got %q", span.Name)
 	}
 	if span.SpanKind != trace.SpanKindServer {
 		t.Errorf("expected SpanKindServer, got %v", span.SpanKind)
 	}
-	if span.Status.Code != codes.Ok {
-		t.Errorf("expected status Ok, got %v", span.Status.Code)
-	}
-
-	// Verify parent trace ID matches.
+	// Should be a child of the provided traceparent.
 	if span.Parent.TraceID().String() != "4bf92f3577b34da6a3ce929d0e0e4736" {
 		t.Errorf("parent trace id: got %s", span.Parent.TraceID().String())
 	}
-
-	// Verify attributes.
-	hasAttr := func(key string) bool {
-		for _, a := range span.Attributes {
-			if string(a.Key) == key {
-				return true
-			}
-		}
-		return false
-	}
-	if !hasAttr("db.system") {
-		t.Error("missing db.system attribute")
-	}
-	if !hasAttr("db.operation.name") {
-		t.Error("missing db.operation.name attribute")
-	}
-
-	// Check arg count attribute.
-	for _, a := range span.Attributes {
-		if a.Key == attribute.Key("gocache.arg_count") {
-			if a.Value.AsInt64() != 2 {
-				t.Errorf("expected arg_count=2, got %d", a.Value.AsInt64())
-			}
-		}
-	}
 }
 
-func TestRecordCommand_WithoutTraceparent(t *testing.T) {
+func TestStartOperation_WithoutTraceparent(t *testing.T) {
 	tracer, exporter := newTestTracer()
 	defer tracer.Shutdown(context.Background())
 
-	now := time.Now()
-	tracer.RecordCommand("GET", []string{"key"}, uint64(time.Millisecond), uint64(now.UnixNano()), false, "", nil)
+	tp := tracer.StartOperation("cleanup_1", "cleanup", map[string]string{})
+	if tp == "" {
+		t.Fatal("expected generated traceparent")
+	}
+
+	tracer.CompleteOperation("cleanup_1", "completed", "", map[string]string{})
 
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {
 		t.Fatalf("expected 1 span, got %d", len(spans))
 	}
-	if spans[0].Name != "gocache GET" {
-		t.Errorf("expected 'gocache GET', got %q", spans[0].Name)
+	if spans[0].Name != "gocache.cleanup" {
+		t.Errorf("expected gocache.cleanup, got %q", spans[0].Name)
 	}
-	// No parent — root span.
+	// Root span — no parent.
 	if spans[0].Parent.IsValid() {
 		t.Error("expected no parent (root span)")
 	}
 }
 
-func TestRecordCommand_Error(t *testing.T) {
+func TestStartOperation_REXFallback(t *testing.T) {
 	tracer, exporter := newTestTracer()
 	defer tracer.Shutdown(context.Background())
 
-	now := time.Now()
-	tracer.RecordCommand("SET", []string{"key", "value"}, uint64(time.Millisecond), uint64(now.UnixNano()), true, "ERR out of memory", nil)
+	// Only shared.rex.traceparent set (no shared.traceparent).
+	ctx := map[string]string{
+		"shared.rex.traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}
+
+	tracer.StartOperation("cmd_2", "command", ctx)
+	tracer.CompleteOperation("cmd_2", "completed", "", ctx)
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	// Should use the REX traceparent as parent.
+	if spans[0].Parent.TraceID().String() != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Errorf("expected REX traceparent as parent, got %s", spans[0].Parent.TraceID().String())
+	}
+}
+
+func TestCompleteOperation_Failed(t *testing.T) {
+	tracer, exporter := newTestTracer()
+	defer tracer.Shutdown(context.Background())
+
+	tracer.StartOperation("snap_1", "snapshot", map[string]string{})
+	tracer.CompleteOperation("snap_1", "failed", "disk full", map[string]string{})
 
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {
@@ -174,39 +147,138 @@ func TestRecordCommand_Error(t *testing.T) {
 	if spans[0].Status.Code != codes.Error {
 		t.Errorf("expected Error status, got %v", spans[0].Status.Code)
 	}
-	if spans[0].Status.Description != "ERR out of memory" {
-		t.Errorf("expected error description, got %q", spans[0].Status.Description)
+	if spans[0].Status.Description != "disk full" {
+		t.Errorf("expected 'disk full', got %q", spans[0].Status.Description)
 	}
 }
 
-func TestRecordCommand_NilTracer(t *testing.T) {
-	// Should not panic.
-	var tracer *Tracer
-	tracer.RecordCommand("SET", nil, 0, 0, false, "", nil)
-}
-
-func TestRecordCommand_Timing(t *testing.T) {
+func TestCompleteOperation_SecretsRedacted(t *testing.T) {
 	tracer, exporter := newTestTracer()
 	defer tracer.Shutdown(context.Background())
 
-	startNs := uint64(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano())
-	elapsedNs := uint64(10 * time.Millisecond)
+	tracer.StartOperation("cmd_3", "command", map[string]string{})
 
-	tracer.RecordCommand("PING", nil, elapsedNs, startNs, false, "", nil)
+	ctx := map[string]string{
+		"shared.username":   "john",
+		"shared.secret.jwt": "eyJ...",
+		"_command":          "SET",
+		"_secret.session":   "tok",
+	}
+	tracer.CompleteOperation("cmd_3", "completed", "", ctx)
 
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {
 		t.Fatalf("expected 1 span, got %d", len(spans))
 	}
 
-	span := spans[0]
-	expectedStart := time.Unix(0, int64(startNs))
-	expectedEnd := expectedStart.Add(time.Duration(elapsedNs))
-
-	if !span.StartTime.Equal(expectedStart) {
-		t.Errorf("start time: got %v, want %v", span.StartTime, expectedStart)
+	// Check attributes — secrets should be redacted.
+	attrs := make(map[string]string)
+	for _, a := range spans[0].Attributes {
+		attrs[string(a.Key)] = a.Value.AsString()
 	}
-	if !span.EndTime.Equal(expectedEnd) {
-		t.Errorf("end time: got %v, want %v", span.EndTime, expectedEnd)
+
+	if attrs["shared.username"] != "john" {
+		t.Error("expected shared.username in attributes")
+	}
+	if attrs["_command"] != "SET" {
+		t.Error("expected _command in attributes")
+	}
+	if _, ok := attrs["shared.secret.jwt"]; ok {
+		t.Error("shared.secret.jwt should be redacted")
+	}
+	if _, ok := attrs["_secret.session"]; ok {
+		t.Error("_secret.session should be redacted")
+	}
+}
+
+func TestCompleteOperation_Unknown(t *testing.T) {
+	tracer, _ := newTestTracer()
+	defer tracer.Shutdown(context.Background())
+
+	// Should not panic.
+	tracer.CompleteOperation("nonexistent", "completed", "", nil)
+}
+
+func TestNilTracer(t *testing.T) {
+	var tracer *Tracer
+	// Should not panic.
+	tp := tracer.StartOperation("cmd_1", "command", nil)
+	if tp != "" {
+		t.Error("expected empty traceparent from nil tracer")
+	}
+	tracer.CompleteOperation("cmd_1", "completed", "", nil)
+}
+
+func TestRecordLog_AttachesToSpan(t *testing.T) {
+	tracer, exporter := newTestTracer()
+	defer tracer.Shutdown(context.Background())
+
+	tracer.StartOperation("cmd_10", "command", map[string]string{})
+
+	tracer.RecordLog("cmd_10", "info", "cache hit", map[string]string{
+		"_source":           "server",
+		"shared.username":   "john",
+		"shared.secret.jwt": "eyJ...",
+		"key":               "user:123",
+	})
+
+	tracer.CompleteOperation("cmd_10", "completed", "", map[string]string{})
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	events := spans[0].Events
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event on span, got %d", len(events))
+	}
+
+	evt := events[0]
+	if evt.Name != "cache hit" {
+		t.Errorf("expected event name 'cache hit', got %q", evt.Name)
+	}
+
+	// Check attributes — secrets should be redacted.
+	attrs := make(map[string]string)
+	for _, a := range evt.Attributes {
+		attrs[string(a.Key)] = a.Value.AsString()
+	}
+	if attrs["log.level"] != "info" {
+		t.Error("expected log.level=info")
+	}
+	if attrs["key"] != "user:123" {
+		t.Error("expected key=user:123")
+	}
+	if attrs["shared.username"] != "john" {
+		t.Error("expected shared.username=john")
+	}
+	if _, ok := attrs["shared.secret.jwt"]; ok {
+		t.Error("shared.secret.jwt should be redacted")
+	}
+}
+
+func TestRecordLog_NoInflightSpan(t *testing.T) {
+	tracer, _ := newTestTracer()
+	defer tracer.Shutdown(context.Background())
+
+	// Should not panic — operation already completed or doesn't exist.
+	tracer.RecordLog("nonexistent", "warn", "orphaned log", nil)
+}
+
+func TestRecordLog_NilTracer(t *testing.T) {
+	var tracer *Tracer
+	tracer.RecordLog("cmd_1", "info", "test", nil)
+}
+
+func TestGenerateTraceparent(t *testing.T) {
+	tp := GenerateTraceparent()
+	if len(tp) == 0 {
+		t.Fatal("expected non-empty traceparent")
+	}
+	// Should be parseable.
+	_, valid := parseTraceparent(tp)
+	if !valid {
+		t.Errorf("generated traceparent %q is not valid", tp)
 	}
 }

--- a/sdk/pluginsdk/sdk.go
+++ b/sdk/pluginsdk/sdk.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"time"
 
 	gcpc "gocache/api/gcpc/v1"
@@ -186,6 +187,12 @@ func Run(ctx context.Context, p Plugin) error {
 	tc := transport.NewConn(conn)
 	defer tc.Close()
 
+	// Track handler goroutines so Run waits for them before returning —
+	// prevents a concurrent OnShutdown from tearing down state while a
+	// handler is still using it.
+	var handlerWg sync.WaitGroup
+	defer handlerWg.Wait()
+
 	// Detect interface support.
 	cp, isCommandPlugin := p.(CommandPlugin)
 	hp, isHookPlugin := p.(HookPlugin)
@@ -272,7 +279,7 @@ func Run(ctx context.Context, p Plugin) error {
 		return fmt.Errorf("registration rejected: %s", ack.Reason)
 	}
 	if len(ack.GrantedScopes) > 0 {
-		pluginLog.Info().Strs("scopes", ack.GrantedScopes).Msg("granted scopes")
+		pluginLog.InfoNoCtx().Strs("scopes", ack.GrantedScopes).Msg("granted scopes")
 	}
 	// Log denied scopes so the plugin author knows which features will be unavailable.
 	if isScopePlugin {
@@ -287,7 +294,7 @@ func Run(ctx context.Context, p Plugin) error {
 			}
 		}
 		if len(denied) > 0 {
-			pluginLog.Warn().Strs("denied", denied).Msg("scopes denied — features requiring these scopes will return errors")
+			pluginLog.WarnNoCtx().Strs("denied", denied).Msg("scopes denied — features requiring these scopes will return errors")
 		}
 	}
 
@@ -349,7 +356,9 @@ func Run(ctx context.Context, p Plugin) error {
 				continue
 			}
 			req := env.GetCommandRequest()
+			handlerWg.Add(1)
 			go func() {
+				defer handlerWg.Done()
 				result := cp.HandleCommand(ctx, req.Command, req.Args, req.Metadata)
 				var protoResult *gcpc.ResultV1
 				if result != nil {
@@ -359,7 +368,7 @@ func Run(ctx context.Context, p Plugin) error {
 				}
 				resp := gcpc.NewCommandResponse(req.RequestId, protoResult)
 				if err := tc.Send(resp); err != nil {
-					pluginLog.Error().Err(err).Str("command", req.Command).Msg("failed to send command response")
+					pluginLog.ErrorNoCtx().Err(err).Str("command", req.Command).Msg("failed to send command response")
 				}
 			}()
 
@@ -384,17 +393,25 @@ func Run(ctx context.Context, p Plugin) error {
 				}
 				resp := gcpc.NewOperationHookResponse(req.RequestId, ctxValues)
 				if err := tc.Send(resp); err != nil {
-					pluginLog.Error().Err(err).Msg("failed to send operation hook response")
+					pluginLog.ErrorNoCtx().Err(err).Msg("failed to send operation hook response")
 				}
 			} else {
 				// Complete phase: fire-and-forget.
-				go ohp.HandleOperationHook(ctx, hookReq)
+				handlerWg.Add(1)
+				go func() {
+					defer handlerWg.Done()
+					ohp.HandleOperationHook(ctx, hookReq)
+				}()
 			}
 
 		case *gcpc.EnvelopeV1_Event:
 			if isEventPlugin {
 				evt := env.GetEvent()
-				go ep.HandleEvent(ctx, evt)
+				handlerWg.Add(1)
+				go func() {
+					defer handlerWg.Done()
+					ep.HandleEvent(ctx, evt)
+				}()
 			}
 
 		case *gcpc.EnvelopeV1_ServerQueryResponse:
@@ -406,7 +423,9 @@ func Run(ctx context.Context, p Plugin) error {
 				continue
 			}
 			req := env.GetHookRequest()
+			handlerWg.Add(1)
 			go func() {
+				defer handlerWg.Done()
 				hookReq := &HookRequest{
 					Phase:       HookPhase(req.Phase),
 					Command:     req.Command,
@@ -427,7 +446,7 @@ func Run(ctx context.Context, p Plugin) error {
 				}
 				resp := gcpc.NewHookResponse(req.RequestId, deny, denyReason, ctxValues)
 				if err := tc.Send(resp); err != nil {
-					pluginLog.Error().Err(err).Str("command", req.Command).Msg("failed to send hook response")
+					pluginLog.ErrorNoCtx().Err(err).Str("command", req.Command).Msg("failed to send hook response")
 				}
 			}()
 		}


### PR DESCRIPTION
  - logger: require *Operation on Trace/Debug/Info/Warn/Error; add *NoCtx variants for early-startup/plugin-loading; add InitWithWriter, Dur helper
  - logcollector: new package reading JSON log lines from server + plugin stdout pipes, emitting log.entry events to the bus
  - server/main: pipe server logs through collector (tee'd to stderr); wrap bootstrap, snapshot load, and config reload in tracked operations with start/complete events and op hooks
  - evaluator: drop no-tracker fallback, tracker now always present
  - plugin manager: pipe plugin stdout to log collector; add LogCollector interface and SetLogCollector
  - gobservability: move OTEL spans from command hooks to new OperationHook (covers all operation types); subscribe to log.entry events for OTEL log export; declare operation:hook + events scopes
  - pluginsdk: wait for handler goroutines before Run returns to avoid OnShutdown tearing down state mid-handler
  - operations: add TypeShutdown
  - events: add HasSubscriber(name)