### PR TITLE
refactor(command): classify handlers by sharding behavior — KeyArgIndex + MultiKey

### DIFF
--- a/api/command/types.go
+++ b/api/command/types.go
@@ -20,8 +20,28 @@ type Result struct {
 // (GETSET, GETDEL, GETEX, BLPOP/BRPOP, LPOP/RPOP, SPOP) must NOT be
 // marked ReadOnly. When in doubt: mark false; the worst case is the
 // command takes the engine path and runs slightly slower.
+//
+// KeyArgIndex and MultiKey describe how a command's keys map onto the
+// engine's keyspace. The sharded engine uses these to route commands to
+// the shard owning the key (single-key) or to the cross-shard
+// coordination path (multi-key). Today the production engine is a
+// single goroutine and ignores both fields; the metadata is in place
+// so a future sharded engine can route without per-handler reflection.
+//
+//   KeyArgIndex >= 0 — a single-key command; the key is at Args[KeyArgIndex].
+//                      Default 0 (the most common case: first arg is key).
+//   KeyArgIndex == -1 — a keyless command (PING, AUTH, HELLO, MULTI,
+//                       DISCARD, INFO, etc.). Has no cache key.
+//   MultiKey == true — a command that touches multiple keys or every key
+//                      (MGET, MSET, RENAME, KEYS, SCAN, SINTER, EXEC,
+//                      WATCH, UNWATCH, DBSIZE, RANDOMKEY, FLUSHDB,
+//                      DELETE-with-N-args, BLPOP-with-N-keys, snapshot
+//                      save/load). KeyArgIndex is ignored when MultiKey
+//                      is true.
 type Spec struct {
-	Min      int
-	Max      int
-	ReadOnly bool
+	Min         int
+	Max         int
+	ReadOnly    bool
+	KeyArgIndex int
+	MultiKey    bool
 }

--- a/pkg/resp/handler/register.go
+++ b/pkg/resp/handler/register.go
@@ -5,7 +5,9 @@ import (
 	"gocache/pkg/resp"
 )
 
-// reg is shorthand for building a Registration inline.
+// reg builds a single-key Registration with the key at Args[0] (the
+// default for the vast majority of commands). Use this for simple
+// mutating handlers like SET, HSET, SADD, ZADD, INCR, etc.
 func reg(h command.Handler, min, max int) command.Registration {
 	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max}}
 }
@@ -19,31 +21,71 @@ func regRO(h command.Handler, min, max int) command.Registration {
 	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max, ReadOnly: true}}
 }
 
+// regKeyless builds a Registration for commands that do not address
+// any cache key — client-state and server-meta commands like PING,
+// AUTH, HELLO, MULTI, DISCARD, INFO, ECHO, SELECT, UNWATCH. The
+// sharded engine runs these inline without dispatching through any
+// shard's queue.
+func regKeyless(h command.Handler, min, max int) command.Registration {
+	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max, KeyArgIndex: -1}}
+}
+
+// regKeylessRO is regKeyless with ReadOnly = true. PING, ECHO, INFO.
+func regKeylessRO(h command.Handler, min, max int) command.Registration {
+	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max, ReadOnly: true, KeyArgIndex: -1}}
+}
+
+// regMulti marks commands that touch multiple keys or iterate the
+// whole keyspace. The sharded engine routes these through cross-shard
+// coordination (sorted-shard-ID lock acquisition) rather than
+// dispatching to a single shard.
+//
+// Examples: DELETE-with-N-args, MGET, MSET, RENAME, KEYS, SCAN,
+// SINTER, SUNION, SDIFF, BLPOP-with-N-keys, FLUSHDB, FLUSHALL,
+// DBSIZE, RANDOMKEY, EXEC (whose queued commands can touch any
+// shard), SNAPSHOT, LOADSNAPSHOT, WATCH, UNWATCH (per-shard
+// watch.Manager updates).
+func regMulti(h command.Handler, min, max int) command.Registration {
+	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max, MultiKey: true}}
+}
+
+// regMultiRO is regMulti with ReadOnly = true.
+func regMultiRO(h command.Handler, min, max int) command.Registration {
+	return command.Registration{Handler: h, Spec: command.Spec{Min: min, Max: max, ReadOnly: true, MultiKey: true}}
+}
+
 // Registrations returns all RESP command handlers with their argument specs.
