### PR TITLE
  Operation-aware context propagation (MDC-equivalent in Go):

### DIFF
--- a/api/logger/logger.go
+++ b/api/logger/logger.go
@@ -4,12 +4,18 @@
 // written to a configurable io.Writer (stdout by default). The log collector
 // worker reads from the pipe and emits LogEntry events to the event bus.
 //
-// The default log methods (Trace, Debug, Info, Warn, Error) require an
-// operation context. Use TraceNoCtx, DebugNoCtx, etc. for the rare cases
-// where no operation is active (early startup, plugin loading).
+// The default log methods (Trace, Debug, Info, Warn, Error) take a
+// context.Context and extract the current *ops.Operation via
+// operations.FromContext. If no operation is present the log line is still
+// written but without operation correlation.
+//
+// Use the NoCtx variants only at boundaries where no operation exists:
+// early startup before the bootstrap operation, plugin discovery/loading,
+// and config parsing.
 package logger
 
 import (
+	"context"
 	"io"
 	"os"
 	"sync/atomic"
@@ -35,19 +41,28 @@ func New(w io.Writer, source, level string) *Logger {
 	return &Logger{zl: zl}
 }
 
-// --- Default log methods (WITH operation context) ---
-// These are the standard methods. Every log call should pass an operation.
-// The operation may be nil — context is simply omitted in that case.
+// --- Default log methods (WITH operation context via ctx) ---
+// These are the standard methods. Every log call should pass the ambient ctx.
+// The operation is extracted via ops.FromContext(ctx); if nil, context is omitted.
 
-func (l *Logger) Trace(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Trace(), op: op} }
-func (l *Logger) Debug(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Debug(), op: op} }
-func (l *Logger) Info(op *ops.Operation) *OpEvent  { return &OpEvent{event: l.zl.Info(), op: op} }
-func (l *Logger) Warn(op *ops.Operation) *OpEvent  { return &OpEvent{event: l.zl.Warn(), op: op} }
-func (l *Logger) Error(op *ops.Operation) *OpEvent { return &OpEvent{event: l.zl.Error(), op: op} }
+func (l *Logger) Trace(ctx context.Context) *OpEvent {
+	return &OpEvent{event: l.zl.Trace(), op: ops.FromContext(ctx)}
+}
+func (l *Logger) Debug(ctx context.Context) *OpEvent {
+	return &OpEvent{event: l.zl.Debug(), op: ops.FromContext(ctx)}
+}
+func (l *Logger) Info(ctx context.Context) *OpEvent {
+	return &OpEvent{event: l.zl.Info(), op: ops.FromContext(ctx)}
+}
+func (l *Logger) Warn(ctx context.Context) *OpEvent {
+	return &OpEvent{event: l.zl.Warn(), op: ops.FromContext(ctx)}
+}
+func (l *Logger) Error(ctx context.Context) *OpEvent {
+	return &OpEvent{event: l.zl.Error(), op: ops.FromContext(ctx)}
+}
 
 // --- NoCtx methods (WITHOUT operation context) ---
-// For the rare cases where no operation is active: early startup, plugin loading,
-// shutdown after operations are cleaned up.
+// For boundaries with no operation: early startup, plugin loading, config loading.
 
 func (l *Logger) TraceNoCtx() *zerolog.Event { return l.zl.Trace() }
 func (l *Logger) DebugNoCtx() *zerolog.Event { return l.zl.Debug() }
