### PR TITLE
docs: document startup context injection

### DIFF
--- a/docs/gcpc/README.md
+++ b/docs/gcpc/README.md
@@ -65,6 +65,22 @@ The correlation ID enables multiplexed dispatch -- multiple commands can be in-f
 | HookRequest | Server -> Plugin | Pre/post hook invocation with command context and metadata |
 | HookResponse | Plugin -> Server | Allow/deny decision (pre-hooks) or acknowledgement (post-hooks) |
 
+### Operation Hooks (field numbers 80-81)
+
+| Message | Direction | Purpose |
+|---------|-----------|---------|
+| OperationHookRequest | Server -> Plugin | Operation lifecycle notification (phase=start/complete, filtered context, optional `replayed` + `replay_start_unix_ns`) |
+| OperationHookResponse | Plugin -> Server | Context enrichment for live PhaseStart; ignored for PhaseComplete and replayed starts |
+
+The `replayed` and `replay_start_unix_ns` fields (tags 7/8) are used when a plugin registers while operations are already active. The server synthesizes a PhaseStart for each tracker-active op that started before the plugin's registration watermark, filtered by the plugin's declared type patterns. `replay_start_unix_ns` is the op's absolute wall-clock start time in Unix nanoseconds — pass directly into OTEL `trace.WithTimestamp` to anchor the reconstructed span at its real occurrence time. Replayed starts are fire-and-forget; the server does not wait for a response since the live enrichment window has already closed.
+
+### Events (field numbers 70-71)
+
+| Message | Direction | Purpose |
+|---------|-----------|---------|
+| EventSubscribe | Plugin -> Server | Declares which event types the plugin consumes |
+| Event | Server -> Plugin | Fire-and-forget delivery — server also retains every Event in a bounded replay ring so a plugin subscribing mid-run catches up on history before switching to live. See the Event Replay section below. |
+
 ## Registration Handshake
 
 1. Plugin connects to the server's Unix domain socket (path provided via `GOCACHE_PLUGIN_SOCK` environment variable)
@@ -236,6 +252,27 @@ The `REX.META` handler lives in `pkg/rex/handler/handler.go` and is registered b
 
 The hook executor extracts `shared.rex.*` keys from the hook context into the dedicated `metadata` field on `HookRequestV1` (prefix-stripped). The command router receives bare-key metadata from the evaluator and forwards it on `CommandRequestV1`.
 
+## Event Replay
+
+The server retains every emitted event in a bounded FIFO ring (`events.replay_capacity`, default 10 000). When a plugin subscribes via `EventSubscribe`, the server:
+
+1. Snapshots the ring under the same write lock that gates `Emit`, filtering by the subscribed types.
+2. Delivers the retained events synchronously in FIFO order **before** the first live event is dispatched.
+3. Switches the subscription to live-only delivery.
+
+This lets an IPC plugin that connects at t=500 ms still observe events emitted at t=0. When overflow occurs (ring saturated), the oldest entry is dropped and a synthetic `replay.gap` event is delivered ahead of the retained events so subscribers can alert on misses. Setting `events.replay_capacity: 0` disables the ring entirely.
+
+## Operation Hook Replay
+
+When an `OperationHookPlugin` registers while operations are already active, the server synthesizes a PhaseStart for each `tracker.Active()` entry whose `StartTime` precedes the registration watermark and whose type matches the plugin's declared patterns. Replayed envelopes carry `replayed=true` and `replay_start_unix_ns` — the op's absolute wall-clock start in Unix ns.
+
+- **Delivery**: synchronous, in start-time order (parent before child) so span reconstruction sees operations in their natural tree order.
+- **Response**: replayed PhaseStart is fire-and-forget — the server does not wait for enrichment because the live enrichment window has already closed.
+- **Suppression**: `plugins.min_restart_interval_for_replay` (default 30 s) skips replay for a plugin that re-registers inside that window, preventing crash-looping plugins from drowning in synthetic starts.
+- **Wall-clock anchoring**: plugins typically pass `time.Unix(0, replay_start_unix_ns)` directly into OTEL's `trace.WithTimestamp` so reconstructed spans land at their actual occurrence time rather than subscribe time.
+
+Replay is "active ops only" by design — ops that started and completed before subscribe do not manifest via the ophook channel; they surface through the event bus replay ring as `OperationStart` + `OperationComplete` event pairs.
+
 ## Scope Negotiation
 
 Plugins declare requested scopes in the `Register` message. The server validates against the configuration-defined allowlist and returns the granted set in `RegisterAck`.