+//
+// Spec.KeyArgIndex / Spec.MultiKey classification is used by the
+// sharded engine to route commands. Today the production single-engine
+// dispatcher ignores both; the metadata is in place so a sharded
+// engine can route without per-handler reflection. See api/command.Spec
+// doc comments for classification rules.
 func Registrations() map[string]command.Registration {
 	return map[string]command.Registration{
-		// String commands
+		// String commands — single-key, key at Args[0].
 		resp.CmdSet:     reg(HandleSet, 2, -1),
 		resp.CmdGet:     regRO(HandleGet, 1, 1),
-		resp.CmdDelete:  reg(HandleDelete, 1, -1),
-		resp.CmdExists:  regRO(HandleExists, 1, 1),
+		resp.CmdDelete:  regMulti(HandleDelete, 1, -1), // multi-arg in this codebase
+		resp.CmdExists:  regRO(HandleExists, 1, 1),    // single-arg only
 		resp.CmdExpire:  reg(HandleExpire, 2, 2),
 		resp.CmdPExpire: reg(HandlePexpire, 2, 2),
 		resp.CmdTTL:     regRO(HandleTtl, 1, 1),
 		resp.CmdPTTL:    regRO(HandlePttl, 1, 1),
 		resp.CmdSetNX:   reg(HandleSetnx, 2, 2),
 
-		// List commands
+		// List commands — single-key.
 		resp.CmdLPush:  reg(HandleLpush, 2, -1),
 		resp.CmdRPush:  reg(HandleRpush, 2, -1),
 		resp.CmdLPop:   reg(HandleLpop, 1, 1),
 		resp.CmdRPop:   reg(HandleRpop, 1, 1),
 		resp.CmdLLen:   regRO(HandleLlen, 1, 1),
 		resp.CmdLRange: regRO(HandleLRange, 3, 3),
-		resp.CmdBLPop:  reg(HandleBlpop, 2, -1),
-		resp.CmdBRPop:  reg(HandleBrpop, 2, -1),
+		// BLPOP/BRPOP take "key [key ...] timeout" — multi-key.
+		resp.CmdBLPop: regMulti(HandleBlpop, 2, -1),
+		resp.CmdBRPop: regMulti(HandleBrpop, 2, -1),
 
-		// Hash commands
+		// Hash commands — single-key.
 		resp.CmdHSet:    reg(HandleHset, 3, -1),
 		resp.CmdHGet:    regRO(HandleHget, 2, 2),
 		resp.CmdHDel:    reg(HandleHdel, 2, -1),
@@ -53,18 +95,19 @@ func Registrations() map[string]command.Registration {
 		resp.CmdHVals:   regRO(HandleHvals, 1, 1),
 		resp.CmdHLen:    regRO(HandleHlen, 1, 1),
 
-		// Set commands
+		// Set commands — single-key for SADD/SREM/etc.; multi-key for set-ops.
 		resp.CmdSAdd:      reg(HandleSadd, 2, -1),
 		resp.CmdSRem:      reg(HandleSrem, 2, -1),
 		resp.CmdSMembers:  regRO(HandleSmembers, 1, 1),
 		resp.CmdSIsMember: regRO(HandleSismember, 2, 2),
 		resp.CmdSCard:     regRO(HandleScard, 1, 1),
 		resp.CmdSPop:      reg(HandleSpop, 1, 1),
-		resp.CmdSInter:    regRO(HandleSinter, 1, -1),
-		resp.CmdSUnion:    regRO(HandleSunion, 1, -1),
-		resp.CmdSDiff:     regRO(HandleSdiff, 1, -1),
+		// SINTER/SUNION/SDIFF take 1..N set keys — multi-key.
+		resp.CmdSInter: regMultiRO(HandleSinter, 1, -1),
+		resp.CmdSUnion: regMultiRO(HandleSunion, 1, -1),
+		resp.CmdSDiff:  regMultiRO(HandleSdiff, 1, -1),
 
-		// Sorted Set commands
+		// Sorted Set commands — single-key.
 		resp.CmdZAdd:   reg(HandleZadd, 3, -1),
 		resp.CmdZRem:   reg(HandleZrem, 2, -1),
 		resp.CmdZScore: regRO(HandleZscore, 2, 2),
@@ -73,29 +116,29 @@ func Registrations() map[string]command.Registration {
 		resp.CmdZRank:  regRO(HandleZrank, 2, 2),
 		resp.CmdZCount: regRO(HandleZcount, 3, 3),
 
-		// Transaction commands — never read-only: MULTI/DISCARD/EXEC
-		// transition client state and EXEC re-enters the engine.
-		resp.CmdMulti:   reg(HandleMulti, 0, 0),
-		resp.CmdDiscard: reg(HandleDiscard, 0, 0),
-		resp.CmdExec:    reg(HandleExec, 0, 0),
+		// Transaction commands. MULTI/DISCARD only mutate per-client
+		// transaction state — keyless. EXEC executes queued commands
+		// that may touch any shard — multi-key for sharded routing.
+		resp.CmdMulti:   regKeyless(HandleMulti, 0, 0),
+		resp.CmdDiscard: regKeyless(HandleDiscard, 0, 0),
+		resp.CmdExec:    regMulti(HandleExec, 0, 0),
 
-		// Persistence commands — Snapshot writes the snapshot file (side
-		// effect even though no cache mutation); LoadSnapshot mutates state.
-		resp.CmdSnapshot:     reg(HandleSnapshot, 0, 0),
-		resp.CmdLoadSnapshot: reg(HandleLoadSnapshot, 1, 1),
+		// Persistence — both touch the entire keyspace.
+		resp.CmdSnapshot:     regMulti(HandleSnapshot, 0, 0),
+		resp.CmdLoadSnapshot: regMulti(HandleLoadSnapshot, 1, 1),
 
-		// Server commands
-		resp.CmdDBSize:   regRO(HandleDBSize, 0, 0),
-		resp.CmdInfo:     regRO(HandleInfo, 0, 1),
-		resp.CmdHello:    reg(HandleHello, 1, -1), // mutates client proto-version state
-		resp.CmdPing:     regRO(HandlePing, 0, 1),
-		resp.CmdEcho:     regRO(HandleEcho, 1, 1),
-		resp.CmdSelect:   reg(HandleSelect, 1, 1),
-		resp.CmdFlushDB:  reg(HandleFlushDB, 0, 0),
-		resp.CmdFlushAll: reg(HandleFlushAll, 0, 0),
-		resp.CmdAuth:     reg(HandleAuth, 1, 1), // mutates client auth state
+		// Server / client-state commands.
+		resp.CmdDBSize:   regMultiRO(HandleDBSize, 0, 0), // counts every key
+		resp.CmdInfo:     regKeylessRO(HandleInfo, 0, 1),
+		resp.CmdHello:    regKeyless(HandleHello, 1, -1), // mutates client proto-version state
+		resp.CmdPing:     regKeylessRO(HandlePing, 0, 1),
+		resp.CmdEcho:     regKeylessRO(HandleEcho, 1, 1),
+		resp.CmdSelect:   regKeyless(HandleSelect, 1, 1),
+		resp.CmdFlushDB:  regMulti(HandleFlushDB, 0, 0),  // clears every key
+		resp.CmdFlushAll: regMulti(HandleFlushAll, 0, 0), // clears every key
+		resp.CmdAuth:     regKeyless(HandleAuth, 1, 1),   // mutates client auth state
 
-		// String counter commands — all mutate.
+		// String counter commands — single-key.
 		resp.CmdIncr:        reg(HandleIncr, 1, 1),
 		resp.CmdDecr:        reg(HandleDecr, 1, 1),
 		resp.CmdIncrBy:      reg(HandleIncrBy, 2, 2),
@@ -104,25 +147,25 @@ func Registrations() map[string]command.Registration {
 		resp.CmdAppend:      reg(HandleAppend, 2, 2),
 		resp.CmdStrlen:      regRO(HandleStrlen, 1, 1),
 
-		// Multi-key commands
-		resp.CmdMGet: regRO(HandleMget, 1, -1),
-		resp.CmdMSet: reg(HandleMset, 2, -1),
+		// Multi-key string commands.
+		resp.CmdMGet: regMultiRO(HandleMget, 1, -1),
+		resp.CmdMSet: regMulti(HandleMset, 2, -1),
 
-		// Key management commands
+		// Key management.
 		resp.CmdType:      regRO(HandleType, 1, 1),
-		resp.CmdRename:    reg(HandleRename, 2, 2),
-		resp.CmdRenameNX:  reg(HandleRenameNX, 2, 2),
-		resp.CmdKeys:      regRO(HandleKeys, 1, 1),
-		resp.CmdScan:      regRO(HandleScan, 1, -1),
-		resp.CmdRandomKey: regRO(HandleRandomKey, 0, 0),
+		resp.CmdRename:    regMulti(HandleRename, 2, 2),   // src + dst
+		resp.CmdRenameNX:  regMulti(HandleRenameNX, 2, 2), // src + dst
+		resp.CmdKeys:      regMultiRO(HandleKeys, 1, 1),   // pattern over all keys
+		resp.CmdScan:      regMultiRO(HandleScan, 1, -1),  // cursor over all keys
+		resp.CmdRandomKey: regMultiRO(HandleRandomKey, 0, 0),
 
-		// Watch commands — WATCH mutates the per-client watcher state in
-		// WatchManager (registers interest); not read-only despite the
-		// name. UNWATCH same.
-		resp.CmdWatch:   reg(HandleWatch, 1, -1),
-		resp.CmdUnwatch: reg(HandleUnwatch, 0, 0),
+		// WATCH/UNWATCH coordinate watcher state across shards. WATCH
+		// mutates the per-client watcher state in WatchManager
+		// (registers interest); not read-only despite the name.
+		resp.CmdWatch:   regMulti(HandleWatch, 1, -1),
+		resp.CmdUnwatch: regKeyless(HandleUnwatch, 0, 0), // walks ctx.WatchedKeys, no input arg
 
-		// Key introspection — pure read.
+		// Key introspection — pure read on a single key.
 		resp.CmdObject: regRO(HandleObject, 1, 2),
 	}
 }

--- a/pkg/resp/handler/register_test.go
+++ b/pkg/resp/handler/register_test.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"testing"
+)
+
+// TestRegistrations_ShardingClassification verifies every registered
+// command falls into exactly one of three sharding buckets:
+//   - keyless: KeyArgIndex == -1, MultiKey == false
+//   - single-key: KeyArgIndex >= 0, MultiKey == false
+//   - multi-key: MultiKey == true (KeyArgIndex ignored)
+//
+// And that single-key commands' KeyArgIndex is within [0, Min) — i.e.,
+// the key is at a position the command actually requires. This catches
+// off-by-one mistakes when a future command adds args before the key.
+func TestRegistrations_ShardingClassification(t *testing.T) {
+	regs := Registrations()
+	if len(regs) == 0 {
+		t.Fatal("Registrations() returned empty map")
+	}
+
+	for name, r := range regs {
+		s := r.Spec
+		switch {
+		case s.MultiKey:
+			// MultiKey overrides KeyArgIndex; nothing else to check.
+		case s.KeyArgIndex == -1:
+			// Keyless. Min/Max can be any non-negative pair.
+		case s.KeyArgIndex >= 0:
+			// Single-key. KeyArgIndex must be a position the command
+			// actually requires (i.e. < Min).
+			if s.Min <= s.KeyArgIndex {
+				t.Errorf("%s: single-key but KeyArgIndex=%d >= Min=%d (key not guaranteed present)",
+					name, s.KeyArgIndex, s.Min)
+			}
+		default:
+			t.Errorf("%s: invalid Spec.KeyArgIndex=%d (must be -1 or >=0)", name, s.KeyArgIndex)
+		}
+	}
+}
+
+// TestRegistrations_KeylessCommands enumerates the expected keyless set.
+// If a future change reclassifies one of these, the test will surface
+// the change so the sharded engine routing is reconsidered.
+func TestRegistrations_KeylessCommands(t *testing.T) {
+	expected := map[string]bool{
+		"MULTI":   true,
+		"DISCARD": true,
+		"AUTH":    true,
+		"HELLO":   true,
+		"PING":    true,
+		"ECHO":    true,
+		"SELECT":  true,
+		"INFO":    true,
+		"UNWATCH": true,
+	}
+	regs := Registrations()
+	for name, r := range regs {
+		isKeyless := r.Spec.KeyArgIndex == -1 && !r.Spec.MultiKey
+		want := expected[name]
+		if isKeyless != want {
+			t.Errorf("%s: keyless=%v, want %v", name, isKeyless, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds two fields to `api/command.Spec` that describe how a command's keys map onto the engine's keyspace, and classifies every registered handler.

```go
type Spec struct {
    Min         int
    Max         int
    ReadOnly    bool
    KeyArgIndex int   // -1 keyless, >=0 single-key at this arg index
    MultiKey    bool  // touches multiple keys or every key
}
```

## Why this exists

The diagnosis from #38 confirmed channel-hop dispatch dominates contention; the prototype from #39 validated per-shard locking gives +53% mixed pipelined throughput at N=16. Production implementation needs the dispatcher to know *which shard* a command's key lives on. Doing that cleanly requires per-handler metadata; today the choice was either:

1. Hard-code the classification inside the dispatcher (per-command if/else)
2. Reflect on each handler's name
3. Encode the shape as Spec metadata (this PR)

(3) is cheapest at runtime, lives next to the existing `Spec.Min`/`Max`/`ReadOnly` fields, and is plugin-visible so plugin commands can declare the same shape.

## What changes

- `api/command/types.go`: two new fields with extensive doc comments explaining the classification rules.
- `pkg/resp/handler/register.go`: six helper constructors (`reg`/`regRO`/`regKeyless`/`regKeylessRO`/`regMulti`/`regMultiRO`) replace the previous two; every command is classified.
- `pkg/resp/handler/register_test.go`: new asserting (a) every command falls into exactly one bucket, (b) single-key `KeyArgIndex` stays within `[0, Min)` so the key is guaranteed present, (c) the keyless set matches an explicit allow-list — surfacing future reclassifications for review.

## Classification

**Keyless** (KeyArgIndex=-1, MultiKey=false) — no cache touch:
MULTI, DISCARD, AUTH, HELLO, PING, ECHO, SELECT, INFO, UNWATCH.

**Multi-key** (MultiKey=true) — touches multiple keys or all keys:
DELETE (multi-arg), BLPOP/BRPOP (multi-key + timeout), MGET, MSET, RENAME, RENAMENX, KEYS, SCAN, RANDOMKEY, DBSIZE, FLUSHDB, FLUSHALL, EXEC (queued commands span shards), SNAPSHOT, LOADSNAPSHOT, WATCH, SINTER, SUNION, SDIFF.

**Single-key** (default — KeyArgIndex=0, MultiKey=false) — everything else (~30 commands): SET, GET, EXPIRE, INCR family, all hash/set/sorted-set ops on one key, etc.

## Behavior change

**None.** The production single-engine dispatcher reads neither field. The metadata is in place for the next PR, which will add per-shard cache + engine routing through this same registry.

## Test plan

- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] `staticcheck -tags 'crashdump otlp' ./...` clean
- [x] `go test -race ./...` clean (all packages)
- [x] New `TestRegistrations_ShardingClassification` and `TestRegistrations_KeylessCommands` pass

## Sequencing

This is the first of three PRs implementing #34's per-shard locking design A.

1. **This PR**: classification metadata, no behavior change.
2. Next: per-shard cache + engine with N=1 default — verifies the structural refactor works without changing throughput characteristics.
3. After: bump N=16 default + bench against #38 baseline.

Each PR is independently reviewable and can be reverted without affecting the others.

Refs #34