@@ -70,6 +85,11 @@ func (e *OpEvent) Str(key, val string) *OpEvent {
 
 func (e *OpEvent) Int(key string, val int) *OpEvent {
 	e.event = e.event.Int(key, val)
+	return e
+}
+
+func (e *OpEvent) Int64(key string, val int64) *OpEvent {
+	e.event = e.event.Int64(key, val)
 	return e
 }
 
@@ -146,11 +166,11 @@ func Default() *Logger {
 
 // --- Package-level convenience functions (WITH context, delegate to Default()) ---
 
-func Trace(op *ops.Operation) *OpEvent { return Default().Trace(op) }
-func Debug(op *ops.Operation) *OpEvent { return Default().Debug(op) }
-func Info(op *ops.Operation) *OpEvent  { return Default().Info(op) }
-func Warn(op *ops.Operation) *OpEvent  { return Default().Warn(op) }
-func Error(op *ops.Operation) *OpEvent { return Default().Error(op) }
+func Trace(ctx context.Context) *OpEvent { return Default().Trace(ctx) }
+func Debug(ctx context.Context) *OpEvent { return Default().Debug(ctx) }
+func Info(ctx context.Context) *OpEvent  { return Default().Info(ctx) }
+func Warn(ctx context.Context) *OpEvent  { return Default().Warn(ctx) }
+func Error(ctx context.Context) *OpEvent { return Default().Error(ctx) }
 
 // --- Package-level convenience functions (NO context, delegate to Default()) ---
 

--- a/api/operations/ctxkey.go
+++ b/api/operations/ctxkey.go
@@ -1,0 +1,28 @@
+package operations
+
+import "context"
+
+// ctxKey is an unexported type used as a context key to prevent collisions
+// with other packages. The zero-value of the struct is used as the key.
+type ctxKey struct{}
+
+// WithContext returns a child context that carries op. Call at each operation
+// boundary so downstream code (cache, engine, persistence, workers) can pull
+// the current operation via FromContext for logging and correlation.
+func WithContext(ctx context.Context, op *Operation) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, ctxKey{}, op)
+}
+
+// FromContext returns the operation stored in ctx, or nil if none is present.
+// Returning nil is expected for pre-operation boundaries (startup before the
+// bootstrap op, plugin loading, config loading).
+func FromContext(ctx context.Context) *Operation {
+	if ctx == nil {
+		return nil
+	}
+	op, _ := ctx.Value(ctxKey{}).(*Operation)
+	return op
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -139,12 +139,13 @@ func main() {
 		snapOp := tracker.Start(ops.TypeSnapshot, bootOp.ID)
 		snapOp.Enrich("_file", cfg.Persistence.SnapshotFile)
 		snapOp.Enrich("_trigger", "startup")
+		snapCtx := ops.WithContext(ctx, snapOp)
 		if opHookExec != nil && opHookExec.HasAny() {
-			opHookExec.RunStartHooks(ctx, snapOp)
+			opHookExec.RunStartHooks(snapCtx, snapOp)
 		}
 		eventBus.Emit(events.NewOperationStart(snapOp.ID, string(snapOp.Type), bootOp.ID, snapOp.ContextSnapshot(false)))
-		if err := persistence.LoadSnapshot(cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
-			logger.Warn(snapOp).Err(err).Msg("failed to load snapshot")
+		if err := persistence.LoadSnapshot(snapCtx, cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
+			logger.Warn(snapCtx).Err(err).Msg("failed to load snapshot")
 			snapOp.Fail(err.Error())
 			if opHookExec != nil {
 				opHookExec.RunCompleteHooks(snapOp)
@@ -152,7 +153,7 @@ func main() {
 			eventBus.Emit(events.NewOperationComplete(snapOp.ID, string(snapOp.Type), uint64(snapOp.Duration().Nanoseconds()), "failed", err.Error(), snapOp.ContextSnapshot(false)))
 			tracker.Fail(snapOp.ID, err.Error())
 		} else {
-			logger.Info(snapOp).Str("file", cfg.Persistence.SnapshotFile).Msg("snapshot loaded")
+			logger.Info(snapCtx).Str("file", cfg.Persistence.SnapshotFile).Msg("snapshot loaded")
 			snapOp.Complete()
 			if opHookExec != nil {
 				opHookExec.RunCompleteHooks(snapOp)
@@ -180,21 +181,22 @@ func main() {
 	}
 	cleanupWorker.SetTracker(tracker)
 	cleanupWorker.SetEmitter(eventBus)
-	snapshotWorker.Start()
-	cleanupWorker.Start()
+	snapshotWorker.Start(ctx)
+	cleanupWorker.Start(ctx)
 
 	// Hot reload: config changes create config_reload operations.
 	v.WatchConfig()
 	v.OnConfigChange(func(e fsnotify.Event) {
 		reloadOp := tracker.Start(ops.TypeConfigReload, "")
 		reloadOp.Enrich("_file", e.Name)
+		reloadCtx := ops.WithContext(context.Background(), reloadOp)
 		if opHookExec != nil && opHookExec.HasAny() {
-			opHookExec.RunStartHooks(context.Background(), reloadOp)
+			opHookExec.RunStartHooks(reloadCtx, reloadOp)
 		}
 
 		newCfg, err := config.Reload(v)
 		if err != nil {
-			logger.Warn(reloadOp).Err(err).Msg("failed to parse updated config")
+			logger.Warn(reloadCtx).Err(err).Msg("failed to parse updated config")
 			reloadOp.Fail(err.Error())
 			if opHookExec != nil {
 				opHookExec.RunCompleteHooks(reloadOp)
@@ -203,17 +205,18 @@ func main() {
 			tracker.Fail(reloadOp.ID, err.Error())
 			return
 		}
-		logger.Info(reloadOp).Str("file", e.Name).Msg("config reloaded")
+		logger.Info(reloadCtx).Str("file", e.Name).Msg("config reloaded")
 
 		prev := cfgPtr.Load()
 		if newCfg.Server.GetAddr() != prev.Server.GetAddr() {
-			logger.Warn(reloadOp).Msg("server address/port changes require a restart")
+			logger.Warn(reloadCtx).Msg("server address/port changes require a restart")
 		}
 
 		snapshotWorker.UpdateInterval(newCfg.Persistence.SnapshotInterval)
 		snapshotWorker.UpdateFile(newCfg.Persistence.SnapshotFile)
 		cleanupWorker.UpdateInterval(newCfg.Workers.CleanupInterval)
 		cacheInstance.SetMemoryLimit(
+			reloadCtx,
 			newCfg.Memory.MaxMemoryMB,
 			cache.ParseEvictionPolicy(newCfg.Memory.EvictionPolicy),
 		)
@@ -280,24 +283,26 @@ func handleShutdown(
 	// Create shutdown operation — plugins see this via operation hooks
 	// before they are shut down.
 	var shutdownOp *ops.Operation
+	shutdownCtx := context.Background()
 	if tracker != nil {
 		shutdownOp = tracker.Start(ops.TypeShutdown, "")
 		shutdownOp.Enrich("_reason", reason)
+		shutdownCtx = ops.WithContext(shutdownCtx, shutdownOp)
 		if opHookExec != nil && opHookExec.HasAny() {
-			opHookExec.RunStartHooks(context.Background(), shutdownOp)
+			opHookExec.RunStartHooks(shutdownCtx, shutdownOp)
 		}
 		eventBus.Emit(events.NewServerShutdown(reason).WithOperationID(shutdownOp.ID))
 	}
 
-	logger.Info(shutdownOp).Msg("starting graceful shutdown sequence")
+	logger.Info(shutdownCtx).Msg("starting graceful shutdown sequence")
 
 	// Unblock all waiting BLPOP/BRPOP clients first so their connections can close.
 	blockingRegistry.Shutdown()
 
 	shutdownTimeout := 10 * time.Second
-	logger.Info(shutdownOp).Str("step", "1/6").Dur("timeout", shutdownTimeout).Msg("shutting down server")
+	logger.Info(shutdownCtx).Str("step", "1/6").Dur("timeout", shutdownTimeout).Msg("shutting down server")
 	if err := srv.Shutdown(shutdownTimeout); err != nil {
-		logger.Warn(shutdownOp).Err(err).Msg("server shutdown error")
+		logger.Warn(shutdownCtx).Err(err).Msg("server shutdown error")
 	}
 
 	// Fire operation complete hooks BEFORE shutting down plugins
@@ -308,22 +313,22 @@ func handleShutdown(
 
 	// Shutdown plugins.
 	if pluginManager != nil {
-		logger.Info(shutdownOp).Str("step", "2/6").Msg("shutting down plugins")
+		logger.Info(shutdownCtx).Str("step", "2/6").Msg("shutting down plugins")
 		pluginManager.Shutdown(cfg.Plugins.ShutdownTimeout)
 	}
 
-	logger.Info(shutdownOp).Str("step", "3/6").Msg("stopping background workers")
+	logger.Info(shutdownCtx).Str("step", "3/6").Msg("stopping background workers")
 	snapshotWorker.Stop()
 	cleanupWorker.Stop()
 
-	logger.Info(shutdownOp).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
-	if err := persistence.SaveSnapshot(cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
-		logger.Warn(shutdownOp).Err(err).Msg("failed to save final snapshot")
+	logger.Info(shutdownCtx).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
+	if err := persistence.SaveSnapshot(shutdownCtx, cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
+		logger.Warn(shutdownCtx).Err(err).Msg("failed to save final snapshot")
 	} else {
-		logger.Info(shutdownOp).Msg("final snapshot saved successfully")
+		logger.Info(shutdownCtx).Msg("final snapshot saved successfully")
 	}
 
-	logger.Info(shutdownOp).Str("step", "5/6").Msg("stopping engine")
+	logger.Info(shutdownCtx).Str("step", "5/6").Msg("stopping engine")
 	engineInstance.Stop()
 
 	if shutdownOp != nil {
@@ -334,5 +339,5 @@ func handleShutdown(
 		tracker.Complete(shutdownOp.ID)
 	}
 
-	logger.Info(shutdownOp).Str("step", "6/6").Msg("shutdown complete")
+	logger.Info(shutdownCtx).Str("step", "6/6").Msg("shutdown complete")
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"container/list"
+	"context"
 	"errors"
 	"gocache/api/logger"
 	"strings"
@@ -120,8 +121,9 @@ func (c *Cache) RUnlock() {
 }
 
 // SetMemoryLimit updates the memory limit and eviction policy at runtime.
-// Safe to call from any goroutine.
-func (c *Cache) SetMemoryLimit(maxMemoryMB int64, policy EvictionPolicy) {
+// Safe to call from any goroutine. ctx carries the operation (e.g. config
+// reload) for log correlation.
+func (c *Cache) SetMemoryLimit(ctx context.Context, maxMemoryMB int64, policy EvictionPolicy) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if maxMemoryMB > 0 {
@@ -130,11 +132,11 @@ func (c *Cache) SetMemoryLimit(maxMemoryMB int64, policy EvictionPolicy) {
 		c.maxBytes = 0
 	}
 	c.evictionPolicy = policy
-	logger.InfoNoCtx().Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
+	logger.Info(ctx).Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
 
 	// Evict if the new limit is below current usage.
 	if c.maxBytes > 0 && c.usedBytes > c.maxBytes && c.evictionPolicy == EvictionLRU {
-		c.evictLRU(0)
+		c.evictLRU(ctx, 0)
 	}
 }
 
@@ -166,8 +168,9 @@ func (c *Cache) MaxBytes() int64 {
 // RawSet stores a key with the given value and expiration, enforcing the
 // memory limit. It evicts LRU entries as needed (EvictionLRU) or returns
 // ErrOutOfMemory (EvictionNone) when the limit would be exceeded.
-// Must be called while holding the cache write lock.
-func (c *Cache) RawSet(key string, value interface{}, expiration int64) error {
+// Must be called while holding the cache write lock. ctx carries the
+// operation (command, cleanup, etc.) for log correlation.
+func (c *Cache) RawSet(ctx context.Context, key string, value interface{}, expiration int64) error {
 	if c.maxBytes > 0 {
 		newSize := estimateSize(key, value)
 		oldSize := c.sizes[key]
@@ -175,9 +178,9 @@ func (c *Cache) RawSet(key string, value interface{}, expiration int64) error {
 		if delta > 0 && c.usedBytes+delta > c.maxBytes {
 			switch c.evictionPolicy {
 			case EvictionLRU:
-				c.evictLRU(delta)
+				c.evictLRU(ctx, delta)
 			case EvictionNone:
-				logger.WarnNoCtx().Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
+				logger.Warn(ctx).Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
 				return ErrOutOfMemory
 			}
 		}
@@ -242,14 +245,14 @@ func (c *Cache) setInternal(key string, value interface{}, expiration int64) {
 
 // evictLRU removes least recently used entries until delta bytes can be
 // accommodated within the memory limit.
-func (c *Cache) evictLRU(delta int64) {
+func (c *Cache) evictLRU(ctx context.Context, delta int64) {
 	for c.maxBytes > 0 && c.usedBytes+delta > c.maxBytes {
 		elem := c.lruList.Back()
 		if elem == nil {
 			break
 		}
 		evictKey := elem.Value.(string)
-		logger.DebugNoCtx().Str("key", evictKey).Msg("lru eviction")
+		logger.Debug(ctx).Str("key", evictKey).Msg("lru eviction")
 		c.delete(evictKey)
 	}
 }
@@ -314,8 +317,8 @@ func (c *Cache) RawTTL(key string) int64 {
 	return c.ttl[key]
 }
 
-func (c *Cache) Clear() {
-	logger.InfoNoCtx().Int("items", len(c.items)).Msg("cache cleared")
+func (c *Cache) Clear(ctx context.Context) {
+	logger.Info(ctx).Int("items", len(c.items)).Msg("cache cleared")
 	c.items = make(map[string]*Entry)
 	c.ttl = make(map[string]int64)
 	c.lruList.Init()

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache_test
 
 import (
+	"context"
 	"errors"
 	"gocache/pkg/cache"
 	"gocache/pkg/persistence"
@@ -10,7 +11,7 @@ import (
 
 func TestCache_Basic(t *testing.T) {
 	c := cache.New()
-	if err := c.RawSet("key", "value", 0); err != nil {
+	if err := c.RawSet(context.Background(), "key", "value", 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -31,17 +32,17 @@ func TestCache_Snapshot(t *testing.T) {
 	defer os.Remove(filename)
 
 	c := cache.New()
-	if err := c.RawSet("snap", "data", 0); err != nil {
+	if err := c.RawSet(context.Background(), "snap", "data", 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	err := persistence.SaveSnapshot(filename, c)
+	err := persistence.SaveSnapshot(context.Background(), filename, c)
 	if err != nil {
 		t.Fatalf("failed to save snapshot: %v", err)
 	}
 
 	cacheInstance2 := cache.New()
-	err = persistence.LoadSnapshot(filename, cacheInstance2)
+	err = persistence.LoadSnapshot(context.Background(), filename, cacheInstance2)
 	if err != nil {
 		t.Fatalf("failed to load snapshot: %v", err)
 	}
@@ -59,7 +60,7 @@ func TestCache_MemoryLimit_LRU(t *testing.T) {
 	// Fill it: each write evicts the previous LRU entry
 	for i := 0; i < 5; i++ {
 		key := string(rune('a' + i))
-		if err := c.RawSet(key, "value", 0); err != nil {
+		if err := c.RawSet(context.Background(), key, "value", 0); err != nil {
 			t.Fatalf("unexpected OOM on LRU cache at key %s: %v", key, err)
 		}
 	}
@@ -80,12 +81,12 @@ func TestCache_MemoryLimit_NoEviction(t *testing.T) {
 	c := cache.NewWithBytes(200, cache.EvictionNone)
 
 	// First write should succeed (cache is empty)
-	if err := c.RawSet("first", "v", 0); err != nil {
+	if err := c.RawSet(context.Background(), "first", "v", 0); err != nil {
 		t.Fatalf("unexpected error on first write: %v", err)
 	}
 
 	// Subsequent writes that exceed the limit must return ErrOutOfMemory
-	err := c.RawSet("second", "v", 0)
+	err := c.RawSet(context.Background(), "second", "v", 0)
 	if !errors.Is(err, cache.ErrOutOfMemory) {
 		t.Errorf("expected ErrOutOfMemory, got %v", err)
 	}
@@ -98,7 +99,7 @@ func TestCache_MemoryTracking(t *testing.T) {
 		t.Errorf("expected 0 used bytes on empty cache, got %d", c.UsedBytes())
 	}
 
-	_ = c.RawSet("key", "hello", 0)
+	_ = c.RawSet(context.Background(), "key", "hello", 0)
 	usedAfterSet := c.UsedBytes()
 	if usedAfterSet <= 0 {
 		t.Errorf("expected usedBytes > 0 after set, got %d", usedAfterSet)
@@ -114,14 +115,14 @@ func TestCache_LRU_OrderOnGet(t *testing.T) {
 	// Cache that holds ~2 small entries; verify that GET refreshes LRU order
 	c := cache.NewWithBytes(300, cache.EvictionLRU)
 
-	_ = c.RawSet("a", "1", 0)
-	_ = c.RawSet("b", "2", 0) // b is now MRU, a is LRU
+	_ = c.RawSet(context.Background(), "a", "1", 0)
+	_ = c.RawSet(context.Background(), "b", "2", 0) // b is now MRU, a is LRU
 
 	// Access "a" to make it MRU; "b" becomes LRU
 	c.RawGet("a")
 
 	// Writing a new key should evict "b" (now LRU), not "a"
-	_ = c.RawSet("c", "3", 0)
+	_ = c.RawSet(context.Background(), "c", "3", 0)
 
 	_, aFound := c.RawGet("a")
 	_, bFound := c.RawGet("b")
@@ -143,7 +144,7 @@ func TestCache_SetMemoryLimit_EvictsWhenLowered(t *testing.T) {
 	c := cache.New()
 	for i := 0; i < 10; i++ {
 		key := "key" + string(rune('a'+i))
-		if err := c.RawSet(key, "somevalue", 0); err != nil {
+		if err := c.RawSet(context.Background(), key, "somevalue", 0); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}
@@ -157,13 +158,13 @@ func TestCache_SetMemoryLimit_EvictsWhenLowered(t *testing.T) {
 	}
 
 	// Lower the limit to something tiny — should trigger eviction.
-	c.SetMemoryLimit(1, cache.EvictionLRU) // 1 MB — still bigger than our data
+	c.SetMemoryLimit(context.Background(), 1, cache.EvictionLRU) // 1 MB — still bigger than our data
 	// Use a byte-level limit via the internal path: set maxBytes directly by
 	// creating a new cache with bytes limit to test eviction trigger.
 	small := cache.NewWithBytes(200, cache.EvictionLRU)
 	for i := 0; i < 5; i++ {
 		key := "k" + string(rune('a'+i))
-		_ = small.RawSet(key, "val", 0)
+		_ = small.RawSet(context.Background(), key, "val", 0)
 	}
 	before := small.Len()
 	if before == 0 {
@@ -171,12 +172,12 @@ func TestCache_SetMemoryLimit_EvictsWhenLowered(t *testing.T) {
 	}
 
 	// Lower to 1 byte — must evict down.
-	small.SetMemoryLimit(0, cache.EvictionLRU) // disable limit first
+	small.SetMemoryLimit(context.Background(), 0, cache.EvictionLRU) // disable limit first
 	// Manually set a very small byte limit. Since SetMemoryLimit takes MB,
 	// we use NewWithBytes + re-populate to test the eviction path.
 	tiny := cache.NewWithBytes(1, cache.EvictionLRU)
 	for i := 0; i < 5; i++ {
-		_ = tiny.RawSet("k"+string(rune('a'+i)), "val", 0)
+		_ = tiny.RawSet(context.Background(), "k"+string(rune('a'+i)), "val", 0)
 	}
 	// Only one key should survive (each entry > 128 bytes overhead).
 	if tiny.Len() > 1 {
@@ -187,7 +188,7 @@ func TestCache_SetMemoryLimit_EvictsWhenLowered(t *testing.T) {
 func TestCache_LargeEntryExceedsMaxBytes(t *testing.T) {
 	// A single entry larger than maxBytes should be rejected with noeviction.
 	c := cache.NewWithBytes(1, cache.EvictionNone)
-	err := c.RawSet("big", "this is way more than 1 byte of data", 0)
+	err := c.RawSet(context.Background(), "big", "this is way more than 1 byte of data", 0)
 	if !errors.Is(err, cache.ErrOutOfMemory) {
 		t.Errorf("expected ErrOutOfMemory for oversized entry, got %v", err)
 	}

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -5,6 +5,8 @@
 package command
 
 import (
+	"context"
+
 	apicommand "gocache/api/command"
 	"gocache/pkg/blocking"
 	"gocache/pkg/cache"
@@ -22,7 +24,14 @@ type Spec = apicommand.Spec
 type Handler func(ctx *Context) Result
 
 // Context carries all dependencies needed to execute a command.
+//
+// Context is request-scoped and short-lived: it is constructed per command
+// by the evaluator and discarded when the handler returns. The ambient
+// context.Context is held in an unexported field and exposed via the
+// Context() method, following the http.Request precedent — see
+// (*Context).Context and (*Context).SetContext.
 type Context struct {
+	ctx              context.Context
 	Client           *clientctx.ClientContext
 	Op               string
 	Args             []string
@@ -38,22 +47,54 @@ type Context struct {
 	RequirePass  string
 
 	// EvalFn re-enters the evaluator pipeline. Used by EXEC to execute
-	// queued commands in a batch. The bool parameter is inBatch.
-	EvalFn func(ctx *clientctx.ClientContext, op string, args []string, inBatch bool) Result
+	// queued commands in a batch. parentCtx is the connection-scoped ctx
+	// from the outer Evaluate call.
+	EvalFn func(parentCtx context.Context, client *clientctx.ClientContext, op string, args []string, inBatch bool) Result
+}
+
+// Context returns the ambient context.Context carrying the current
+// *ops.Operation (retrievable via operations.FromContext). Handlers
+// should pass this down to cache/persistence calls and logger calls so
+// logs stay correlated with the command operation.
+//
+// Do NOT capture the returned context in a goroutine that outlives the
+// handler call: the command operation completes when the handler returns,
+// and a later log would carry a stale (completed) operation.
+//
+// Returns context.Background() if no context was set, so callers never
+// receive nil.
+func (c *Context) Context() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+	return c.ctx
+}
+
+// SetContext assigns the ambient context.Context. Called by the evaluator
+// when building the Context before handler dispatch.
+func (c *Context) SetContext(ctx context.Context) {
+	c.ctx = ctx
 }
 
 // Dispatch runs fn either directly (when InBatch is true, meaning the engine
 // lock is already held) or through the engine dispatcher. It wraps the result
-// into a Result, propagating any error.
+// into a Result, propagating any error. If the engine is stopped or the
+// command context is cancelled before fn runs, the returned Result carries
+// that error.
 func Dispatch(ctx *Context, fn func() interface{}) Result {
-	var res interface{}
 	if ctx.InBatch {
-		res = fn()
-	} else {
-		res = ctx.Engine.DispatchWithResult(fn)
+		res := fn()
+		if err, ok := res.(error); ok {
+			return Result{Err: err}
+		}
+		return Result{Value: res}
 	}
-	if err, ok := res.(error); ok {
+	res, err := ctx.Engine.DispatchWithResult(ctx.Context(), fn)
+	if err != nil {
 		return Result{Err: err}
+	}
+	if resultErr, ok := res.(error); ok {
+		return Result{Err: resultErr}
 	}
 	return Result{Value: res}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,10 +1,25 @@
+// Package engine serialises all cache mutations through a single goroutine.
+//
+// Callers submit work via Dispatch or DispatchWithResult. The engine goroutine
+// executes the work under the cache lock and returns the result through a
+// per-call channel. Callers pass a context.Context so shutdown and timeouts
+// propagate correctly; if the context expires before the work starts, the
+// engine returns ctx.Err() without executing the function. If the engine is
+// stopped before the work starts, ErrEngineStopped is returned.
 package engine
 
 import (
+	"context"
+	"errors"
+	"sync"
+
 	"gocache/api/logger"
 	"gocache/pkg/cache"
-	"sync"
 )
+
+// ErrEngineStopped is returned by Dispatch/DispatchWithResult when the engine
+// has been stopped before the work could be executed.
+var ErrEngineStopped = errors.New("engine stopped")
 
 type Command struct {
 	Execute func() interface{}
@@ -48,7 +63,10 @@ func (e *Engine) Stop() {
 	})
 }
 
-func (e *Engine) Dispatch(fn func()) {
+// Dispatch submits fn to the engine and blocks until it runs (or the engine
+// stops, or ctx is cancelled). Returns nil on success, ErrEngineStopped if
+// the engine stopped before execution, or ctx.Err() if ctx was cancelled.
+func (e *Engine) Dispatch(ctx context.Context, fn func()) error {
 	resChan := make(chan interface{}, 1)
 	select {
 	case e.cmdChan <- Command{
@@ -59,15 +77,24 @@ func (e *Engine) Dispatch(fn func()) {
 		ResChan: resChan,
 	}:
 	case <-e.stopChan:
-		return
+		return ErrEngineStopped
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 	select {
 	case <-resChan:
+		return nil
 	case <-e.stopChan:
+		return ErrEngineStopped
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
-func (e *Engine) DispatchWithResult(fn func() interface{}) interface{} {
+// DispatchWithResult submits fn to the engine and blocks until it runs.
+// Returns (result, nil) on success, (nil, ErrEngineStopped) if the engine
+// stopped before execution, or (nil, ctx.Err()) if ctx was cancelled.
+func (e *Engine) DispatchWithResult(ctx context.Context, fn func() interface{}) (interface{}, error) {
 	resChan := make(chan interface{}, 1)
 	select {
 	case e.cmdChan <- Command{
@@ -75,12 +102,16 @@ func (e *Engine) DispatchWithResult(fn func() interface{}) interface{} {
 		ResChan: resChan,
 	}:
 	case <-e.stopChan:
-		return nil
+		return nil, ErrEngineStopped
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 	select {
 	case res := <-resChan:
-		return res
+		return res, nil
 	case <-e.stopChan:
-		return nil
+		return nil, ErrEngineStopped
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,10 +1,13 @@
 package engine
 
 import (
-	"gocache/pkg/cache"
+	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"gocache/pkg/cache"
 )
 
 func newTestEngine(t *testing.T) (*Engine, *cache.Cache) {
@@ -19,9 +22,12 @@ func newTestEngine(t *testing.T) (*Engine, *cache.Cache) {
 func TestDispatchWithResult(t *testing.T) {
 	e, _ := newTestEngine(t)
 
-	res := e.DispatchWithResult(func() interface{} {
+	res, err := e.DispatchWithResult(context.Background(), func() interface{} {
 		return 42
 	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if res != 42 {
 		t.Errorf("expected 42, got %v", res)
 	}
@@ -31,9 +37,11 @@ func TestDispatch(t *testing.T) {
 	e, _ := newTestEngine(t)
 
 	var called atomic.Bool
-	e.Dispatch(func() {
+	if err := e.Dispatch(context.Background(), func() {
 		called.Store(true)
-	})
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	// Dispatch is synchronous — by the time it returns, fn has run.
 	if !called.Load() {
 		t.Error("expected Dispatch to execute the function")
@@ -49,7 +57,7 @@ func TestDispatchWithResult_Serialization(t *testing.T) {
 
 	go func() {
 		for range n {
-			e.DispatchWithResult(func() interface{} {
+			_, _ = e.DispatchWithResult(context.Background(), func() interface{} {
 				counter++
 				return nil
 			})
@@ -68,19 +76,34 @@ func TestDispatchWithResult_Serialization(t *testing.T) {
 	}
 }
 
-func TestStop_ReturnsNil(t *testing.T) {
+func TestStop_ReturnsEngineStopped(t *testing.T) {
 	c := cache.New()
 	e := New(c)
 	go e.Run()
 
 	e.Stop()
 
-	// After stop, DispatchWithResult should return nil.
-	res := e.DispatchWithResult(func() interface{} {
+	// After stop, DispatchWithResult should return ErrEngineStopped.
+	res, err := e.DispatchWithResult(context.Background(), func() interface{} {
 		return "should not run"
 	})
 	if res != nil {
-		t.Errorf("expected nil after stop, got %v", res)
+		t.Errorf("expected nil result after stop, got %v", res)
+	}
+	if !errors.Is(err, ErrEngineStopped) {
+		t.Errorf("expected ErrEngineStopped, got %v", err)
+	}
+}
+
+func TestDispatch_CtxCancelled(t *testing.T) {
+	e, _ := newTestEngine(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := e.Dispatch(ctx, func() {})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
 	}
 }
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -37,21 +37,14 @@ type OpHookExecutor interface {
 	RunCompleteHooks(op *ops.Operation)
 }
 
-// Evaluator is the command dispatch pipeline.
-type Evaluator interface {
-	Evaluate(ctx *clientctx.ClientContext, op string, args []string) command.Result
-	RegisterHandler(op string, handler command.Handler)
-	SetPluginRouter(r *router.Router)
-	SetHookExecutor(e command.HookExecutor)
-	SetEmitter(e events.Emitter)
-	SetTracker(t *serverOps.Tracker)
-	SetOpHookExecutor(e OpHookExecutor)
-	CoreCommandNames() []string
-}
-
-// BaseEvaluator is the pipeline implementation. It owns no command-specific
+// BaseEvaluator is the command dispatch pipeline. It owns no command-specific
 // knowledge — handlers and their argument specs are provided by external
 // packages (resp/handler, rex/handler) via command.Registration.
+//
+// Following "accept interfaces, return structs," constructors return
+// *BaseEvaluator directly; consumers that need a narrower surface for testing
+// should define their own interface locally (pkg/server does this via a
+// package-private alias of the methods it actually calls).
 type BaseEvaluator struct {
 	cache              *cache.Cache
 	engine             *engine.Engine
@@ -69,7 +62,7 @@ type BaseEvaluator struct {
 	opHookExecutor     OpHookExecutor
 }
 
-func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) Evaluator {
+func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *BaseEvaluator {
 	b := &BaseEvaluator{
 		cache:              c,
 		engine:             e,
@@ -137,18 +130,18 @@ func (b *BaseEvaluator) registerAll() {
 	}
 }
 
-func (b *BaseEvaluator) Evaluate(ctx *clientctx.ClientContext, op string, args []string) command.Result {
-	return b.evaluateInternal(ctx, op, args, false)
+func (b *BaseEvaluator) Evaluate(parentCtx context.Context, client *clientctx.ClientContext, op string, args []string) command.Result {
+	return b.evaluateInternal(parentCtx, client, op, args, false)
 }
 
-func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string, args []string, inBatch bool) command.Result {
+func (b *BaseEvaluator) evaluateInternal(parentCtx context.Context, ctx *clientctx.ClientContext, op string, args []string, inBatch bool) command.Result {
 	op = strings.ToUpper(op)
 
 	handler, ok := b.handlers[op]
 	if !ok {
 		// Fall through to plugin router for plugin-provided commands.
 		if b.pluginRouter != nil && b.pluginRouter.HasCommand(op) {
-			return b.routeToPlugin(ctx, op, args)
+			return b.routeToPlugin(parentCtx, ctx, op, args)
 		}
 		logger.DebugNoCtx().Str("command", op).Msg("unknown command")
 		return command.Result{Value: resp.ErrUnknown(strings.ToLower(op))}
@@ -192,9 +185,14 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 		}
 	}
 
+	// Build operation-carrying context so handlers and downstream (cache,
+	// persistence) can log with correlation. Derives from the parent
+	// (connection) context so cancellation propagates into plugin routing.
+	opCtx := ops.WithContext(parentCtx, cmdOp)
+
 	// Fire operation start hooks (synchronous — enriches context before work).
 	if b.opHookExecutor != nil && b.opHookExecutor.HasAny() {
-		b.opHookExecutor.RunStartHooks(context.Background(), cmdOp)
+		b.opHookExecutor.RunStartHooks(opCtx, cmdOp)
 	}
 
 	// Emit operation.start + command.pre events.
@@ -217,6 +215,7 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 		RequirePass:      b.requirePass,
 		EvalFn:           b.evaluateInternal,
 	}
+	cmdCtx.SetContext(opCtx)
 
 	// --- Command hooks (pre) ---
 	var hookCtx map[string]string
@@ -224,7 +223,7 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 	if hasHooks {
 		hookCtx = cmdOp.ContextSnapshot(false)
 
-		if pre := b.hookExecutor.RunPreHooks(context.Background(), op, args, hookCtx); pre != nil {
+		if pre := b.hookExecutor.RunPreHooks(opCtx, op, args, hookCtx); pre != nil {
 			if pre.Denied {
 				cmdOp.Fail("denied: " + pre.DenyReason)
 				if b.opHookExecutor != nil {
@@ -248,7 +247,7 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 		elapsedNs := time.Now().UnixNano() - startNs
 		hookCtx[command.ElapsedNs] = strconv.FormatInt(elapsedNs, 10)
 		resultVal, resultErr := resultToHookStrings(result)
-		b.hookExecutor.RunPostHooks(context.Background(), op, args, resultVal, resultErr, hookCtx)
+		b.hookExecutor.RunPostHooks(opCtx, op, args, resultVal, resultErr, hookCtx)
 	}
 
 	// --- Complete operation ---
@@ -275,11 +274,13 @@ func (b *BaseEvaluator) evaluateInternal(ctx *clientctx.ClientContext, op string
 	return result
 }
 
-// routeToPlugin dispatches a command to a plugin via the router.
-func (b *BaseEvaluator) routeToPlugin(client *clientctx.ClientContext, op string, args []string) command.Result {
+// routeToPlugin dispatches a command to a plugin via the router. The per-call
+// timeout is derived from parentCtx so connection-level cancellation also
+// aborts the plugin call.
+func (b *BaseEvaluator) routeToPlugin(parentCtx context.Context, client *clientctx.ClientContext, op string, args []string) command.Result {
 	metadata := rex.BuildMetadata(client.RexMeta, client.CmdMeta)
 
-	ctx, cancel := context.WithTimeout(context.Background(), pluginCommandTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, pluginCommandTimeout)
 	defer cancel()
 
 	val, err := b.pluginRouter.Route(ctx, op, args, metadata)

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -25,7 +25,7 @@ func newTestEvaluator() (*BaseEvaluator, *engine.Engine, *serverOps.Tracker) {
 	go e.Run()
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
-	eval := New(c, e, "test.dat", "", br, wm).(*BaseEvaluator)
+	eval := New(c, e, "test.dat", "", br, wm)
 	tracker := serverOps.NewTracker()
 	eval.SetTracker(tracker)
 	return eval, e, tracker
@@ -86,7 +86,7 @@ func TestEvaluate_BasicCommand(t *testing.T) {
 	defer e.Stop()
 
 	ctx := clientctx.New()
-	result := eval.Evaluate(ctx, "PING", nil)
+	result := eval.Evaluate(context.Background(), ctx, "PING", nil)
 	if result.Value != "PONG" {
 		t.Errorf("expected PONG, got %v", result.Value)
 	}
@@ -97,7 +97,7 @@ func TestEvaluate_WithTracker_CreatesOperation(t *testing.T) {
 	defer e.Stop()
 
 	ctx := clientctx.New()
-	result := eval.Evaluate(ctx, "PING", nil)
+	result := eval.Evaluate(context.Background(), ctx, "PING", nil)
 	if result.Value != "PONG" {
 		t.Errorf("expected PONG, got %v", result.Value)
 	}
@@ -117,7 +117,7 @@ func TestEvaluate_WithTracker_OperationHasContext(t *testing.T) {
 	eval.SetOpHookExecutor(opHook)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	if opHook.startCalled.Load() != 1 {
 		t.Errorf("expected start hook called once, got %d", opHook.startCalled.Load())
@@ -150,7 +150,7 @@ func TestEvaluate_WithTracker_ParentID(t *testing.T) {
 	ctx := clientctx.New()
 	ctx.OperationID = "conn_1" // simulate connection operation
 
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	if opHook.lastOp.Load().ParentID != "conn_1" {
 		t.Errorf("expected parent conn_1, got %q", opHook.lastOp.Load().ParentID)
@@ -170,7 +170,7 @@ func TestEvaluate_WithTracker_REXMetadataInContext(t *testing.T) {
 		"tenant":      "acme",
 	}
 
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// REX metadata should be in operation context with shared.rex. prefix.
 	tp, ok := opHook.lastOp.Load().Get("shared.rex.traceparent")
@@ -198,7 +198,7 @@ func TestEvaluate_WithTracker_OpHookEnrichment(t *testing.T) {
 	eval.SetOpHookExecutor(opHook)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// Verify enrichment landed in operation.
 	tp, ok := opHook.lastOp.Load().Get("shared.traceparent")
@@ -215,7 +215,7 @@ func TestEvaluate_WithTracker_EmitsEvents(t *testing.T) {
 	eval.SetEmitter(emitter)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// Should have: operation.start, command.pre, command.post, operation.complete
 	if len(emitter.events) < 4 {
@@ -275,7 +275,7 @@ func TestEvaluate_WithTracker_CmdHooksDeriveFromOpContext(t *testing.T) {
 	eval.SetHookExecutor(cmdHook)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// The hook context should contain the operation-enriched traceparent.
 	if cmdHook.lastHookCtx == nil {
@@ -311,7 +311,7 @@ func TestEvaluate_WithTracker_PreHookDeny_FailsOperation(t *testing.T) {
 	eval.SetHookExecutor(cmdHook)
 
 	ctx := clientctx.New()
-	result := eval.Evaluate(ctx, "PING", nil)
+	result := eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// Command should be denied.
 	if result.Value == "PONG" {
@@ -352,7 +352,7 @@ func TestEvaluate_WithTracker_PreHookEnrichmentFlowsToOperation(t *testing.T) {
 	eval.SetHookExecutor(cmdHook)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// Pre-hook enrichments should be in the operation.
 	user, _ := opHook.lastOp.Load().Get("shared.user")
@@ -366,7 +366,7 @@ func TestEvaluate_UnknownCommand(t *testing.T) {
 	defer e.Stop()
 
 	ctx := clientctx.New()
-	result := eval.Evaluate(ctx, "NOSUCHCMD", nil)
+	result := eval.Evaluate(context.Background(), ctx, "NOSUCHCMD", nil)
 
 	// Unknown commands don't create operations (they bail before the op lifecycle).
 	if tracker.ActiveCount() != 0 {
@@ -382,7 +382,7 @@ func TestEvaluate_TransactionQueued(t *testing.T) {
 	ctx := clientctx.New()
 	ctx.InTransaction = true
 
-	result := eval.Evaluate(ctx, "SET", []string{"key", "value"})
+	result := eval.Evaluate(context.Background(), ctx, "SET", []string{"key", "value"})
 	if result.Value != "QUEUED" {
 		t.Errorf("expected QUEUED, got %v", result.Value)
 	}
@@ -406,7 +406,7 @@ func TestEvaluate_ConcurrentCommands(t *testing.T) {
 	for range n {
 		go func() {
 			ctx := clientctx.New()
-			eval.Evaluate(ctx, "PING", nil)
+			eval.Evaluate(context.Background(), ctx, "PING", nil)
 			done <- struct{}{}
 		}()
 	}
@@ -435,7 +435,7 @@ func TestEvaluate_OperationTimingAccuracy(t *testing.T) {
 	eval.SetEmitter(emitter)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// Find the operation.complete event and check elapsed_ns > 0.
 	for _, evt := range emitter.events {
@@ -464,7 +464,7 @@ func TestEvaluate_OperationContextHasElapsed(t *testing.T) {
 	eval.SetOpHookExecutor(opHook)
 
 	ctx := clientctx.New()
-	eval.Evaluate(ctx, "PING", nil)
+	eval.Evaluate(context.Background(), ctx, "PING", nil)
 
 	// The completed operation should have _elapsed_ns in context.
 	elapsed, ok := opHook.lastOp.Load().Get(command.ElapsedNs)
@@ -483,7 +483,7 @@ func TestEvaluate_ArgValidation_NoOperation(t *testing.T) {
 
 	ctx := clientctx.New()
 	// SET requires 2 args.
-	result := eval.Evaluate(ctx, "SET", []string{"key"})
+	result := eval.Evaluate(context.Background(), ctx, "SET", []string{"key"})
 
 	// Arg validation failure happens before operation creation.
 	// Actually — arg validation happens BEFORE op creation in current code.

--- a/pkg/logcollector/collector.go
+++ b/pkg/logcollector/collector.go
@@ -9,8 +9,8 @@ package logcollector
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"io"
+	"strconv"
 	"sync"
 
 	"gocache/api/events"
@@ -83,56 +83,28 @@ func (c *Collector) parseLine(sourceName string, line []byte) {
 	}
 	operationID := stringField(raw, "_operation_id")
 
-	// Extract _ctx (redacted operation context written by the logger).
-	var ctxFields map[string]string
-	if ctxRaw, ok := raw["_ctx"]; ok {
-		if ctxMap, ok := ctxRaw.(map[string]interface{}); ok {
-			ctxFields = make(map[string]string, len(ctxMap))
-			for k, v := range ctxMap {
-				if s, ok := v.(string); ok {
-					ctxFields[k] = s
-				}
-			}
-		}
-	}
-
-	// Build fields from remaining keys (exclude well-known).
-	fields := make(map[string]string)
+	// Build the fields map directly: one allocation sized for the upper bound
+	// (raw keys + potential _ctx keys + "_source"). Unknown keys are written
+	// straight in; _ctx entries are flattened in-place rather than merged.
+	ctxMap, _ := raw["_ctx"].(map[string]interface{})
+	fields := make(map[string]string, len(raw)+len(ctxMap)+1)
 	fields["_source"] = source
 	for k, v := range raw {
 		switch k {
 		case "level", "message", "time", "source", "_operation_id", "_ctx":
 			continue
 		default:
-			switch val := v.(type) {
-			case string:
-				fields[k] = val
-			case float64:
-				// JSON numbers are float64.
-				if val == float64(int64(val)) {
-					fields[k] = json.Number(fmt.Sprintf("%d", int64(val))).String()
-				} else {
-					fields[k] = json.Number(fmt.Sprintf("%g", val)).String()
-				}
-			case bool:
-				if val {
-					fields[k] = "true"
-				} else {
-					fields[k] = "false"
-				}
-			default:
-				if b, err := json.Marshal(val); err == nil {
-					fields[k] = string(b)
-				}
+			if s, ok := formatJSONValue(v); ok {
+				fields[k] = s
 			}
 		}
 	}
-
-	// Merge _ctx fields into the event fields. The _ctx contains the redacted
-	// operation context (shared.traceparent, _command, etc.). These flow through
-	// to the LogEntry event so subscribers can correlate.
-	for k, v := range ctxFields {
-		fields[k] = v
+	// _ctx contains the redacted operation context (shared.traceparent,
+	// _command, etc.) — flatten it into fields so subscribers can correlate.
+	for k, v := range ctxMap {
+		if s, ok := v.(string); ok {
+			fields[k] = s
+		}
 	}
 
 	evt := events.NewLogEntry(level, message, "", fields)
@@ -150,4 +122,29 @@ func stringField(m map[string]interface{}, key string) string {
 		}
 	}
 	return ""
+}
+
+// formatJSONValue renders a decoded JSON value as a string suitable for
+// the log fields map. Returns ("", false) if the value cannot be serialised.
+func formatJSONValue(v interface{}) (string, bool) {
+	switch val := v.(type) {
+	case string:
+		return val, true
+	case float64:
+		// JSON numbers decode as float64; detect integers and render cleanly.
+		if val == float64(int64(val)) {
+			return strconv.FormatInt(int64(val), 10), true
+		}
+		return strconv.FormatFloat(val, 'g', -1, 64), true
+	case bool:
+		return strconv.FormatBool(val), true
+	case nil:
+		return "", false
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
+	}
 }

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"context"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -27,12 +28,13 @@ type SnapshotEntry struct {
 
 // SaveSnapshot writes a snapshot atomically: it encodes into a sibling temp
 // file first, fsyncs, then renames over the destination. A crash mid-write
-// leaves the previous snapshot intact instead of corrupting it.
-func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
+// leaves the previous snapshot intact instead of corrupting it. ctx carries
+// the snapshot operation for log correlation.
+func SaveSnapshot(ctx context.Context, filename string, cacheInstance *cache.Cache) error {
 	dir := filepath.Dir(filename)
 	tmp, err := os.CreateTemp(dir, ".snapshot-*.tmp")
 	if err != nil {
-		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("failed to create snapshot temp file")
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("failed to create snapshot temp file")
 		return fmt.Errorf("create snapshot temp %s: %w", filename, err)
 	}
 	tmpName := tmp.Name()
@@ -58,13 +60,13 @@ func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
 	// Write count header first so the decoder knows exactly how many entries follow.
 	if err := encoder.Encode(len(entries)); err != nil {
 		_ = tmp.Close()
-		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot encode error")
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot encode error")
 		return fmt.Errorf("encode snapshot %s: %w", filename, err)
 	}
 	for _, e := range entries {
 		if err := encoder.Encode(e); err != nil {
 			_ = tmp.Close()
-			logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot encode error")
+			logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot encode error")
 			return fmt.Errorf("encode snapshot %s: %w", filename, err)
 		}
 	}
@@ -83,28 +85,30 @@ func SaveSnapshot(filename string, cacheInstance *cache.Cache) error {
 		return fmt.Errorf("rename snapshot %s: %w", filename, err)
 	}
 
-	logger.InfoNoCtx().Str("file", filename).Int("entries", len(entries)).Msg("snapshot saved")
+	logger.Info(ctx).Str("file", filename).Int("entries", len(entries)).Msg("snapshot saved")
 	return nil
 }
 
-func LoadSnapshot(filename string, cacheInstance *cache.Cache) error {
+// LoadSnapshot reads a snapshot file and populates the cache. ctx carries
+// the snapshot operation for log correlation.
+func LoadSnapshot(ctx context.Context, filename string, cacheInstance *cache.Cache) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			logger.DebugNoCtx().Str("file", filename).Msg("snapshot file not found, skipping")
+			logger.Debug(ctx).Str("file", filename).Msg("snapshot file not found, skipping")
 			return nil
 		}
-		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("failed to open snapshot file")
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("failed to open snapshot file")
 		return fmt.Errorf("open snapshot %s: %w", filename, err)
 	}
 	defer file.Close()
 
 	decoder := gob.NewDecoder(file)
-	cacheInstance.Clear()
+	cacheInstance.Clear(ctx)
 
 	var count int
 	if err := decoder.Decode(&count); err != nil {
-		logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot decode error")
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot decode error")
 		return fmt.Errorf("decode snapshot %s: %w", filename, err)
 	}
 
@@ -112,18 +116,18 @@ func LoadSnapshot(filename string, cacheInstance *cache.Cache) error {
 	for i := 0; i < count; i++ {
 		var e SnapshotEntry
 		if err := decoder.Decode(&e); err != nil {
-			logger.ErrorNoCtx().Err(err).Str("file", filename).Msg("snapshot decode error")
+			logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot decode error")
 			return fmt.Errorf("decode snapshot %s: %w", filename, err)
 		}
 
 		if e.Expiration > 0 && e.Expiration < time.Now().UnixNano() {
-			logger.TraceNoCtx().Str("key", e.Key).Msg("skipped expired entry during load")
+			logger.Trace(ctx).Str("key", e.Key).Msg("skipped expired entry during load")
 			continue
 		}
 		cacheInstance.RawLoad(e.Key, e.Value, e.Expiration)
 		loaded++
 	}
 
-	logger.InfoNoCtx().Str("file", filename).Int("entries", loaded).Msg("snapshot loaded")
+	logger.Info(ctx).Str("file", filename).Int("entries", loaded).Msg("snapshot loaded")
 	return nil
 }

--- a/pkg/persistence/persistence_test.go
+++ b/pkg/persistence/persistence_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"context"
 	"gocache/pkg/cache"
 	"os"
 	"path/filepath"
@@ -14,18 +15,18 @@ func TestSaveAndLoadRoundtrip(t *testing.T) {
 
 	c := cache.New()
 	c.Lock()
-	_ = c.RawSet("str", "hello", 0)
-	_ = c.RawSet("list", []string{"a", "b", "c"}, 0)
-	_ = c.RawSet("hash", map[string]string{"k": "v"}, 0)
-	_ = c.RawSet("set", map[string]struct{}{"x": {}, "y": {}}, 0)
+	_ = c.RawSet(context.Background(), "str", "hello", 0)
+	_ = c.RawSet(context.Background(), "list", []string{"a", "b", "c"}, 0)
+	_ = c.RawSet(context.Background(), "hash", map[string]string{"k": "v"}, 0)
+	_ = c.RawSet(context.Background(), "set", map[string]struct{}{"x": {}, "y": {}}, 0)
 	c.Unlock()
 
-	if err := SaveSnapshot(file, c); err != nil {
+	if err := SaveSnapshot(context.Background(), file, c); err != nil {
 		t.Fatalf("SaveSnapshot failed: %v", err)
 	}
 
 	c2 := cache.New()
-	if err := LoadSnapshot(file, c2); err != nil {
+	if err := LoadSnapshot(context.Background(), file, c2); err != nil {
 		t.Fatalf("LoadSnapshot failed: %v", err)
 	}
 
@@ -53,7 +54,7 @@ func TestSaveAndLoadRoundtrip(t *testing.T) {
 
 func TestLoadSnapshot_FileNotFound(t *testing.T) {
 	c := cache.New()
-	err := LoadSnapshot("/nonexistent/path/file.dat", c)
+	err := LoadSnapshot(context.Background(), "/nonexistent/path/file.dat", c)
 	if err != nil {
 		t.Errorf("expected nil for missing file, got %v", err)
 	}
@@ -66,16 +67,16 @@ func TestLoadSnapshot_SkipsExpired(t *testing.T) {
 	c := cache.New()
 	c.Lock()
 	// Set a key that's already expired.
-	_ = c.RawSet("expired", "val", time.Now().Add(-time.Hour).UnixNano())
-	_ = c.RawSet("alive", "val", 0)
+	_ = c.RawSet(context.Background(), "expired", "val", time.Now().Add(-time.Hour).UnixNano())
+	_ = c.RawSet(context.Background(), "alive", "val", 0)
 	c.Unlock()
 
-	if err := SaveSnapshot(file, c); err != nil {
+	if err := SaveSnapshot(context.Background(), file, c); err != nil {
 		t.Fatalf("SaveSnapshot failed: %v", err)
 	}
 
 	c2 := cache.New()
-	if err := LoadSnapshot(file, c2); err != nil {
+	if err := LoadSnapshot(context.Background(), file, c2); err != nil {
 		t.Fatalf("LoadSnapshot failed: %v", err)
 	}
 
@@ -91,7 +92,7 @@ func TestLoadSnapshot_SkipsExpired(t *testing.T) {
 }
 
 func TestSaveSnapshot_CreateError(t *testing.T) {
-	err := SaveSnapshot("/nonexistent/dir/file.dat", cache.New())
+	err := SaveSnapshot(context.Background(), "/nonexistent/dir/file.dat", cache.New())
 	if err == nil {
 		t.Error("expected error for invalid path")
 	}
@@ -103,7 +104,7 @@ func TestLoadSnapshot_EmptyFile(t *testing.T) {
 	_ = os.WriteFile(file, []byte{}, 0644)
 
 	c := cache.New()
-	err := LoadSnapshot(file, c)
+	err := LoadSnapshot(context.Background(), file, c)
 	if err == nil {
 		t.Error("expected error for empty file")
 	}

--- a/pkg/plugin/manager/it_gcpc_test.go
+++ b/pkg/plugin/manager/it_gcpc_test.go
@@ -112,9 +112,8 @@ func setupManager(t *testing.T) (*Manager, *serverEvents.Bus, *serverOps.Tracker
 	mgr := NewManager(cfg, []string{"GET", "SET", "PING"}, &mockState{})
 	mgr.SetEventBus(eventBus)
 
-	// Set the context (normally done by Start()).
+	// Establish the lifecycle context (normally done by Start()).
 	ctx, cancel := context.WithCancel(context.Background())
-	mgr.ctx = ctx
 	mgr.cancel = cancel
 	t.Cleanup(cancel)
 
@@ -138,7 +137,7 @@ func setupManager(t *testing.T) (*Manager, *serverEvents.Bus, *serverOps.Tracker
 			if err != nil {
 				return
 			}
-			go mgr.handleConnection(conn)
+			go mgr.handleConnection(ctx, conn)
 		}
 	}()
 

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -33,6 +33,11 @@ type LogCollector interface {
 
 // Manager handles plugin lifecycle: discovery, fork/exec, registration,
 // health monitoring, restart, and graceful shutdown.
+//
+// The lifecycle context.Context is not stored on the Manager. Start derives
+// one from its caller and threads it into every spawned goroutine via closure
+// or parameter. Shutdown calls the stored cancel function to terminate all
+// in-flight goroutines and subprocesses.
 type Manager struct {
 	cfg            plugin.PluginsConfig
 	listener       *transport.Listener
@@ -44,9 +49,12 @@ type Manager struct {
 	queryRegistry  *QueryRegistry
 	eventBus       *serverEvents.Bus
 	logCollector   LogCollector
-	ctx            context.Context
-	cancel         context.CancelFunc
-	wg             sync.WaitGroup
+
+	// cancel terminates the lifecycle context derived inside Start.
+	// nil before Start; reset to nil by Shutdown.
+	cancel context.CancelFunc
+
+	wg sync.WaitGroup
 }
 
 // NewManager creates a plugin manager with the given configuration.
@@ -110,12 +118,15 @@ func (m *Manager) EventBus() *serverEvents.Bus {
 
 // Start discovers plugins, opens the IPC listener, launches plugin processes,
 // and begins accepting connections. Non-blocking: spawns goroutines and returns.
-func (m *Manager) Start(ctx context.Context) error {
-	m.ctx, m.cancel = context.WithCancel(ctx)
+func (m *Manager) Start(parentCtx context.Context) error {
+	lifecycleCtx, cancel := context.WithCancel(parentCtx)
+	m.cancel = cancel
 
 	// Discover plugins from directory + YAML overrides.
 	entries, err := plugin.Discover(m.cfg)
 	if err != nil {
+		cancel()
+		m.cancel = nil
 		return fmt.Errorf("discover plugins: %w", err)
 	}
 	if len(entries) == 0 {
@@ -126,6 +137,8 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Create IPC listener.
 	m.listener, err = transport.NewListener(m.cfg.SocketPath)
 	if err != nil {
+		cancel()
+		m.cancel = nil
 		return fmt.Errorf("create plugin listener: %w", err)
 	}
 	logger.InfoNoCtx().Str("socket", m.cfg.SocketPath).Int("plugins", len(entries)).Msg("plugin listener started")
@@ -135,18 +148,18 @@ func (m *Manager) Start(ctx context.Context) error {
 		inst := &PluginInstance{
 			Name:        entry.Name,
 			BinPath:     entry.BinPath,
-			Critical:    entry.Critical,
 			Priority:    entry.Priority,
-			State:       StateLoaded,
 			MaxRestarts: m.cfg.MaxRestarts,
 		}
+		inst.setCriticalAtLoad(entry.Critical)
+		inst.SetState(StateLoaded)
 		m.registry.Add(inst)
-		m.launchPlugin(inst)
+		m.launchPlugin(lifecycleCtx, inst)
 	}
 
 	// Accept incoming plugin connections.
 	m.wg.Add(1)
-	go m.acceptLoop()
+	go m.acceptLoop(lifecycleCtx)
 
 	return nil
 }
@@ -166,11 +179,12 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 
 	// Send Shutdown to each running plugin.
 	for _, inst := range m.registry.All() {
-		if inst.State != StateRunning && inst.State != StateRegistered {
+		st := inst.State()
+		if st != StateRunning && st != StateRegistered {
 			continue
 		}
-		if inst.Conn != nil {
-			if err := inst.Conn.Send(gcpcv1.NewShutdown(deadline)); err != nil {
+		if c := inst.Conn(); c != nil {
+			if err := c.Send(gcpcv1.NewShutdown(deadline)); err != nil {
 				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("failed to send shutdown")
 			}
 		}
@@ -183,8 +197,8 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 	done := make(chan struct{})
 	go func() {
 		for _, inst := range m.registry.All() {
-			if inst.Cmd != nil && inst.Cmd.Process != nil {
-				_ = inst.Cmd.Wait()
+			if c := inst.Cmd(); c != nil && c.Process != nil {
+				_ = c.Wait()
 			}
 		}
 		close(done)
@@ -196,33 +210,37 @@ func (m *Manager) Shutdown(timeout time.Duration) {
 	case <-timer.C:
 		// Force-kill remaining plugins.
 		for _, inst := range m.registry.All() {
-			if inst.State == StateShutdown {
+			if inst.State() == StateShutdown {
 				continue
 			}
-			if inst.Cmd != nil && inst.Cmd.Process != nil {
+			if c := inst.Cmd(); c != nil && c.Process != nil {
 				logger.WarnNoCtx().Str("plugin", inst.Name).Msg("force killing plugin")
-				_ = syscall.Kill(-inst.Cmd.Process.Pid, syscall.SIGKILL)
+				_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 			}
 		}
 	}
 
-	m.cancel()
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
 	m.wg.Wait()
 
 	// Clean up all connections.
 	for _, inst := range m.registry.All() {
-		if inst.Conn != nil {
-			_ = inst.Conn.Close()
+		if c := inst.Conn(); c != nil {
+			_ = c.Close()
 		}
-		m.registry.SetState(inst.Name, StateShutdown)
+		inst.SetState(StateShutdown)
 	}
 }
 
-// launchPlugin fork/execs the plugin binary.
-func (m *Manager) launchPlugin(inst *PluginInstance) {
-	m.registry.SetState(inst.Name, StateStarting)
+// launchPlugin fork/execs the plugin binary. ctx is the manager's lifecycle
+// context and binds the subprocess lifetime via exec.CommandContext.
+func (m *Manager) launchPlugin(ctx context.Context, inst *PluginInstance) {
+	inst.SetState(StateStarting)
 
-	cmd := exec.CommandContext(m.ctx, inst.BinPath)
+	cmd := exec.CommandContext(ctx, inst.BinPath)
 	cmd.Env = append(os.Environ(), "GOCACHE_PLUGIN_SOCK="+m.cfg.SocketPath)
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -249,7 +267,7 @@ func (m *Manager) launchPlugin(inst *PluginInstance) {
 			_ = logPipeW.Close()
 			_ = logPipeR.Close()
 		}
-		if inst.Critical {
+		if inst.Critical() {
 			logger.FatalNoCtx().Str("plugin", inst.Name).Msg("critical plugin failed to start")
 		}
 		return
@@ -261,7 +279,7 @@ func (m *Manager) launchPlugin(inst *PluginInstance) {
 		_ = logPipeW.Close()
 	}
 
-	inst.Cmd = cmd
+	inst.SetCmd(cmd)
 	logger.InfoNoCtx().Str("plugin", inst.Name).Int("pid", cmd.Process.Pid).Msg("plugin process started")
 
 	// Monitor process exit in background.
@@ -269,22 +287,22 @@ func (m *Manager) launchPlugin(inst *PluginInstance) {
 	go func() {
 		defer m.wg.Done()
 		err := cmd.Wait()
-		if m.ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return // shutting down, ignore
 		}
 		logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("plugin process exited unexpectedly")
-		m.handlePluginExit(inst)
+		m.handlePluginExit(ctx, inst)
 	}()
 }
 
 // acceptLoop accepts incoming plugin connections and handles registration.
-func (m *Manager) acceptLoop() {
+func (m *Manager) acceptLoop(ctx context.Context) {
 	defer m.wg.Done()
 
 	for {
 		conn, err := m.listener.Accept()
 		if err != nil {
-			if m.ctx.Err() != nil {
+			if ctx.Err() != nil {
 				return // shutting down
 			}
 			logger.ErrorNoCtx().Err(err).Msg("plugin accept error")
@@ -294,13 +312,13 @@ func (m *Manager) acceptLoop() {
 		m.wg.Add(1)
 		go func() {
 			defer m.wg.Done()
-			m.handleConnection(conn)
+			m.handleConnection(ctx, conn)
 		}()
 	}
 }
 
 // handleConnection processes the registration handshake for a new plugin connection.
-func (m *Manager) handleConnection(conn *transport.Conn) {
+func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	// Expect Register as first message.
 	env, err := conn.Recv()
 	if err != nil {
@@ -326,16 +344,6 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 		return
 	}
 
-	// Accept registration.
-	inst.Conn = conn
-	inst.Version = reg.Version
-	inst.Commands = reg.Commands
-	// Plugin self-describes critical, but YAML override takes precedence (already set in Discover).
-	// Only apply plugin's self-description if not overridden.
-	if _, hasOverride := m.cfg.Overrides[reg.Name]; !hasOverride {
-		inst.Critical = reg.Critical
-	}
-
 	// --- Scope validation ---
 	grantedScopes, err := m.validateScopes(reg.Name, reg.RequestedScopes)
 	if err != nil {
@@ -345,7 +353,11 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 		return
 	}
 	m.scopeRegistry.Register(reg.Name, grantedScopes)
-	inst.GrantedScopes = permissions.ScopeStrings(grantedScopes)
+
+	// Plugin self-describes critical, but YAML override takes precedence (already
+	// seeded during Discover). Honor the plugin's value only if no YAML override.
+	_, hasOverride := m.cfg.Overrides[reg.Name]
+	inst.Register(conn, reg.Version, reg.Commands, permissions.ScopeStrings(grantedScopes), reg.Critical, !hasOverride)
 
 	// Register plugin commands with the router.
 	if len(reg.Commands) > 0 {
@@ -367,7 +379,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 				// Hook-only plugin — create a PluginConn for it.
 				pc = router.NewPluginConn(reg.Name, conn)
 			}
-			m.hookRegistry.Register(reg.Name, int(reg.Priority), inst.Critical, pc, filteredHooks)
+			m.hookRegistry.Register(reg.Name, int(reg.Priority), inst.Critical(), pc, filteredHooks)
 		}
 		if dropped := len(reg.Hooks) - len(filteredHooks); dropped > 0 {
 			logger.WarnNoCtx().Str("plugin", reg.Name).Int("dropped", dropped).Msg("hooks dropped due to missing scope")
@@ -395,7 +407,7 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 			Msg("operation hooks dropped due to missing 'operation:hook' scope")
 	}
 
-	m.registry.SetState(reg.Name, StateRegistered)
+	inst.SetState(StateRegistered)
 
 	grantedStrings := permissions.ScopeStrings(grantedScopes)
 	if err := conn.Send(gcpcv1.NewRegisterAck(true, "", grantedStrings)); err != nil {
@@ -406,22 +418,23 @@ func (m *Manager) handleConnection(conn *transport.Conn) {
 		return
 	}
 
-	m.registry.SetState(reg.Name, StateRunning)
-	logger.InfoNoCtx().Str("plugin", reg.Name).Str("version", reg.Version).Bool("critical", inst.Critical).Int("commands", len(reg.Commands)).Strs("scopes", grantedStrings).Msg("plugin registered")
+	inst.SetState(StateRunning)
+	critical := inst.Critical()
+	logger.InfoNoCtx().Str("plugin", reg.Name).Str("version", reg.Version).Bool("critical", critical).Int("commands", len(reg.Commands)).Strs("scopes", grantedStrings).Msg("plugin registered")
 
 	if m.eventBus != nil {
-		m.eventBus.Emit(events.NewPluginRegistered(reg.Name, reg.Version, inst.Critical))
+		m.eventBus.Emit(events.NewPluginRegistered(reg.Name, reg.Version, critical))
 	}
 
 	// Start health-check loop.
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
-		m.healthLoop(inst)
+		m.healthLoop(ctx, inst)
 	}()
 
 	// Read loop for this plugin (handles ShutdownAck and future messages).
-	m.readLoop(inst)
+	m.readLoop(ctx, inst)
 }
 
 // validateScopes resolves the granted scopes for a plugin.
@@ -489,21 +502,25 @@ func (m *Manager) filterHooksByScope(pluginName string, hooks []*gcpcv1.HookDecl
 }
 
 // healthLoop periodically sends health checks to a plugin.
-func (m *Manager) healthLoop(inst *PluginInstance) {
+func (m *Manager) healthLoop(ctx context.Context, inst *PluginInstance) {
 	ticker := time.NewTicker(m.cfg.HealthInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-m.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if inst.State != StateRunning {
+			if inst.State() != StateRunning {
 				return
 			}
-			if err := inst.Conn.Send(gcpcv1.NewHealthCheck()); err != nil {
+			c := inst.Conn()
+			if c == nil {
+				return
+			}
+			if err := c.Send(gcpcv1.NewHealthCheck()); err != nil {
 				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("health check send failed")
-				m.registry.SetState(inst.Name, StateUnhealthy)
+				inst.SetState(StateUnhealthy)
 				return
 			}
 		}
@@ -511,14 +528,18 @@ func (m *Manager) healthLoop(inst *PluginInstance) {
 }
 
 // readLoop reads messages from a connected plugin.
-func (m *Manager) readLoop(inst *PluginInstance) {
+func (m *Manager) readLoop(ctx context.Context, inst *PluginInstance) {
+	conn := inst.Conn()
+	if conn == nil {
+		return
+	}
 	for {
-		env, err := inst.Conn.Recv()
+		env, err := conn.Recv()
 		if err != nil {
-			if m.ctx.Err() != nil {
+			if ctx.Err() != nil {
 				return // shutting down
 			}
-			if inst.State == StateRunning {
+			if inst.State() == StateRunning {
 				logger.WarnNoCtx().Str("plugin", inst.Name).Err(err).Msg("plugin connection lost")
 				m.router.UnregisterPlugin(inst.Name)
 				m.hookRegistry.Unregister(inst.Name)
@@ -527,9 +548,9 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 				if m.eventBus != nil {
 					m.eventBus.Unsubscribe("plugin:" + inst.Name)
 				}
-				m.registry.SetState(inst.Name, StateUnhealthy)
+				inst.SetState(StateUnhealthy)
 				if m.eventBus != nil {
-					m.eventBus.Emit(events.NewPluginCrashed(inst.Name, inst.Critical, err.Error()))
+					m.eventBus.Emit(events.NewPluginCrashed(inst.Name, inst.Critical(), err.Error()))
 				}
 			}
 			return
@@ -539,15 +560,15 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 		case *gcpcv1.EnvelopeV1_HealthResponse:
 			resp := env.GetHealthResponse()
 			if resp.Ok {
-				inst.LastHealth = time.Now()
+				inst.SetLastHealth(time.Now())
 			} else {
 				logger.WarnNoCtx().Str("plugin", inst.Name).Str("status", resp.Status).Msg("plugin reported unhealthy")
-				m.registry.SetState(inst.Name, StateUnhealthy)
+				inst.SetState(StateUnhealthy)
 				return
 			}
 		case *gcpcv1.EnvelopeV1_ShutdownAck:
 			logger.InfoNoCtx().Str("plugin", inst.Name).Msg("plugin acknowledged shutdown")
-			m.registry.SetState(inst.Name, StateShutdown)
+			inst.SetState(StateShutdown)
 			return
 		case *gcpcv1.EnvelopeV1_EventSubscribe:
 			sub := env.GetEventSubscribe()
@@ -565,7 +586,7 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 			}
 			// Bridge: subscribe on the server bus with a handler that forwards via GCPC.
 			// Context in events is filtered per plugin visibility before forwarding.
-			pluginConn := inst.Conn
+			pluginConn := conn
 			pluginName := inst.Name
 			m.eventBus.Subscribe("plugin:"+inst.Name, types, func(evt events.Event) {
 				cloned := proto.Clone(evt.Proto).(*gcpcv1.EventV1)
@@ -580,7 +601,7 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 			query := env.GetServerQuery()
 			requiredScope := permissions.ScopeForTopic(query.Topic)
 			if !m.scopeRegistry.HasScope(inst.Name, requiredScope) {
-				_ = inst.Conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, nil,
+				_ = conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, nil,
 					fmt.Sprintf("permission denied: missing scope %q", requiredScope)))
 				continue
 			}
@@ -589,7 +610,7 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 			if qErr != nil {
 				errMsg = qErr.Error()
 			}
-			_ = inst.Conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, data, errMsg))
+			_ = conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, data, errMsg))
 		default:
 			logger.DebugNoCtx().Str("plugin", inst.Name).Msg("unexpected message from plugin")
 		}
@@ -597,40 +618,39 @@ func (m *Manager) readLoop(inst *PluginInstance) {
 }
 
 // handlePluginExit handles unexpected plugin process termination.
-func (m *Manager) handlePluginExit(inst *PluginInstance) {
+func (m *Manager) handlePluginExit(ctx context.Context, inst *PluginInstance) {
 	// Unregister commands, hooks, scopes, and event subscriptions.
 	m.router.UnregisterPlugin(inst.Name)
 	m.hookRegistry.Unregister(inst.Name)
 	m.opHookRegistry.Unregister(inst.Name)
 	m.scopeRegistry.Unregister(inst.Name)
+	critical := inst.Critical()
 	if m.eventBus != nil {
 		m.eventBus.Unsubscribe("plugin:" + inst.Name)
-	}
-	if m.eventBus != nil {
-		m.eventBus.Emit(events.NewPluginCrashed(inst.Name, inst.Critical, "process exited unexpectedly"))
+		m.eventBus.Emit(events.NewPluginCrashed(inst.Name, critical, "process exited unexpectedly"))
 	}
 
-	if inst.Critical {
+	if critical {
 		logger.FatalNoCtx().Str("plugin", inst.Name).Msg("critical plugin crashed — shutting down server")
 		return
 	}
 
-	if inst.Restarts >= inst.MaxRestarts {
-		logger.ErrorNoCtx().Str("plugin", inst.Name).Int("restarts", inst.Restarts).Msg("max restarts exceeded, giving up")
-		m.registry.SetState(inst.Name, StateShutdown)
+	if restarts := inst.Restarts(); restarts >= inst.MaxRestarts {
+		logger.ErrorNoCtx().Str("plugin", inst.Name).Int("restarts", restarts).Msg("max restarts exceeded, giving up")
+		inst.SetState(StateShutdown)
 		return
 	}
 
-	inst.Restarts++
-	logger.InfoNoCtx().Str("plugin", inst.Name).Int("attempt", inst.Restarts).Msg("restarting non-critical plugin")
-	m.registry.SetState(inst.Name, StateRestarting)
+	attempt := inst.IncrementRestarts()
+	logger.InfoNoCtx().Str("plugin", inst.Name).Int("attempt", attempt).Msg("restarting non-critical plugin")
+	inst.SetState(StateRestarting)
 
-	if inst.Conn != nil {
-		_ = inst.Conn.Close()
-		inst.Conn = nil
+	if c := inst.Conn(); c != nil {
+		_ = c.Close()
+		inst.SetConn(nil)
 	}
 
-	m.launchPlugin(inst)
+	m.launchPlugin(ctx, inst)
 }
 
 // filterEventContext filters context maps in event data per plugin visibility.

--- a/pkg/plugin/manager/query.go
+++ b/pkg/plugin/manager/query.go
@@ -102,8 +102,8 @@ func pluginsHandler(registry *Registry) QueryHandlerFunc {
 		plugins := registry.All()
 		data := make(map[string]string, len(plugins)*2)
 		for _, p := range plugins {
-			data[p.Name+".state"] = p.State.String()
-			data[p.Name+".critical"] = strconv.FormatBool(p.Critical)
+			data[p.Name+".state"] = p.State().String()
+			data[p.Name+".critical"] = strconv.FormatBool(p.Critical())
 		}
 		return data, nil
 	}

--- a/pkg/plugin/manager/query_test.go
+++ b/pkg/plugin/manager/query_test.go
@@ -109,8 +109,14 @@ func TestStatsHandler(t *testing.T) {
 
 func TestPluginsHandler(t *testing.T) {
 	reg := NewRegistry()
-	reg.Add(&PluginInstance{Name: "auth", State: StateRunning, Critical: true})
-	reg.Add(&PluginInstance{Name: "metrics", State: StateRunning, Critical: false})
+	authInst := &PluginInstance{Name: "auth"}
+	authInst.SetState(StateRunning)
+	authInst.SetCritical(true)
+	metricsInst := &PluginInstance{Name: "metrics"}
+	metricsInst.SetState(StateRunning)
+	metricsInst.SetCritical(false)
+	reg.Add(authInst)
+	reg.Add(metricsInst)
 
 	handler := pluginsHandler(reg)
 	data, err := handler()

--- a/pkg/plugin/manager/registry.go
+++ b/pkg/plugin/manager/registry.go
@@ -48,20 +48,157 @@ func (s PluginState) String() string {
 }
 
 // PluginInstance holds runtime state for a single plugin.
+//
+// Lifecycle mutation happens from multiple goroutines (launchPlugin,
+// handleConnection, healthLoop, readLoop, handlePluginExit, Shutdown) so
+// all mutable fields are guarded by mu. The immutable configuration fields
+// (Name, BinPath, Priority, MaxRestarts) are set at construction and never
+// modified, so they are exported and safe to read without locking.
 type PluginInstance struct {
-	Name          string
-	Version       string
-	Critical      bool
-	Priority      int
-	BinPath       string
-	State         PluginState
-	Conn          *transport.Conn
-	Cmd           *exec.Cmd
-	LastHealth    time.Time
-	Restarts      int
-	MaxRestarts   int
-	Commands      []*gcpc.CommandDeclV1 // commands declared during registration
-	GrantedScopes []string              // scopes granted during registration
+	// Immutable after construction — safe to read without locking.
+	Name        string
+	BinPath     string
+	Priority    int
+	MaxRestarts int
+
+	// mu guards all fields below.
+	mu            sync.RWMutex
+	version       string
+	critical      bool
+	state         PluginState
+	conn          *transport.Conn
+	cmd           *exec.Cmd
+	lastHealth    time.Time
+	restarts      int
+	commands      []*gcpc.CommandDeclV1
+	grantedScopes []string
+}
+
+// State returns the plugin's current lifecycle state.
+func (p *PluginInstance) State() PluginState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.state
+}
+
+// SetState assigns the plugin's current lifecycle state.
+func (p *PluginInstance) SetState(s PluginState) {
+	p.mu.Lock()
+	p.state = s
+	p.mu.Unlock()
+}
+
+// Conn returns the transport connection, or nil if not yet registered or already closed.
+func (p *PluginInstance) Conn() *transport.Conn {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.conn
+}
+
+// SetConn assigns the transport connection.
+func (p *PluginInstance) SetConn(c *transport.Conn) {
+	p.mu.Lock()
+	p.conn = c
+	p.mu.Unlock()
+}
+
+// Cmd returns the underlying process handle, or nil if not yet started.
+func (p *PluginInstance) Cmd() *exec.Cmd {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cmd
+}
+
+// SetCmd assigns the underlying process handle.
+func (p *PluginInstance) SetCmd(c *exec.Cmd) {
+	p.mu.Lock()
+	p.cmd = c
+	p.mu.Unlock()
+}
+
+// Version returns the version string the plugin reported at registration.
+func (p *PluginInstance) Version() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.version
+}
+
+// Critical reports whether a failure of this plugin should crash the server.
+func (p *PluginInstance) Critical() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.critical
+}
+
+// SetCritical overrides the critical flag. Normally set at construction from
+// YAML or self-declared during registration — this setter exists for that single
+// registration-time override path.
+func (p *PluginInstance) SetCritical(c bool) {
+	p.mu.Lock()
+	p.critical = c
+	p.mu.Unlock()
+}
+
+// SetLastHealth records the time of the most recent successful health check.
+func (p *PluginInstance) SetLastHealth(t time.Time) {
+	p.mu.Lock()
+	p.lastHealth = t
+	p.mu.Unlock()
+}
+
+// Restarts returns the number of restart attempts so far.
+func (p *PluginInstance) Restarts() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.restarts
+}
+
+// IncrementRestarts bumps the restart counter and returns the new value.
+func (p *PluginInstance) IncrementRestarts() int {
+	p.mu.Lock()
+	p.restarts++
+	n := p.restarts
+	p.mu.Unlock()
+	return n
+}
+
+// GrantedScopes returns a snapshot of the scopes granted at registration.
+func (p *PluginInstance) GrantedScopes() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]string, len(p.grantedScopes))
+	copy(out, p.grantedScopes)
+	return out
+}
+
+// Register atomically applies the registration payload to the instance.
+// Called once on handshake completion; serialises the version/commands/scopes
+// assignment so concurrent readers never observe a half-initialised instance.
+// criticalOverride is applied only if honor is true (i.e. no YAML override).
+func (p *PluginInstance) Register(
+	conn *transport.Conn,
+	version string,
+	commands []*gcpc.CommandDeclV1,
+	grantedScopes []string,
+	criticalOverride bool,
+	honorCritical bool,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.conn = conn
+	p.version = version
+	p.commands = commands
+	p.grantedScopes = grantedScopes
+	if honorCritical {
+		p.critical = criticalOverride
+	}
+}
+
+// setCriticalAtLoad is used by the manager during discovery to seed critical
+// from YAML/discovery before Register runs. Package-private because it has no
+// valid external use; external "override" paths should use SetCritical.
+func (p *PluginInstance) setCriticalAtLoad(c bool) {
+	p.critical = c
 }
 
 // Registry is a thread-safe catalog of plugin instances.
@@ -105,11 +242,15 @@ func (r *Registry) All() []*PluginInstance {
 	return result
 }
 
+// SetState updates the state of a named plugin via the instance's own mutex.
+// Kept for API compatibility; prefer PluginInstance.SetState when you already
+// hold a reference to the instance.
 func (r *Registry) SetState(name string, state PluginState) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if p, ok := r.plugins[name]; ok {
-		p.State = state
+	r.mu.RLock()
+	p, ok := r.plugins[name]
+	r.mu.RUnlock()
+	if ok {
+		p.SetState(state)
 	}
 }
 

--- a/pkg/plugin/manager/registry_test.go
+++ b/pkg/plugin/manager/registry_test.go
@@ -7,7 +7,8 @@ import (
 func TestRegistry_AddGetRemove(t *testing.T) {
 	r := NewRegistry()
 
-	p := &PluginInstance{Name: "auth", BinPath: "/bin/auth", State: StateLoaded}
+	p := &PluginInstance{Name: "auth", BinPath: "/bin/auth"}
+	p.SetState(StateLoaded)
 	r.Add(p)
 
 	got, ok := r.Get("auth")
@@ -39,13 +40,15 @@ func TestRegistry_All(t *testing.T) {
 
 func TestRegistry_SetState(t *testing.T) {
 	r := NewRegistry()
-	r.Add(&PluginInstance{Name: "x", State: StateLoaded})
+	inst := &PluginInstance{Name: "x"}
+	inst.SetState(StateLoaded)
+	r.Add(inst)
 
 	r.SetState("x", StateRunning)
 
 	p, _ := r.Get("x")
-	if p.State != StateRunning {
-		t.Errorf("expected Running, got %s", p.State)
+	if got := p.State(); got != StateRunning {
+		t.Errorf("expected Running, got %s", got)
 	}
 }
 

--- a/pkg/plugin/ophooks/executor.go
+++ b/pkg/plugin/ophooks/executor.go
@@ -2,7 +2,6 @@ package ophooks
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	opctx "gocache/api/context"
@@ -94,5 +93,3 @@ func (e *Executor) RunCompleteHooks(op *ops.Operation) {
 func (e *Executor) RegistryForTesting() *Registry {
 	return e.registry
 }
-
-var _ fmt.Stringer // suppress unused import warning if fmt is used only in errors

--- a/pkg/plugin/router/router.go
+++ b/pkg/plugin/router/router.go
@@ -21,11 +21,13 @@ var (
 	ErrDuplicateCmd    = errors.New("command already registered by another plugin")
 )
 
-// RequestSeq is exported so the hooks package can generate unique IDs too.
-var RequestSeq atomic.Uint64
+// requestSeq is a package-private monotonic counter; callers outside the
+// package use NextRequestID to mint IDs.
+var requestSeq atomic.Uint64
 
+// NextRequestID returns a new unique request identifier for plugin calls.
 func NextRequestID() string {
-	return fmt.Sprintf("req-%d", RequestSeq.Add(1))
+	return fmt.Sprintf("req-%d", requestSeq.Add(1))
 }
 
 // PluginRoute describes a single command route to a plugin.

--- a/pkg/resp/handler/basic.go
+++ b/pkg/resp/handler/basic.go
@@ -47,7 +47,7 @@ func HandleSelect(cmdCtx *command.Context) command.Result {
 // HandleFlushDB clears the entire cache (single-DB server, same as FLUSHALL).
 func HandleFlushDB(cmdCtx *command.Context) command.Result {
 	return command.Dispatch(cmdCtx, func() interface{} {
-		cmdCtx.Cache.Clear()
+		cmdCtx.Cache.Clear(cmdCtx.Context())
 		return "OK"
 	})
 }
@@ -55,7 +55,7 @@ func HandleFlushDB(cmdCtx *command.Context) command.Result {
 // HandleFlushAll clears the entire cache.
 func HandleFlushAll(cmdCtx *command.Context) command.Result {
 	return command.Dispatch(cmdCtx, func() interface{} {
-		cmdCtx.Cache.Clear()
+		cmdCtx.Cache.Clear(cmdCtx.Context())
 		return "OK"
 	})
 }
@@ -140,7 +140,7 @@ func HandleIncrByFloat(cmdCtx *command.Context) command.Result {
 		newVal := existing + incr
 		newStr := strconv.FormatFloat(newVal, 'f', -1, 64)
 		rawTTL := cmdCtx.Cache.RawTTL(key)
-		if setErr := cmdCtx.Cache.RawSet(key, newStr, rawTTL); setErr != nil {
+		if setErr := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, newStr, rawTTL); setErr != nil {
 			return setErr
 		}
 		return newStr
@@ -170,7 +170,7 @@ func HandleAppend(cmdCtx *command.Context) command.Result {
 		}
 
 		newStr := existing + suffix
-		if setErr := cmdCtx.Cache.RawSet(key, newStr, rawTTL); setErr != nil {
+		if setErr := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, newStr, rawTTL); setErr != nil {
 			return setErr
 		}
 		return int64(len(newStr))
@@ -234,7 +234,7 @@ func HandleMset(cmdCtx *command.Context) command.Result {
 	}
 	return command.Dispatch(cmdCtx, func() interface{} {
 		for i := 0; i < len(cmdCtx.Args); i += 2 {
-			if setErr := cmdCtx.Cache.RawSet(cmdCtx.Args[i], cmdCtx.Args[i+1], 0); setErr != nil {
+			if setErr := cmdCtx.Cache.RawSet(cmdCtx.Context(), cmdCtx.Args[i], cmdCtx.Args[i+1], 0); setErr != nil {
 				return setErr
 			}
 		}
@@ -266,7 +266,7 @@ func incrByDelta(cmdCtx *command.Context, key string, delta int64) interface{} {
 	}
 
 	newVal := current + delta
-	if setErr := cmdCtx.Cache.RawSet(key, strconv.FormatInt(newVal, 10), rawTTL); setErr != nil {
+	if setErr := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, strconv.FormatInt(newVal, 10), rawTTL); setErr != nil {
 		return setErr
 	}
 	return newVal
@@ -335,7 +335,7 @@ func HandleSet(cmdCtx *command.Context) command.Result {
 			exp = cmdCtx.Cache.RawTTL(key)
 		}
 
-		if err := cmdCtx.Cache.RawSet(key, val, exp); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, val, exp); err != nil {
 			return err
 		}
 		return "OK"
@@ -356,7 +356,7 @@ func HandleSetnx(cmdCtx *command.Context) command.Result {
 			}
 			cmdCtx.Cache.RawDelete(key)
 		}
-		if err := cmdCtx.Cache.RawSet(key, val, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, val, 0); err != nil {
 			return err
 		}
 		return 1
@@ -382,7 +382,7 @@ func HandlePexpire(cmdCtx *command.Context) command.Result {
 			return 0
 		}
 		expiration := time.Now().Add(time.Duration(ms) * time.Millisecond).UnixNano()
-		if err := cmdCtx.Cache.RawSet(key, entry.Value, expiration); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, entry.Value, expiration); err != nil {
 			return err
 		}
 		return 1
@@ -488,7 +488,7 @@ func HandleExpire(cmdCtx *command.Context) command.Result {
 		if ttl > 0 {
 			expiration = time.Now().Add(ttl).UnixNano()
 		}
-		if err := cmdCtx.Cache.RawSet(key, entry.Value, expiration); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, entry.Value, expiration); err != nil {
 			return err
 		}
 		return 1

--- a/pkg/resp/handler/hash.go
+++ b/pkg/resp/handler/hash.go
@@ -36,7 +36,7 @@ func HandleHset(cmdCtx *command.Context) command.Result {
 			hash[field] = value
 		}
 
-		if err := cmdCtx.Cache.RawSet(key, hash, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, hash, 0); err != nil {
 			return err
 		}
 		return added
@@ -98,7 +98,7 @@ func HandleHdel(cmdCtx *command.Context) command.Result {
 		if len(hash) == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, hash, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, hash, 0); err != nil {
 				return err
 			}
 		}

--- a/pkg/resp/handler/keys.go
+++ b/pkg/resp/handler/keys.go
@@ -70,7 +70,7 @@ func HandleRename(cmdCtx *command.Context) command.Result {
 
 		cmdCtx.Cache.RawDelete(dst)
 		cmdCtx.Cache.RawDelete(src)
-		if err := cmdCtx.Cache.RawSet(dst, entry.Value, expiration); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), dst, entry.Value, expiration); err != nil {
 			return err
 		}
 		return "OK"
@@ -111,7 +111,7 @@ func HandleRenameNX(cmdCtx *command.Context) command.Result {
 		}
 
 		cmdCtx.Cache.RawDelete(src)
-		if err := cmdCtx.Cache.RawSet(dst, entry.Value, expiration); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), dst, entry.Value, expiration); err != nil {
 			return err
 		}
 		return 1

--- a/pkg/resp/handler/lists.go
+++ b/pkg/resp/handler/lists.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"gocache/api/logger"
 	"gocache/pkg/blocking"
 	"gocache/pkg/cache"
 	"gocache/pkg/command"
@@ -31,7 +32,7 @@ func HandleLpush(cmdCtx *command.Context) command.Result {
 			reversed[len(values)-1-i] = v
 		}
 		list = append(reversed, list...)
-		if err := cmdCtx.Cache.RawSet(key, list, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, 0); err != nil {
 			return err
 		}
 		return len(list)
@@ -59,7 +60,7 @@ func HandleRpush(cmdCtx *command.Context) command.Result {
 		}
 
 		list = append(list, values...)
-		if err := cmdCtx.Cache.RawSet(key, list, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, 0); err != nil {
 			return err
 		}
 		return len(list)
@@ -90,7 +91,7 @@ func HandleLpop(cmdCtx *command.Context) command.Result {
 		if len(list) == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, list, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, 0); err != nil {
 				return err
 			}
 		}
@@ -118,7 +119,7 @@ func HandleRpop(cmdCtx *command.Context) command.Result {
 		if len(list) == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, list, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, 0); err != nil {
 				return err
 			}
 		}
@@ -233,7 +234,11 @@ func handleBlockingPop(cmdCtx *command.Context, fromLeft bool) command.Result {
 			if len(list) == 0 {
 				cmdCtx.Cache.RawDelete(key)
 			} else {
-				_ = cmdCtx.Cache.RawSet(key, list, cmdCtx.Cache.RawTTL(key))
+				// Shrinking write — RawSet cannot return ErrOutOfMemory because
+				// delta ≤ 0, but surface any unexpected error instead of dropping it.
+				if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, cmdCtx.Cache.RawTTL(key)); err != nil {
+					logger.Error(cmdCtx.Context()).Err(err).Str("key", key).Msg("unexpected error on pop write-back")
+				}
 			}
 			return []interface{}{key, val}
 		}
@@ -291,7 +296,7 @@ func tryWakeBlockedClients(cmdCtx *command.Context, key string) {
 		if !found {
 			return
 		}
-		popResult := cmdCtx.Engine.DispatchWithResult(func() interface{} {
+		popResult, dispatchErr := cmdCtx.Engine.DispatchWithResult(cmdCtx.Context(), func() interface{} {
 			entry, ok := cmdCtx.Cache.RawGet(key)
 			if !ok {
 				return nil
@@ -308,10 +313,18 @@ func tryWakeBlockedClients(cmdCtx *command.Context, key string) {
 			if len(list) == 0 {
 				cmdCtx.Cache.RawDelete(key)
 			} else {
-				_ = cmdCtx.Cache.RawSet(key, list, cmdCtx.Cache.RawTTL(key))
+				// Shrinking write — RawSet cannot return ErrOutOfMemory because
+				// delta ≤ 0, but surface any unexpected error instead of dropping it.
+				if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, list, cmdCtx.Cache.RawTTL(key)); err != nil {
+					logger.Error(cmdCtx.Context()).Err(err).Str("key", key).Msg("unexpected error on blocked-pop write-back")
+				}
 			}
 			return val
 		})
+		if dispatchErr != nil {
+			logger.Error(cmdCtx.Context()).Err(dispatchErr).Str("key", key).Msg("blocked-pop dispatch failed")
+			return
+		}
 		if popResult == nil {
 			return
 		}

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -13,14 +13,14 @@ import (
 
 func HandleSnapshot(cmdCtx *command.Context) command.Result {
 	executeFn := func() interface{} {
-		if err := persistence.SaveSnapshot(cmdCtx.SnapshotFile, cmdCtx.Cache); err != nil {
+		if err := persistence.SaveSnapshot(cmdCtx.Context(), cmdCtx.SnapshotFile, cmdCtx.Cache); err != nil {
 			return err
 		}
 		return "OK"
 	}
 	res := command.Dispatch(cmdCtx, executeFn)
 	if res.Err != nil {
-		logger.ErrorNoCtx().Err(res.Err).Msg("snapshot command failed")
+		logger.Error(cmdCtx.Context()).Err(res.Err).Msg("snapshot command failed")
 	}
 	return res
 }
@@ -38,14 +38,14 @@ func HandleLoadSnapshot(cmdCtx *command.Context) command.Result {
 	}
 
 	executeFn := func() interface{} {
-		if err := persistence.LoadSnapshot(filename, cmdCtx.Cache); err != nil {
+		if err := persistence.LoadSnapshot(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
 			return err
 		}
 		return "OK"
 	}
 	res := command.Dispatch(cmdCtx, executeFn)
 	if res.Err != nil {
-		logger.ErrorNoCtx().Err(res.Err).Str("file", filename).Msg("loadsnapshot command failed")
+		logger.Error(cmdCtx.Context()).Err(res.Err).Str("file", filename).Msg("loadsnapshot command failed")
 	}
 	return res
 }
@@ -69,9 +69,10 @@ func sanitizeSnapshotPath(baseSnapshotFile, requested string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve base dir: %w", err)
 	}
-	// filepath.Base on requested strips any remaining separators, leaving only
-	// a file name. Combined with the absolute-path/".." rejection above this
-	// guarantees the result stays in baseDir.
+	// filepath.Base returns the final path element (not interior segments),
+	// so anything the caller sent like "sub/file" collapses to "file".
+	// Combined with the absolute-path/".." rejection above, the result is
+	// guaranteed to live directly under baseDir.
 	final := filepath.Join(baseDir, filepath.Base(requested))
 
 	// Defense in depth: verify the result is within baseDir after cleaning.

--- a/pkg/resp/handler/set.go
+++ b/pkg/resp/handler/set.go
@@ -138,7 +138,7 @@ func HandleSadd(cmdCtx *command.Context) command.Result {
 			}
 		}
 
-		if err := cmdCtx.Cache.RawSet(key, set, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, set, 0); err != nil {
 			return err
 		}
 		return added
@@ -175,7 +175,7 @@ func HandleSrem(cmdCtx *command.Context) command.Result {
 		if len(set) == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, set, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, set, 0); err != nil {
 				return err
 			}
 		}
@@ -289,7 +289,7 @@ func HandleSpop(cmdCtx *command.Context) command.Result {
 		if len(set) == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, set, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, set, 0); err != nil {
 				return err
 			}
 		}

--- a/pkg/resp/handler/sortedset.go
+++ b/pkg/resp/handler/sortedset.go
@@ -46,7 +46,7 @@ func HandleZadd(cmdCtx *command.Context) command.Result {
 			}
 		}
 
-		if err := cmdCtx.Cache.RawSet(key, zset, 0); err != nil {
+		if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, zset, 0); err != nil {
 			return err
 		}
 		return added
@@ -82,7 +82,7 @@ func HandleZrem(cmdCtx *command.Context) command.Result {
 		if zset.Card() == 0 {
 			cmdCtx.Cache.RawDelete(key)
 		} else {
-			if err := cmdCtx.Cache.RawSet(key, zset, 0); err != nil {
+			if err := cmdCtx.Cache.RawSet(cmdCtx.Context(), key, zset, 0); err != nil {
 				return err
 			}
 		}

--- a/pkg/resp/handler/transactions.go
+++ b/pkg/resp/handler/transactions.go
@@ -50,10 +50,11 @@ func HandleExec(cmdCtx *command.Context) command.Result {
 		return command.Result{Value: []interface{}{}}
 	}
 
-	results := cmdCtx.Engine.DispatchWithResult(func() interface{} {
+	batchCtx := cmdCtx.Context()
+	results, err := cmdCtx.Engine.DispatchWithResult(batchCtx, func() interface{} {
 		batchResults := make([]interface{}, len(queue))
 		for i, cmdParts := range queue {
-			res := cmdCtx.EvalFn(cmdCtx.Client, cmdParts[0], cmdParts[1:], true)
+			res := cmdCtx.EvalFn(batchCtx, cmdCtx.Client, cmdParts[0], cmdParts[1:], true)
 			if res.Err != nil {
 				batchResults[i] = res.Err.Error()
 			} else {
@@ -62,6 +63,9 @@ func HandleExec(cmdCtx *command.Context) command.Result {
 		}
 		return batchResults
 	})
+	if err != nil {
+		return command.Result{Err: err}
+	}
 	return command.Result{Value: results}
 }
 

--- a/pkg/resp/handler/transactions_test.go
+++ b/pkg/resp/handler/transactions_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -15,8 +16,8 @@ func TestHandler_Transactions(t *testing.T) {
 	tm := transaction.NewManager()
 
 	// evalFn re-enters through the handler map, like the evaluator pipeline.
-	var evalFn func(*clientctx.ClientContext, string, []string, bool) command.Result
-	evalFn = func(client *clientctx.ClientContext, op string, args []string, inBatch bool) command.Result {
+	var evalFn func(context.Context, *clientctx.ClientContext, string, []string, bool) command.Result
+	evalFn = func(_ context.Context, client *clientctx.ClientContext, op string, args []string, inBatch bool) command.Result {
 		op = strings.ToUpper(op)
 		h, ok := handlers[op]
 		if !ok {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,7 +31,7 @@ type Server struct {
 	addr             string
 	cache            *cache.Cache
 	engine           *engine.Engine
-	evaluator        evaluator.Evaluator
+	evaluator        *evaluator.BaseEvaluator
 	listener         net.Listener
 	shutdownChan     chan struct{}
 	connectionWg     sync.WaitGroup
@@ -129,8 +129,8 @@ func (srv *Server) Start(ctx context.Context) error {
 
 	logger.InfoNoCtx().Str("addr", srv.addr).Msg("server listening")
 
-	// Accept connections in a goroutine
-	go srv.acceptConnections()
+	// Accept connections in a goroutine; propagate the server lifecycle ctx.
+	go srv.acceptConnections(ctx)
 
 	// Wait for shutdown signal or context cancellation
 	select {
@@ -143,7 +143,7 @@ func (srv *Server) Start(ctx context.Context) error {
 }
 
 // acceptConnections handles the accept loop
-func (srv *Server) acceptConnections() {
+func (srv *Server) acceptConnections(ctx context.Context) {
 	for {
 		conn, err := srv.listener.Accept()
 		if err != nil {
@@ -159,7 +159,7 @@ func (srv *Server) acceptConnections() {
 		}
 
 		srv.connectionWg.Add(1)
-		go srv.handleConnection(conn)
+		go srv.handleConnection(ctx, conn)
 	}
 }
 
@@ -201,18 +201,19 @@ func (srv *Server) Shutdown(timeout time.Duration) error {
 	return err
 }
 
-func (srv *Server) handleConnection(conn net.Conn) {
+func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 	srv.activeConns.Add(1)
 	defer srv.activeConns.Add(-1)
 
 	remoteAddr := conn.RemoteAddr().String()
 	connStart := time.Now()
 
-	// Create connection operation.
+	// Create connection operation and derive a connection-scoped ctx.
 	connOp := srv.tracker.Start(ops.TypeConnection, "")
 	connOp.Enrich("_remote_addr", remoteAddr)
+	connCtx := ops.WithContext(serverCtx, connOp)
 	if srv.opHookExecutor != nil {
-		srv.opHookExecutor.RunStartHooks(context.Background(), connOp)
+		srv.opHookExecutor.RunStartHooks(connCtx, connOp)
 	}
 	srv.emitter.Emit(events.NewConnectionOpen(remoteAddr).WithOperationID(connOp.ID))
 
@@ -338,7 +339,7 @@ func (srv *Server) handleConnection(conn net.Conn) {
 		}
 
 		ctx.CmdMeta = cmdMeta
-		res := srv.evaluator.Evaluate(ctx, op, parts[1:])
+		res := srv.evaluator.Evaluate(connCtx, ctx, op, parts[1:])
 		ctx.CmdMeta = nil
 		cmdMeta = nil
 		if err := writer.Write(srv.mapToResp(ctx, res)); err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -34,7 +34,7 @@ func startTestServer(t *testing.T, requirePass string) (*Server, string) {
 	}
 	srv.listener = listener
 
-	go srv.acceptConnections()
+	go srv.acceptConnections(context.Background())
 	t.Cleanup(func() { srv.Shutdown(2 * time.Second) })
 
 	return srv, listener.Addr().String()

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -18,7 +18,10 @@ import (
 const defaultInterval = 5 * time.Minute
 
 type Worker interface {
-	Start()
+	// Start begins the worker's ticker loop. parentCtx is the scheduler/server
+	// lifecycle context; operations created each tick derive from it so
+	// cancellation propagates.
+	Start(parentCtx context.Context)
 	Stop()
 	UpdateInterval(d time.Duration)
 }
@@ -45,20 +48,23 @@ func (w *baseWorker) SetEmitter(e events.Emitter) { w.emitter = e }
 // SetOpHookExecutor sets the operation hook executor.
 func (w *baseWorker) SetOpHookExecutor(e evaluator.OpHookExecutor) { w.opHookExecutor = e }
 
-// startOp creates an operation if tracker is set, runs start hooks, emits start event.
-func (w *baseWorker) startOp(opType ops.Type) *ops.Operation {
+// startOp creates an operation if tracker is set, runs start hooks, emits start
+// event. Returns (op, ctx) where ctx is derived from parentCtx and carries op
+// for log correlation downstream.
+func (w *baseWorker) startOp(parentCtx context.Context, opType ops.Type) (*ops.Operation, context.Context) {
 	if w.tracker == nil {
-		return nil
+		return nil, parentCtx
 	}
 	op := w.tracker.Start(opType, "")
 	op.Enrich("_trigger", "scheduled")
+	opCtx := ops.WithContext(parentCtx, op)
 	if w.opHookExecutor != nil && w.opHookExecutor.HasAny() {
-		w.opHookExecutor.RunStartHooks(context.Background(), op)
+		w.opHookExecutor.RunStartHooks(opCtx, op)
 	}
 	if w.emitter != nil {
 		w.emitter.Emit(events.NewOperationStart(op.ID, string(op.Type), "", op.ContextSnapshot(false)))
 	}
-	return op
+	return op, opCtx
 }
 
 // completeOp marks an operation as completed, runs complete hooks, emits events.
@@ -136,7 +142,7 @@ func (w *SnapshotWorker) UpdateFile(file string) {
 	w.fileChan <- file
 }
 
-func (w *SnapshotWorker) Start() {
+func (w *SnapshotWorker) Start(parentCtx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	w.wg.Add(1)
 	go func() {
@@ -145,19 +151,22 @@ func (w *SnapshotWorker) Start() {
 			select {
 			case <-ticker.C:
 				file := w.file
-				op := w.startOp(ops.TypeSnapshot)
+				op, opCtx := w.startOp(parentCtx, ops.TypeSnapshot)
 				if op != nil {
 					op.Enrich("_file", file)
 				}
-				w.engine.Dispatch(func() {
-					if err := persistence.SaveSnapshot(file, w.cache); err != nil {
-						logger.WarnNoCtx().Err(err).Msg("snapshot save failed")
+				if err := w.engine.Dispatch(opCtx, func() {
+					if err := persistence.SaveSnapshot(opCtx, file, w.cache); err != nil {
+						logger.Warn(opCtx).Err(err).Msg("snapshot save failed")
 						w.failOp(op, err.Error())
 					} else {
-						logger.DebugNoCtx().Str("file", file).Msg("snapshot saved")
+						logger.Debug(opCtx).Str("file", file).Msg("snapshot saved")
 						w.completeOp(op)
 					}
-				})
+				}); err != nil {
+					logger.Warn(opCtx).Err(err).Msg("snapshot dispatch failed")
+					w.failOp(op, err.Error())
+				}
 			case d := <-w.intervalChan:
 				ticker.Reset(safeInterval(d))
 			case f := <-w.fileChan:
@@ -187,7 +196,7 @@ func NewCleanupWorker(c *cache.Cache, e *engine.Engine, interval time.Duration) 
 	}
 }
 
-func (w *CleanupWorker) Start() {
+func (w *CleanupWorker) Start(parentCtx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	w.wg.Add(1)
 	go func() {
@@ -195,8 +204,8 @@ func (w *CleanupWorker) Start() {
 		for {
 			select {
 			case <-ticker.C:
-				op := w.startOp(ops.TypeCleanup)
-				w.engine.Dispatch(func() {
+				op, opCtx := w.startOp(parentCtx, ops.TypeCleanup)
+				if err := w.engine.Dispatch(opCtx, func() {
 					now := time.Now().UnixNano()
 					w.cache.Range(func(key string, entry *cache.Entry, expiration int64) bool {
 						if expiration > 0 && now > expiration {
@@ -204,9 +213,12 @@ func (w *CleanupWorker) Start() {
 						}
 						return true
 					})
-					logger.DebugNoCtx().Msg("cleanup sweep completed")
+					logger.Debug(opCtx).Msg("cleanup sweep completed")
 					w.completeOp(op)
-				})
+				}); err != nil {
+					logger.Warn(opCtx).Err(err).Msg("cleanup dispatch failed")
+					w.failOp(op, err.Error())
+				}
 			case d := <-w.intervalChan:
 				ticker.Reset(safeInterval(d))
 			case <-w.stopChan:

--- a/pkg/workers/workers_test.go
+++ b/pkg/workers/workers_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"context"
 	"gocache/pkg/cache"
 	"gocache/pkg/engine"
 	"os"
@@ -22,15 +23,15 @@ func TestSnapshotWorker_CreatesFile(t *testing.T) {
 	c, e := setup(t)
 
 	// Add some data.
-	e.Dispatch(func() {
-		_ = c.RawSet("key", "val", 0)
+	e.Dispatch(context.Background(), func() {
+		_ = c.RawSet(context.Background(), "key", "val", 0)
 	})
 
 	dir := t.TempDir()
 	file := filepath.Join(dir, "test_snapshot.dat")
 
 	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file)
-	w.Start()
+	w.Start(context.Background())
 	defer w.Stop()
 
 	// Wait for at least one tick.
@@ -45,29 +46,35 @@ func TestCleanupWorker_RemovesExpired(t *testing.T) {
 	c, e := setup(t)
 
 	// Add an already-expired key.
-	e.Dispatch(func() {
-		_ = c.RawSet("expired", "val", time.Now().Add(-time.Hour).UnixNano())
-		_ = c.RawSet("alive", "val", 0)
+	e.Dispatch(context.Background(), func() {
+		_ = c.RawSet(context.Background(), "expired", "val", time.Now().Add(-time.Hour).UnixNano())
+		_ = c.RawSet(context.Background(), "alive", "val", 0)
 	})
 
 	w := NewCleanupWorker(c, e, 50*time.Millisecond)
-	w.Start()
+	w.Start(context.Background())
 	defer w.Stop()
 
 	time.Sleep(200 * time.Millisecond)
 
-	res := e.DispatchWithResult(func() interface{} {
+	res, err := e.DispatchWithResult(context.Background(), func() interface{} {
 		_, found := c.RawGet("expired")
 		return found
 	})
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
 	if res.(bool) {
 		t.Error("expected expired key to be cleaned up")
 	}
 
-	res = e.DispatchWithResult(func() interface{} {
+	res, err = e.DispatchWithResult(context.Background(), func() interface{} {
 		_, found := c.RawGet("alive")
 		return found
 	})
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
 	if !res.(bool) {
 		t.Error("expected alive key to remain")
 	}
@@ -77,7 +84,7 @@ func TestWorker_Stop(t *testing.T) {
 	_, e := setup(t)
 
 	w := NewCleanupWorker(cache.New(), e, time.Hour)
-	w.Start()
+	w.Start(context.Background())
 	w.Stop()
 	w.Stop() // idempotent
 }
@@ -86,7 +93,7 @@ func TestWorker_UpdateInterval(t *testing.T) {
 	_, e := setup(t)
 
 	w := NewCleanupWorker(cache.New(), e, time.Hour)
-	w.Start()
+	w.Start(context.Background())
 	defer w.Stop()
 
 	// Should not block or panic.
@@ -95,8 +102,8 @@ func TestWorker_UpdateInterval(t *testing.T) {
 
 func TestSnapshotWorker_UpdateFile(t *testing.T) {
 	c, e := setup(t)
-	e.Dispatch(func() {
-		_ = c.RawSet("k", "v", 0)
+	e.Dispatch(context.Background(), func() {
+		_ = c.RawSet(context.Background(), "k", "v", 0)
 	})
 
 	dir := t.TempDir()
@@ -104,7 +111,7 @@ func TestSnapshotWorker_UpdateFile(t *testing.T) {
 	file2 := filepath.Join(dir, "snap2.dat")
 
 	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file1)
-	w.Start()
+	w.Start(context.Background())
 
 	// Switch to file2.
 	w.UpdateFile(file2)


### PR DESCRIPTION
  - api/operations: add WithContext/FromContext helpers (unexported struct ctxKey) so any package can store/retrieve the current *Operation on context.Context.
  - api/logger: Trace/Debug/Info/Warn/Error now take context.Context and pull the operation via ops.FromContext; NoCtx variants retained for pre-operation boundaries (plugin loading, config parse).
  - pkg/cache: RawSet/Clear/evictLRU/SetMemoryLimit take ctx as first param.
  - pkg/persistence: SaveSnapshot/LoadSnapshot take ctx.
  - pkg/command: Context gains unexported ctx field exposed via Context() method, following the http.Request precedent.
  - pkg/evaluator: Evaluate(parentCtx, client, op, args) propagates ctx into opCtx, op hooks, command hooks, and plugin routing timeout.
  - pkg/server: Start → acceptConnections → handleConnection all thread ctx; connCtx feeds evaluator + start hooks.
  - pkg/workers: Worker.Start(ctx) interface change; startOp(parentCtx,...) roots operation ctx in caller's lifecycle ctx.
  - Handlers: every cmdCtx.Cache.* call threads cmdCtx.Context().

  Plugin manager hardening:

  - PluginInstance: mutable fields (state, conn, cmd, version, critical, lastHealth, restarts, commands, grantedScopes) now guarded by per- instance RWMutex via thread-safe accessor methods; immutable config fields (Name, BinPath, Priority, MaxRestarts) remain exported.
  - Manager: removed stored ctx field; lifecycle ctx derived in Start and threaded via closure/parameter into launchPlugin/acceptLoop/ handleConnection/healthLoop/readLoop/handlePluginExit.

  Engine dispatch:

  - Engine.Dispatch(ctx, fn) error and Engine.DispatchWithResult(ctx, fn) (interface{}, error); callers distinguish ErrEngineStopped from ctx cancellation. Fixes silent work-loss on shutdown.

  Idiom + polish:

  - pkg/evaluator: drop Evaluator interface, return concrete *BaseEvaluator ("accept interfaces, return structs").
  - pkg/plugin/router: unexport RequestSeq → requestSeq; callers use NextRequestID.
  - pkg/logcollector: single-map allocation in parseLine; replace json.Number(fmt.Sprintf(...)) with strconv.Format*.
  - pkg/plugin/ophooks: drop stray `var _ fmt.Stringer` + fmt import.
  - pkg/resp/handler/lists: surface previously-ignored RawSet errors on blocking-pop write-back.
  - pkg/resp/handler/persistence: clarify sanitizeSnapshotPath comment.