@@ -268,6 +305,8 @@ The full Protobuf schema is at `proto/gcpc/v1/gcpc.proto`.
 | Sequence | [REX Metadata](design/sequence/sequence_rex_metadata.puml) | HELLO REXV negotiation, META accumulation, hook context injection |
 | Sequence | [Scope Registration](design/sequence/sequence_scope_registration.puml) | Scope negotiation during registration |
 | Sequence | [Scope Enforcement](design/sequence/sequence_scope_enforcement.puml) | Runtime scope checks |
+| Sequence | [OpHook Replay on Subscribe](design/sequence/sequence_ophook_replay_on_subscribe.puml) | Synthetic PhaseStart delivery for late subscribers |
 | State | [Plugin Lifecycle](design/state/state_plugin_lifecycle.puml) | Plugin FSM: Loaded -> Running -> Shutdown |
 | State | [Hook Execution](design/state/state_hook_execution.puml) | Hook dispatch state machine |
 | State | [Scope Resolution](design/state/state_scope_resolution.puml) | Scope validation and granting FSM |
+| State | [OpHook Replay Suppression](design/state/state_ophook_replay_suppression.puml) | Replay vs restart-storm suppression per plugin |

--- a/docs/gcpc/design/sequence/sequence_ophook_replay_on_subscribe.puml
+++ b/docs/gcpc/design/sequence/sequence_ophook_replay_on_subscribe.puml
@@ -1,0 +1,58 @@
+@startuml sequence_ophook_replay_on_subscribe
+!include ../../../design/theme.iuml
+
+title OperationHook replay-on-subscribe for a late IPC plugin
+
+participant "Server" as S
+participant "ophooks.Registry" as R
+participant "ophooks.Executor" as E
+participant "operations.Tracker" as T
+participant "PluginConn" as C
+participant "gobservability\n(late subscriber)" as P
+
+== Boot phase — plugin not yet connected ==
+S -> T : Start(TypeStartup) → bootOp
+S -> T : Start(TypeCommand) → cmd_1 (long-running)
+S -> T : Start(TypeConnection) → conn_3
+S -> E : RunStartHooks(bootOp) → no matches
+
+== Plugin connects ==
+P -> S : GCPC handshake + Register\n(operation_hooks = [{*, 10}])
+S -> R : Register("gobs", 10, conn, ["*"])
+activate R
+note right of R : Register acquires write lock\nappends hook entries\ncaptures regTime INSIDE the lock
+R --> S : unlocked; invoke onRegister(pluginName, regTime)
+deactivate R
+S -> E : Replay("gobs", regTime)
+
+activate E
+E -> T : Active()
+T --> E : [bootOp, cmd_1, conn_3, ...]
+E -> E : filter StartTime < regTime\nAND pattern matches "*"
+E -> E : sort by StartTime (parent → child)
+
+loop for each retained op (sync, in order)
+    E -> C : SendFireAndForget(NewOperationHookReplay(\n  reqID, op.ID, op.Type, op.ParentID,\n  filteredCtx, op.StartTime.UnixNano()))
+    C -> P : OperationHookRequestV1 { replayed=true,\n  replay_start_unix_ns=<absolute ns> }
+    P -> P : StartOperation(..., replayed=true, startUnixNs)
+    note right of P
+      Span anchored at
+      time.Unix(0, startUnixNs).
+      Attribute gocache.replayed=true.
+      No response sent — server is
+      not waiting for enrichment.
+    end note
+end
+
+deactivate E
+
+== Live ops after regTime go via normal path ==
+S -> T : Start(TypeCommand) → cmd_42
+S -> E : RunStartHooks(cmd_42) → [gobs match]
+E -> C : Send(OperationHookRequestV1 { replayed=false }) — sync
+C -> P : live start
+P --> C : OperationHookResponseV1 { context_values }
+C --> E : context enrichment
+E -> S : op enriched
+
+@enduml

