### PR TITLE
chore(audit): ClientContext cross-goroutine race audit + FlushDB stress test (closes #35)

### DIFF
--- a/docs/audits/clientctx-cross-goroutine.md
+++ b/docs/audits/clientctx-cross-goroutine.md
@@ -1,0 +1,120 @@
+# ClientContext cross-goroutine race audit
+
+**Issue:** [#35](https://github.com/j-mizera/gocache/issues/35)
+**Trigger:** PR #32 surfaced a pre-existing race on `ClientContext.WatchDirty` —
+written from the engine goroutine (under `cache.Lock` via
+`watch.Manager.NotifyMutation`), read from the connection goroutine
+(`HandleExec`) without the lock. Race existed in main; no test
+exercised it. Fixed in #32 by converting the field to `atomic.Bool`.
+
+This audit sweeps the remaining `ClientContext` fields for the same
+shape of bug.
+
+## Method
+
+For each field, identify:
+
+1. **Writers** — which functions write the field, on which goroutine.
+2. **Readers** — which functions read the field, on which goroutine.
+3. **Synchronization edges** — what happens-before relationship (if any)
+   exists between writer and reader.
+
+The Go memory model gives us happens-before via:
+- channel send/receive (engine `cmdChan` ↔ `resChan` is the main one)
+- mutex Lock/Unlock pairs
+- atomic operations
+- single-goroutine program order
+
+A field is racy if a writer in goroutine A and a reader in goroutine B
+have no synchronization edge between them.
+
+## Findings
+
+### Field-by-field analysis
+
+| Field | Writers | Readers | Synchronization | Race? |
+|---|---|---|---|---|
+| `InTransaction` | `transaction.Multi/Discard`, `HandleExec` (all engine goroutine) | `evaluateInternal:184` (connection), `HandleExec`, `HandleWatch`, `transaction.Manager.{Multi,Discard}` (engine) | engine→connection via `resChan` recv (HB edge); engine self-reads same-goroutine | **no** |
+| `CommandQueue` | `HandleMulti`/`StartTransaction` (engine), `EnqueueCommand` from `evaluateInternal:189` (connection!), `HandleExec`/`ResetTransaction` (engine) | `HandleExec` (engine) reads + nils | Connection appends only when `InTransaction=true` (engine just set it); engine reads queue only on EXEC (connection just sent it). All chains go through `cmdChan`/`resChan` ⇒ HB | **no** |
+| `Authenticated` | `HandleAuth`, `HandleHello` (engine) | `server.go:334` auth gate (connection) | engine→connection via `resChan` recv | **no** |
+| `ProtoVersion` | `HandleHello` (engine) | `server.go:388` `mapValueToResp` (connection), `HandleHello` self (engine) | engine→connection via `resChan` recv | **no** |
+| `RexVersion` | `HandleHello` (engine) | `server.go:297` META gate (connection), `HandleHello` self (engine) | engine→connection via `resChan` recv | **no** |
+| `RexMeta` | `ensureRexStore` (engine, via REX.META subcommands) | `evaluator.go:230,231,250,307` (engine, instrumentation slow path), `routeToPlugin` (connection via `evaluateInternal`) | engine self-reads same-goroutine; connection reads after engine cycle (HB via `resChan`) | **no** |
+| `CmdMeta` | `server.go:350,352` (connection) | `evaluator.go:230,231,250,307` (engine instrumentation, but called via `evaluateInternal` which runs on connection goroutine) | All accesses on connection goroutine | **no** |
+| `OperationID` | `server.go:226` (connection, ONCE at startup) | many (both goroutines) | Set once before any commands; read-only afterwards. No concurrent writes to race against | **no** |
+| `WatchedKeys` | `watch.Manager.Watch` line 31 (under `m.mu`), `ClearWatch` from `watch.Manager.Unwatch` line 47 (under `m.mu`) | `watch.Manager.Unwatch` line 39 (under `m.mu`) | All access under `watch.Manager.mu` | **no** |
+| `watchDirty` | `watch.Manager.NotifyMutation/NotifyAll` (engine, under `cache.Lock` and `m.mu`) | `HandleExec` (engine) | **Cross-goroutine: engine writes from one connection's command, another connection's `HandleExec` reads.** | **was YES, fixed in #32** via `atomic.Bool` |
+
+### Subtle case: `evaluateInternal` is on the connection goroutine
+
+The instrumentation block in `evaluateInternal` (lines 230, 231, 250,
+307) reads `ctx.RexMeta` and `ctx.CmdMeta`. This block runs in the
+**connection goroutine** (NOT inside a handler closure passed to the
+engine), so it does not enter the engine. CmdMeta is also written in
+the connection goroutine (`server.go:350/352`). RexMeta is written in
+the engine goroutine — but the connection goroutine reads it AFTER
+`evaluator.Evaluate` returns from a previous REX.META command, so the
+`resChan` recv establishes happens-before.
+
+### Subtle case: `routeToPlugin` reads RexMeta on the connection goroutine
+
+`routeToPlugin` is called from `evaluateInternal:144` when the command
+is plugin-routed. It reads `client.RexMeta` and `client.CmdMeta` on
+the connection goroutine, sends to plugin via IPC, blocks for response.
+
+A concurrent REX.META command from the SAME client cannot race because
+the connection processes commands serially per-connection. A concurrent
+mutation from ANOTHER client cannot race because each client has its
+own `ClientContext`. **No race.**
+
+## Conclusion
+
+**No new races found beyond `watchDirty` (already fixed in #32).**
+
+The audit confirms the architectural separation is sound:
+
+- Per-connection `ClientContext` fields are safe because each connection
+  has its own context and processes commands serially through the
+  engine queue. The `cmdChan`/`resChan` round-trip per command provides
+  the synchronization edge.
+- The single field that crosses connections (`watchDirty`, written by
+  another connection's mutation goroutine) is now atomic.
+- `WatchedKeys` crosses connections via the watch manager but is gated
+  by the manager's mutex, so writes and reads are serialised.
+
+## Test coverage
+
+`pkg/server/it_concurrency_test.go::TestIT_WatchPropagation_ReadLockBypass`
+(added in PR #32) exercises the `watchDirty` cross-connection path
+under `-race` for 500 ms. It passes consistently — the race detector
+is what would surface a regression here.
+
+`pkg/server/it_concurrency_test.go::TestIT_FlushDBPropagation`
+(added in this audit) exercises the `NotifyAll` path: one connection
+runs WATCH/MULTI/EXEC loops; another runs FLUSHDB to invalidate all
+watched keys via `Manager.NotifyAll`. The same `atomic.Bool` carries
+the cross-connection notification; this test is regression coverage
+for the broader notification path.
+
+## Methodology updates carried forward
+
+The methodology lessons from #28 (mixed-workload baseline, cross-path
+cost confirmation, magnitude-bounded risks) are documented in
+`projects/gocache/plans/command-flow/diagnosis-pre-implementation.md`'s
+"Lessons learned (post-#28)" section. They apply to any future plan
+that changes synchronization primitives.
+
+## Why no code changes ship in this PR
+
+Methodology was added to the Obsidian plan note during the #32 closeout.
+The audit found no new races. The only shippable artefacts are:
+
+- This audit document (regression record for any future contributor
+  asking "did anyone check?").
+- The new `TestIT_FlushDBPropagation` stress test (regression coverage
+  for the NotifyAll path).
+- The Obsidian session note (audit chronicle).
+
+The acceptance criterion "the next plan that changes synchronization
+primitives cites this issue and includes the mixed-workload step" is
+forward-looking — fulfilled by future plans, not by this PR.

--- a/pkg/server/it_concurrency_test.go
+++ b/pkg/server/it_concurrency_test.go
@@ -183,3 +183,96 @@ func TestIT_WatchPropagation_ReadLockBypass(t *testing.T) {
 		setCount.Load(), watchAttempts.Load(), watchAborted.Load(),
 		float64(watchAborted.Load())/float64(watchAttempts.Load())*100)
 }
+
+// TestIT_FlushDBPropagation_AcrossConnections exercises the watch.Manager
+// NotifyAll path: one connection runs WATCH/MULTI/EXEC loops on a single
+// key while another connection issues FLUSHDB repeatedly. FLUSHDB
+// invalidates every watching client by calling Manager.NotifyAll, which
+// writes ctx.watchDirty across all clients (cross-connection mutation).
+//
+// Audit coverage for #35: the watchDirty fix from PR #32 also has to
+// hold for the NotifyAll path (not only NotifyMutation). The same
+// atomic.Bool carries both; this test gives -race coverage for the
+// broader notification surface. Without the fix this would race;
+// with it the race detector stays clean.
+func TestIT_FlushDBPropagation_AcrossConnections(t *testing.T) {
+	_, addr := startTestServer(t, "")
+
+	{
+		c := dial(t, addr)
+		assertOK(t, sendCommand(t, c, "SET", "fkey", "0"))
+		c.Close()
+	}
+
+	const dur = 300 * time.Millisecond
+	stop := make(chan struct{})
+	go func() {
+		time.Sleep(dur)
+		close(stop)
+	}()
+
+	var flushCount atomic.Int64
+	var watchAttempts atomic.Int64
+	var watchAborted atomic.Int64
+
+	var wg sync.WaitGroup
+
+	// FLUSHDB-loop on its own connection.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn := dial(t, addr)
+		defer conn.Close()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sendCommand(t, conn, "FLUSHDB")
+			// Re-seed so the watcher has something to look at.
+			sendCommand(t, conn, "SET", "fkey", "0")
+			flushCount.Add(1)
+		}
+	}()
+
+	// Watcher: WATCH/MULTI/GET/EXEC loop. Some EXECs MUST abort because
+	// FLUSHDB invalidates the watched key via NotifyAll.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn := dial(t, addr)
+		defer conn.Close()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			watchAttempts.Add(1)
+			sendCommand(t, conn, "WATCH", "fkey")
+			sendCommand(t, conn, "MULTI")
+			sendCommand(t, conn, "GET", "fkey")
+			v := sendCommand(t, conn, "EXEC")
+			if v.IsNull {
+				watchAborted.Add(1)
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	if flushCount.Load() == 0 {
+		t.Fatal("FLUSHDB loop never ran")
+	}
+	if watchAttempts.Load() == 0 {
+		t.Fatal("watcher never attempted")
+	}
+	if watchAborted.Load() == 0 {
+		t.Fatalf("expected at least one FLUSHDB-aborted EXEC; got flushes=%d watches=%d aborted=0",
+			flushCount.Load(), watchAttempts.Load())
+	}
+	t.Logf("flushdb stress: flushes=%d watches=%d aborted=%d (%.1f%%)",
+		flushCount.Load(), watchAttempts.Load(), watchAborted.Load(),
+		float64(watchAborted.Load())/float64(watchAttempts.Load())*100)
+}


### PR DESCRIPTION
## Summary

Closes #35 with a **negative-result audit** plus a small piece of regression coverage.

The methodology updates from the issue body (mixed-workload baseline, cross-path cost confirmation, magnitude-bounded risks) already landed in \`projects/gocache/plans/command-flow/diagnosis-pre-implementation.md\` "Lessons learned (post-#28)" section during the #32 closeout. This PR finishes the bonus piece — sweeping ClientContext for the race shape that surfaced on \`WatchDirty\`.

## Audit conclusion

**No new races found beyond \`watchDirty\`** (fixed in #32).

For every ClientContext field, the audit traced writers, readers, and the synchronization edge between them. Full table in [\`docs/audits/clientctx-cross-goroutine.md\`](https://github.com/j-mizera/gocache/blob/chore/sync-state-audit/docs/audits/clientctx-cross-goroutine.md).

Pattern that holds for every other field: per-connection access serialized through the \`cmdChan\`/\`resChan\` round-trip per command (each command gets a happens-before edge between engine writes and the next connection read). The only field that crossed connections without that edge was \`watchDirty\` — one connection's mutation goroutine writing another connection's flag — and the \`atomic.Bool\` from #32 covers that.

\`WatchedKeys\` also crosses connections (via the watch manager) but is gated by \`watch.Manager.mu\`. Audit confirms all access points hold the mutex.

## What ships

1. **\`docs/audits/clientctx-cross-goroutine.md\`** — field-by-field analysis with writer/reader/synchronization columns and the conclusion. Regression record for any future contributor asking "did anyone check?".

2. **\`TestIT_FlushDBPropagation_AcrossConnections\`** — new stress test in \`pkg/server/it_concurrency_test.go\`. 300 ms × -race × concurrent FLUSHDB-loop + WATCH/MULTI/EXEC-loop on a single key. The existing \`TestIT_WatchPropagation_ReadLockBypass\` covers \`NotifyMutation\`; this test covers \`NotifyAll\` (the cross-connection invalidation path FLUSHDB triggers). Same atomic.Bool carries both notifications; this is broader regression coverage.

   Observed run: 534 flushes interleaved with 831 WATCH attempts, 323 EXEC aborts (38.9% abort rate confirms propagation works correctly under concurrency).

## Methodology adoption

The acceptance criterion "the next plan that changes synchronization primitives cites this issue and includes the mixed-workload step" is forward-looking — it's fulfilled by future plans, not by this PR. The PR for the **per-shard locking work tracked in #34** (architectural redesign to remove the channel hop) is the first one expected to consume the new methodology. The Obsidian plan note already documents what that consumption looks like.

## Test plan

- [x] \`go test -race ./...\` — green across all 35 packages
- [x] \`go vet ./...\` — clean
- [x] \`staticcheck ./...\` + \`staticcheck -tags 'crashdump otlp' ./...\` — clean (per memory rule)
- [x] New \`TestIT_FlushDBPropagation_AcrossConnections\` passes under \`-race\` with non-zero abort ratio (regression-detectable signal)

## Why no code fix ships

The audit's purpose was to find races. It found none. The deliverables are documentation (audit record) and test coverage (regression detector for future re-introduction). The original race fixed in #32 stands; nothing else needed to change.

If this audit had found a race, the PR would have fixed it and added a stress test that fails without the fix. Instead, it documents the analysis and adds a stress test that exercises a related cross-connection path so any future regression on the watchDirty atomic — say, a refactor that converts it back to a plain bool — would surface immediately under \`-race\`.

Closes #35