--- a/docs/gcpc/design/state/state_ophook_replay_suppression.puml
+++ b/docs/gcpc/design/state/state_ophook_replay_suppression.puml
@@ -1,0 +1,37 @@
+@startuml state_ophook_replay_suppression
+
+!include ../../../design/theme.iuml
+
+frame "Replay + restart-storm suppression (per plugin)" as F {
+
+    state "Never registered" as Never
+
+    state "Replaying" as Replaying : Active-op snapshot\ntype-filter + sort\nsynchronous sends
+
+    state "Live" as Live : Receives PhaseStart\nand PhaseComplete\nfor new ops
+
+    state "Crashed / disconnected" as Crashed : GCPC conn gone\nRegistry.Unregister
+
+    state "Suppression window" as Suppressed : regTime - lastReplay\n< min_restart_interval_for_replay
+
+    [*] --> Never
+    Never --> Replaying : Register\n(first time)
+    Replaying --> Live : Replay done
+
+    Live --> Crashed : conn loss / panic
+    Crashed --> Suppressed : Re-register within window
+    Crashed --> Replaying : Re-register after window\n(lastReplay cleared by time)
+
+    Suppressed --> Live : skip replay + log\n"replay suppressed —\nrestart-storm window"
+}
+
+note bottom of Suppressed
+  Config: plugins.min_restart_interval_for_replay
+  Default: 30s. Zero disables suppression
+  (every register gets a full replay).
+  lastReplay is recorded before the mutex
+  is released so two near-simultaneous
+  re-registers can't both pass the check.
+end note
+
+@enduml

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -57,6 +57,9 @@ memory:
 workers:
   cleanup_interval: 1m
 
+events:
+  replay_capacity: 10000   # bounded ring for late subscribers; 0 disables
+
 plugins:
   enabled: false
   dir: "bin/plugins"
@@ -65,14 +68,46 @@ plugins:
   shutdown_timeout: 5s
   max_restarts: 3
   connect_timeout: 10s
+  min_restart_interval_for_replay: 30s     # ophook replay skipped if plugin re-registers within window
   overrides:
     auth:
-      critical: true
+      failure_policy: halt_server          # canonical — replaces legacy `critical: true`
       priority: 1
       scopes: ["hook:pre", "read"]
 ```
 
 Configuration is hot-reloadable via fsnotify. Changes to memory limits, eviction policy, snapshot interval, cleanup interval, and log level take effect without restart. Address and port changes require a restart.
+
+### Embedded plugins (compile-time-linked)
+
+A narrow set of capabilities must be active before config loads or before any IPC plugin can connect — crashdump collection, OTLP emission from t=0. These ship as **embedded plugins** linked in via build tags:
+
+```bash
+# Default: no embedded plugins (15 MB).
+go build ./cmd/server
+
+# With embedded crashdump scanner and OTLP exporter (~24 MB).
+go build -tags "crashdump otlp" ./cmd/server
+
+# Docker: per-variant image matrix published to GHCR on every main push.
+docker pull ghcr.io/<org>/gocache:minimal   # no embedded
+docker pull ghcr.io/<org>/gocache:default   # crashdump
+docker pull ghcr.io/<org>/gocache:full      # crashdump + otlp
+docker pull ghcr.io/<org>/gocache:latest    # alias for :default
+```
+
+Embedded-plugin env vars (all optional):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `GOCACHE_CRASHDUMP_DIR` | `crashes/` | Directory for JSON panic dumps |
+| `GOCACHE_CRASHDUMP_DISABLED` | `false` | Skip crashdump writes (tests) |
+| `GOCACHE_BOOT_STATE_FILE` | `boot.state` | Atomic stage marker file |
+| `GOCACHE_EMBEDDED_OTLP_ENDPOINT` | _(unset)_ | Required for OTLP; unset = dormant |
+| `GOCACHE_EMBEDDED_OTLP_SERVICE` | `gocache` | `service.name` resource attribute |
+| `GOCACHE_EMBEDDED_OTLP_TIMEOUT_MS` | `3000` | Export timeout |
+| `GOCACHE_EMBEDDED_OTLP_INSECURE` | auto | True for `http://` endpoints |
+| `GOCACHE_EMBEDDED_OTLP_DISABLED` | `false` | Hard off-switch |
 
 ## Supported Commands
 
@@ -164,7 +199,7 @@ task test
 
 ## Design Documentation
 
-- Server diagrams: `docs/server/design/` (12 diagrams -- components, sequences, state machines)
-- GCPC protocol diagrams: `docs/gcpc/design/` (14 diagrams)
+- Server diagrams: `docs/server/design/` — components, sequences, state machines (including `state_embedded_plugin_lifecycle.puml`, `components_event_bus_ring.puml`, `sequence_boot_crash_survivability.puml`)
+- GCPC protocol diagrams: `docs/gcpc/design/` (including `sequence_ophook_replay_on_subscribe.puml`, `state_ophook_replay_suppression.puml`)
 - Full diagram index with links: [SOLUTION_ARCHITECTURE.md](SOLUTION_ARCHITECTURE.md#design-diagrams)
 - GCPC protocol specification: [docs/gcpc/README.md](../gcpc/README.md)

--- a/docs/server/SOLUTION_ARCHITECTURE.md
+++ b/docs/server/SOLUTION_ARCHITECTURE.md
@@ -239,14 +239,17 @@ Signal (SIGTERM/SIGINT)
 | Component | [Core Subsystems](design/component/components_core.puml) | Evaluator, engine, storage, workers |
 | Component | [Configuration](design/component/components_config.puml) | Config loading, layering, hot reload |
 | Component | [Memory & Eviction](design/component/components_memory_eviction.puml) | LRU eviction internals |
+| Component | [Event Bus + Replay Ring](design/component/components_event_bus_ring.puml) | Bounded ring for late subscriber catch-up |
 | Sequence | [Command Flow](design/sequence/sequence_command_flow.puml) | Core hot path with hooks and plugin fallback |
 | Sequence | [Transactions](design/sequence/sequence_transaction.puml) | MULTI/EXEC/DISCARD flow |
 | Sequence | [TTL Expiry](design/sequence/sequence_ttl_expiry.puml) | Dual strategy: passive + active sweep |
 | Sequence | [Persistence](design/sequence/sequence_persistence.puml) | Snapshot save and load |
 | Sequence | [Hot Reload](design/sequence/sequence_hot_reload.puml) | Config file change detection and application |
 | Sequence | [Graceful Shutdown](design/sequence/sequence_graceful_shutdown.puml) | 6-step shutdown sequence |
+| Sequence | [Boot + Crash Survivability](design/sequence/sequence_boot_crash_survivability.puml) | Embedded plugins, bootstate marker, crashdump defer |
 | State | [Connection Lifecycle](design/state/state_connection.puml) | Client connection FSM (auth, hooks) |
 | State | [Server Lifecycle](design/state/state_server.puml) | Server startup and shutdown FSM |
+| State | [Embedded Plugin Lifecycle](design/state/state_embedded_plugin_lifecycle.puml) | Compile-time-linked observability plugin FSM |
 
 ### GCPC Protocol
 
@@ -267,6 +270,8 @@ See [GCPC documentation](../gcpc/README.md) for protocol details and the followi
 | Sequence | [Hook Context Flow](../gcpc/design/sequence/sequence_hook_context.puml) | Context namespacing across multiple plugins |
 | Sequence | [Scope Registration](../gcpc/design/sequence/sequence_scope_registration.puml) | Scope negotiation |
 | Sequence | [Scope Enforcement](../gcpc/design/sequence/sequence_scope_enforcement.puml) | Runtime scope checks |
+| Sequence | [OpHook Replay on Subscribe](../gcpc/design/sequence/sequence_ophook_replay_on_subscribe.puml) | Synthetic PhaseStart delivery for late subscribers |
 | State | [Plugin Lifecycle](../gcpc/design/state/state_plugin_lifecycle.puml) | Plugin FSM |
 | State | [Hook Execution](../gcpc/design/state/state_hook_execution.puml) | Hook dispatch FSM |
 | State | [Scope Resolution](../gcpc/design/state/state_scope_resolution.puml) | Scope validation FSM |
+| State | [OpHook Replay Suppression](../gcpc/design/state/state_ophook_replay_suppression.puml) | Per-plugin replay vs restart-storm suppression |

--- a/docs/server/design/component/components_event_bus_ring.puml
+++ b/docs/server/design/component/components_event_bus_ring.puml
@@ -1,0 +1,55 @@
+@startuml components_event_bus_ring
+!include ../../../design/theme.iuml
+
+frame "Event Bus with Replay Ring" as F {
+
+    package "pkg/events" as EV {
+        component "Bus" as BUS
+        component "ring\n(bounded FIFO)" as RING
+        component "subscribers map" as SUBS
+    }
+
+    rectangle "Emitters" as EMIT {
+        component "Server boot logs" as BL
+        component "Command post-hooks" as CH
+        component "Connection open/close" as CL
+        component "Plugin lifecycle" as PL
+    }
+
+    rectangle "Subscribers" as SUB {
+        component "LogCollector\n(pkg/logcollector)" as LC
+        component "IPC plugins via GCPC\n(gobservability, custom)" as IPC
+        component "Embedded plugins\n(otlp, crashdump)" as EMB
+    }
+
+    BL --> BUS : Emit
+    CH --> BUS : Emit
+    CL --> BUS : Emit
+    PL --> BUS : Emit
+
+    BUS --> RING : push under write lock
+    BUS --> SUBS : dispatch live
+
+    BUS -> LC : Subscribe\n(snapshot + live)
+    BUS -> IPC : Subscribe\n(snapshot + live)
+    BUS -> EMB : Subscribe\n(usually early, gets few replays)
+}
+
+note bottom of RING
+  Capacity: events.replay_capacity
+  Default 10 000 (~5 MB @ 500B avg).
+  0 disables replay entirely.
+  Overflow drops oldest and emits a
+  synthetic ReplayGap event so late
+  subscribers can alert on misses.
+end note
+
+note top of BUS
+  Subscribe captures the ring snapshot
+  under the same write lock that gates
+  Emit, then delivers synchronously
+  before returning. No dup, no gap
+  across the replay/live boundary.
+end note
+
+@enduml

--- a/docs/server/design/sequence/sequence_boot_crash_survivability.puml
+++ b/docs/server/design/sequence/sequence_boot_crash_survivability.puml
@@ -1,0 +1,68 @@
+@startuml sequence_boot_crash_survivability
+!include ../../../design/theme.iuml
+
+title Boot + crash survivability (embedded plugins + bootstate + crashdump)
+
+participant "main()" as M
+participant "zerolog (stderr)" as L
+participant "embedded.Registry" as ER
+participant "bootstate" as BS
+participant "config.Load" as C
+participant "crashdump" as CD
+participant "runtime" as R
+
+M -> L : InitStderr — JSON from line 1
+M -> BS : Write(stage=embedded_boot)
+M -> M : defer { recover → crashdump.WriteFromPanic }
+note right of M
+  Registered FIRST — survives
+  every later defer, including
+  embedded.ShutdownAll.
+end note
+
+M -> ER : BootAll(ctx)
+activate ER
+ER -> ER : for each registered:\n  invoke(BootInit)\n  Strict panic → Fatal\n  Default panic → log + continue
+ER --> M
+deactivate ER
+M -> M : defer { embedded.ShutdownAll }
+
+M -> BS : Write(stage=config_load)
+M -> C : Load(flags)
+alt Config parse OK
+  C --> M : cfg
+  M -> ER : ConfigLoadedAll(ctx, cfg)
+  note right of ER
+    Crashdump embedded plugin scans
+    <dir>/crashes/ here (logger ready)
+    and emits events.
+    OTLP embedded plugin upgrades
+    endpoint from env to YAML.
+  end note
+else Panic during Load
+  C ->> M : panic
+  M -> M : deferred recover
+  M -> BS : Read(previous stage)
+  M -> CD : WriteFromPanic(stage=config_load, ...)
+  note right of CD
+    If mkdir/write fails, JSON
+    goes to stderr as fallback.
+  end note
+  M -> R : re-panic → stack trace + exit 2
+end
+
+M -> BS : Write(stage=core_init)
+M -> M : cache / engine / watch / tracker init
+M -> BS : Write(stage=plugin_load)
+M -> M : pluginManager.Start(ctx)
+M -> BS : Write(stage=snapshot_load)
+M -> BS : Write(stage=workers_start)
+M -> BS : Write(stage=listener_start)
+M -> BS : Write(stage=running)
+
+== On next boot (previous run crashed) ==
+M -> BS : Read
+BS --> M : stage != running
+M -> L : Warn "previous_run_stage=plugin_load crashed=true"
+
+@enduml

--- a/docs/server/design/state/state_embedded_plugin_lifecycle.puml
+++ b/docs/server/design/state/state_embedded_plugin_lifecycle.puml
@@ -1,0 +1,51 @@
+@startuml state_embedded_plugin_lifecycle
+!include ../../../design/theme.iuml
+
+frame "Embedded Plugin Lifecycle (compile-time-linked, in-process)" as F {
+
+    state "Registered" as Registered : init() called\nviaPLUGINS build-arg\n(e.g. crashdump, otlp)
+
+    state "BootInit" as BootInit : Before config.Load\nOnly env vars available\nzerolog stderr wired
+
+    state "ConfigLoaded" as ConfigLoaded : After config parses\nmay upgrade settings\n(YAML > env)
+
+    state "Running" as Running : Alongside IPC plugins\nSees every event from t=0
+
+    state "ProcessShutdown" as ProcessShutdown : Deferred in main\nRuns even on panic\n(after crashdump write)
+
+    state "PanicRecover" as PanicRecover : invoke() recover\nStrict: halt server\nDefault: log and continue
+
+    [*] --> Registered
+    Registered --> BootInit : embedded.BootAll(ctx)
+    BootInit --> ConfigLoaded : embedded.ConfigLoadedAll
+    ConfigLoaded --> Running
+
+    BootInit -[#EF4444]-> PanicRecover : panic / err
+    ConfigLoaded -[#EF4444]-> PanicRecover : panic / err
+    PanicRecover --> Running : Register (non-strict)
+    PanicRecover -[#EF4444,bold]-> [*] : RegisterStrict (halt)
+
+    Running --> ProcessShutdown : SIGTERM / panic
+    ProcessShutdown --> [*]
+}
+
+note right of BootInit
+  Panic-unwind order (LIFO):
+  1. log pipe close + collector.Wait
+  2. embedded.ShutdownAll
+     — OTLP ForceFlush runs HERE
+  3. ctx cancel
+  4. crashdump.WriteFromPanic
+  5. re-raise for runtime stack
+end note
+
+note right of Registered
+  Registry: two tiers
+  - Register (default)    — recover, continue
+  - RegisterStrict        — halt on failure
+  Use strict only when you
+  truly need halt-on-fail
+  visibility from t=0.
+end note
+
+@enduml


### PR DESCRIPTION
Adds five new PlantUML diagrams covering embedded plugin lifecycle, event bus replay ring, boot + crash survivability, ophook replay-on- subscribe, and restart-storm suppression. Updates the server and GCPC READMEs with the new config keys, embedded plugin tier, Docker build variants, event replay contract, and operation-hook replay semantics. Refreshes the diagram index in SOLUTION_ARCHITECTURE.md.