### PR TITLE
refactor(cache,engine): extract Shard from Cache; per-shard engines (N=1 default)

### DIFF
--- a/bench/results/refactor-extract-shard/post-refactor.txt
+++ b/bench/results/refactor-extract-shard/post-refactor.txt
@@ -1,0 +1,238 @@
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:43Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:45Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:45Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:45Z","message":"engine stop signal received"}
+goos: linux
+goarch: amd64
+pkg: gocache/pkg/server
+cpu: AMD Ryzen 9 7900X 12-Core Processor            
+BenchmarkTCP_GET_Pipelined-4             	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:45Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:47Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:47Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:47Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:47Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:49Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:49Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:49Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:49Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:56Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:56Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:56Z","message":"engine stop signal received"}
+  381517	     14007 ns/op	    9847 B/op	     280 allocs/op
+BenchmarkTCP_GET_Pipelined-4             	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:56Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:58Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:58Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:51:58Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:51:58Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:00Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:00Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:00Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:00Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:02Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:02Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:02Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:02Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:09Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:09Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:09Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:09Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:16Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:16Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:16Z","message":"engine stop signal received"}
+  434744	     12886 ns/op	    9844 B/op	     280 allocs/op
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:16Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:18Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:18Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:18Z","message":"engine stop signal received"}
+BenchmarkTCP_GET_Standard-4              	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:18Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:20Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:20Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:20Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:20Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:22Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:22Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:22Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:22Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:27Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:27Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:27Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:27Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:35Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:35Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:35Z","message":"engine stop signal received"}
+ 1535576	      4040 ns/op	     822 B/op	      27 allocs/op
+BenchmarkTCP_GET_Standard-4              	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:35Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:37Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:39Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:39Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:39Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:39Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:41Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:41Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:41Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:41Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:47Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:47Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:47Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:47Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:55Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:55Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:55Z","message":"engine stop signal received"}
+ 1497446	      3993 ns/op	     822 B/op	      27 allocs/op
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:55Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:56Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:56Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:56Z","message":"engine stop signal received"}
+BenchmarkTCP_Mixed_GetSet_Pipelined-4    	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:56Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:58Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:58Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:52:58Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:52:58Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:00Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:00Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:00Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:00Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:08Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:08Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:08Z","message":"engine stop signal received"}
+  443100	     13698 ns/op	    9141 B/op	     270 allocs/op
+BenchmarkTCP_Mixed_GetSet_Pipelined-4    	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:08Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:10Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:10Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:10Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:10Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:12Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:12Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:12Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:12Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:14Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:14Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:14Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:14Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:21Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:21Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:21Z","message":"engine stop signal received"}
+  438558	     12777 ns/op	    9142 B/op	     270 allocs/op
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:21Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:23Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:23Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:23Z","message":"engine stop signal received"}
+BenchmarkTCP_Mixed_GetHset_Pipelined-4   	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:23Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:25Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:25Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:25Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:25Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:27Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:27Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:27Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:27Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:35Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:35Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:35Z","message":"engine stop signal received"}
+  386702	     16254 ns/op	   11372 B/op	     280 allocs/op
+BenchmarkTCP_Mixed_GetHset_Pipelined-4   	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:35Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:37Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:39Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:39Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:39Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:39Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:41Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:41Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:41Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:41Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:48Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:48Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:48Z","message":"engine stop signal received"}
+  351561	     14583 ns/op	   11113 B/op	     280 allocs/op
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:48Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:50Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:50Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:50Z","message":"engine stop signal received"}
+BenchmarkTCP_Mixed_GetSet_Standard-4     	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:50Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:51Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:51Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:51Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:51Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:53Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:53Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:53Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:53Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:59Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:59Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:53:59Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:53:59Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:07Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:07Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:07Z","message":"engine stop signal received"}
+ 1467082	      4134 ns/op	     725 B/op	      26 allocs/op
+BenchmarkTCP_Mixed_GetSet_Standard-4     	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:07Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:09Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:09Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:09Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:09Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:11Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:11Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:11Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:11Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:13Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:13Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:13Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:13Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:18Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:18Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:18Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:18Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"engine stop signal received"}
+ 1505725	      3973 ns/op	     725 B/op	      26 allocs/op
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:26Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"engine stop signal received"}
+BenchmarkTCP_SET_Standard-4              	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:26Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:26Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:26Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:26Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:31Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:31Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:31Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:31Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"engine stop signal received"}
+ 1420318	      4184 ns/op	    1064 B/op	      27 allocs/op
+BenchmarkTCP_SET_Standard-4              	{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:37Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:37Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:41Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:41Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:41Z","message":"engine stop signal received"}
+{"level":"info","source":"server","shards":1,"time":"2026-05-02T23:54:41Z","message":"engine dispatch loop started"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:47Z","message":"initiating graceful shutdown"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:47Z","message":"all connections closed gracefully"}
+{"level":"info","source":"server","time":"2026-05-02T23:54:47Z","message":"engine stop signal received"}
+ 1391890	      4254 ns/op	    1066 B/op	      27 allocs/op
+PASS
+ok  	gocache/pkg/server	183.735s

--- a/bench/results/refactor-extract-shard/refactor-summary.md
+++ b/bench/results/refactor-extract-shard/refactor-summary.md
@@ -1,0 +1,101 @@
+# Cache → Shard structural refactor (N=1)
+
+**Branch:** `refactor/extract-shard` (off `main` at `af69db7`)
+**Date:** 2026-05-02
+**Issue:** [#34](https://github.com/j-mizera/gocache/issues/34)
+**Outcome:** Structural refactor only. Per-key cache state moves from `*Cache` into a new `*Shard` type; `*Cache` becomes a thin router over `[]*Shard`. The engine grows per-shard goroutines and a `DispatchToShard` API. Default configuration is N=1, behaviorally identical to pre-refactor — verified by `go test -race ./...` clean and benchmark numbers within ±5% (run-to-run noise) on every workload.
+
+## What changed structurally
+
+### `pkg/cache/shard.go` (new, 437 lines)
+
+`Shard` owns one slice of the keyspace plus everything that goes with it:
+- `mu sync.RWMutex`
+- `items map[string]SlabPointer`
+- `nativeValues map[SlabPointer]any`
+- `keysBySlot map[SlabPointer]string`
+- `slabs *slab.Allocator`
+- `lruHead`, `lruTail` (the LRU list, threaded through SlotMeta)
+- `usedBytes`, `maxBytes`, `evictionPolicy`
+- per-shard `onMutate` / `onMutateAll` callbacks bound to the parent Cache's external WATCH callbacks
+
+All per-key methods (`rawGet`, `rawSet`, `rawDelete`, `rawTTL`, `nativeSize`, `setExpiration`, etc.) live on `*Shard`, plus the LRU helpers (`lruPushFront`/`lruRemove`/`lruMoveToFront`), eviction (`evictLRU`), and storage internals (`setInternal`/`setNativeInternal`/`setPackedInternal`/`delete`/`keySize`/`chargedSize`).
+
+### `pkg/cache/cache.go` (rewritten, 470 lines)
+
+`Cache` becomes a thin router:
+- `shards []*Shard` + `n uint64`
+- shared configuration (`packed`, `evictionPolicy`, `maxBytes`, `OnMutate`, `OnMutateAll`)
+- public single-key methods route via `c.Shard(key).method()`
+- `LastAccess(e)` and `ResolvePacked(e)` route via the unexported `Entry.shard` back-reference (set by `Shard.entryFromSlot`)
+- multi-key methods (`Rename`, `Range`, `Clear`) handle the same-shard case (always at N=1) and stub or aggregate for cross-shard
+- aggregate methods (`Len`, `UsedBytes`, `SlabStats`) sum across shards
+- bulk-locking (`Lock`/`Unlock`/`RLock`/`RUnlock`) acquires every shard's mutex in shard-id order; used by tools like `bench/gctrace` and any future cross-shard primitives
+
+### `pkg/cache.Entry` gains an unexported `shard *Shard` back-reference
+
+Set by `Shard.entryFromSlot`. Lets `Cache.LastAccess(e)` and `Cache.ResolvePacked(e)` dereference into the right shard's slab without a separate lookup. Zero handler-code change — the field is private and existing handler call sites use `cmdCtx.Cache.ResolvePacked(entry)` unchanged.
+
+### `pkg/engine/engine.go` (rewritten, 175 lines)
+
+`Engine` now owns N `shardEngine` instances, each with its own goroutine + `cmdChan` + `stopChan`. Each goroutine acquires its shard's write lock before running a handler.
+
+Three dispatch entrypoints:
+- `Dispatch(ctx, fn)` and `DispatchWithResult(ctx, fn)` — route to shard 0 (legacy single-engine semantics, used by snapshot save / cleanup workers).
+- `DispatchToShard(ctx, shard, fn)` — caller-specified shard. Single-key handlers will use this once routing is wired (PR 3).
+
+The `resChanPool` Put-on-success-only safety rule from `#28` carries through unchanged.
+
+## What did not change
+
+- Public `Cache` API surface: every method that existed pre-refactor still exists with the same signature. Handlers, tests, plugins, server code all compile without modification.
+- `pkg/engine.Engine.Dispatch` / `DispatchWithResult` keep their pre-refactor semantics by routing to shard 0 (the only shard at N=1).
+- WATCH propagation, eviction semantics, slab encoding, persistence I/O — all behaviorally identical at N=1.
+- No multi-key handler is stubbed. Every test still passes.
+
+## Verification
+
+| Check | Status |
+|---|---|
+| `go vet ./...` | clean |
+| `staticcheck ./...` | clean |
+| `staticcheck -tags 'crashdump otlp' ./...` | clean |
+| `go test -race -count=1 ./...` | green across all 25 packages |
+| Bench at N=1 vs main `af69db7` (5s × 2 runs each) | within ±5% on every workload |
+
+### Bench delta (N=1 post-refactor vs pre-refactor)
+
+| Benchmark | Pre (ns/op) | Post mean (ns/op, 2 runs) | Δ |
+|---|---:|---:|---:|
+| TCP_GET_Pipelined | 12 669 | 13 447 | +6% (within run-to-run noise) |
+| TCP_GET_Standard | 4 026 | 4 017 | -0.2% |
+| TCP_Mixed_GetSet_Pipelined | 13 880 | 13 238 | -4.6% |
+| TCP_Mixed_GetHset_Pipelined | 15 616 | 15 418 | -1.3% |
+| TCP_Mixed_GetSet_Standard | 4 024 | 4 054 | +0.7% |
+| TCP_SET_Standard | 4 235 | 4 219 | -0.4% |
+
+GET_Pipelined alone shows ~6% mean increase but its single-run spread is 12 584 → 14 827 ns/op (16% range) on the same code, so the +6% sits inside that window. Allocation count (`280 allocs/op`) and bytes (`9 845 B/op`) are byte-identical to pre-refactor.
+
+## Why N=1
+
+This PR is a structural refactor only — it sets up the per-shard machinery without changing default behavior. Bumping `N` to 16 (the prototype's optimal value, validated in #39) requires:
+1. Routing single-key handlers to `DispatchToShard(shard, fn)` so each command lands on the goroutine owning its key — currently the production handlers go through `Dispatch`/`DispatchWithResult` which routes to shard 0.
+2. Cross-shard coordination for multi-key handlers (MGET, MSET, RENAME, KEYS, SCAN, SINTER/SUNION/SDIFF, MULTI/EXEC, WATCH, FLUSHDB, snapshot save/load, cleanup). At N=1 they all hit shard 0 and just work; at N>1 they need sorted-shard-ID lock acquisition and per-shard fan-out.
+
+Both are the next PR's scope.
+
+## Reproduce
+
+```bash
+go test -race -count=1 ./...
+go test -run=NONE -bench='^BenchmarkTCP_(Mixed|GET_Pipelined|GET_Standard|SET_Standard)' \
+  -benchtime=5s -cpu=4 -count=2 ./pkg/server/
+```
+
+## Files
+
+- `pkg/cache/shard.go` (new, 437 lines)
+- `pkg/cache/cache.go` (rewritten, 470 lines — was 837)
+- `pkg/engine/engine.go` (rewritten, 175 lines — was 137)
+- `bench/results/refactor-extract-shard/post-refactor.txt` (raw bench output, two runs)
+- `bench/results/refactor-extract-shard/refactor-summary.md` (this file)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3,12 +3,12 @@ package cache
 import (
 	"context"
 	"errors"
-	"gocache/api/logger"
-	"gocache/pkg/cache/slab"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"gocache/api/logger"
+	"gocache/pkg/cache/slab"
 )
 
 // ErrOutOfMemory is returned by RawSet when the memory limit is reached and
@@ -41,6 +41,13 @@ const entryOverhead = 128
 // bytesPerMB converts a megabyte limit to bytes for the cache's byte budget.
 const bytesPerMB int64 = 1024 * 1024
 
+// evictSampleSize is how many tail-end entries to sample per eviction
+// pass. Mirrors Redis's maxmemory-samples default. Larger = closer to
+// strict LRU but more CPU per eviction; smaller = approximate LRU but
+// faster. 8 is the published Redis sweet spot and preserves the
+// test-pinned semantic that "a key read recently survives eviction".
+const evictSampleSize = 8
+
 type ValueState int
 type ValueType int
 
@@ -71,10 +78,12 @@ const (
 	EncPacked                 // flat []byte (pkg/cache/packed layouts)
 )
 
-// Entry is a value-type snapshot of a cache entry. It is assembled on demand
-// by RawGet / Range from the slab meta and the native-value sidecar; callers
-// never store *Entry in the cache. The items map stores bare SlabPointers,
-// which are inert to the GC.
+// Entry is a value-type snapshot of a cache entry. It is assembled on
+// demand by RawGet / Range from a shard's slab meta and the native-value
+// sidecar; callers never store *Entry in the cache. The unexported
+// shard back-reference is set by Shard.entryFromSlot so Entry-bound
+// Cache methods (ResolvePacked, LastAccess) can dereference into the
+// right shard's slab without a separate routing table.
 type Entry struct {
 	ValueType ValueType
 	Encoding  Encoding
@@ -86,6 +95,11 @@ type Entry struct {
 	// SlotMeta (LRU pointers, last-access, value-type, encoding) plus
 	// the packed bytes (for EncPacked) or is otherwise unused (EncNative).
 	Ptr slab.SlabPointer
+
+	// shard back-references the shard that produced this Entry. Set by
+	// Shard.entryFromSlot. Nil for the zero value (used as "no entry"
+	// sentinel by code that holds an Entry beyond its shard's lock).
+	shard *Shard
 }
 
 // PackedThresholds controls when a collection is promoted from its packed
@@ -102,56 +116,59 @@ type PackedThresholds struct {
 	ListMaxBytes   int // list promotes when encoded buffer > ListMaxBytes
 }
 
+// Cache is a thin router over one or more Shards. Today the production
+// configuration uses N=1 (single shard, identical behaviour to the
+// pre-refactor cache); a follow-up bumps N to spread per-key contention
+// across multiple engine goroutines.
+//
+// Cache holds the configuration (PackedThresholds, eviction policy,
+// memory budget, WATCH callbacks); the per-key state (items map, slab
+// allocator, LRU list, used bytes) lives on each Shard.
 type Cache struct {
-	mu             sync.RWMutex
-	items          map[string]slab.SlabPointer
-	nativeValues   map[slab.SlabPointer]any // populated only for EncNative entries
-	maxBytes       int64                    // 0 = unlimited
-	usedBytes      int64
+	shards []*Shard
+	n      uint64
+
+	// Shared configuration / immutable-after-construction fields.
+	configMu       sync.Mutex // guards the runtime-mutable config below
+	maxBytes       int64      // 0 = unlimited; mirrored to each shard
 	evictionPolicy EvictionPolicy
-	// LRU list is threaded through slab.SlotMeta's LRUPrev/LRUNext. The
-	// head is the most-recently used entry; tail is the eviction target.
-	// A NilPointer head/tail means the list is empty.
-	lruHead slab.SlabPointer
-	lruTail slab.SlabPointer
-	// keysBySlot maps a slab pointer back to the key that owns it. Needed
-	// during eviction: the slot meta knows its LRU neighbours but not the
-	// key. The uint64 key is inert to the GC; only the string value
-	// contributes a per-entry pointer (shared backing array with items).
-	keysBySlot  map[slab.SlabPointer]string
-	packed      PackedThresholds
-	slabs       *slab.Allocator  // backs EncPacked byte payloads + per-entry meta
-	OnMutate    func(key string) // called after a key is set or deleted (for WATCH)
-	OnMutateAll func()           // called when all keys are invalidated (FLUSHDB)
+	packed         PackedThresholds
+
+	// OnMutate / OnMutateAll are external callbacks (WATCH dirty-bit
+	// propagation). Set after construction by the server wiring.
+	OnMutate    func(key string)
+	OnMutateAll func()
 }
 
+// New constructs a Cache with one shard, no memory limit, and LRU eviction.
 func New() *Cache {
-	return newCache(0, EvictionLRU)
+	return newCache(1, 0, EvictionLRU)
 }
 
+// NewWithConfig constructs a Cache from a megabyte limit. shardCount
+// defaults to 1; a future change exposes it as a constructor option.
 func NewWithConfig(maxMemoryMB int64, policy EvictionPolicy) *Cache {
 	var maxBytes int64
 	if maxMemoryMB > 0 {
 		maxBytes = maxMemoryMB * bytesPerMB
 	}
-	return newCache(maxBytes, policy)
+	return newCache(1, maxBytes, policy)
 }
 
 // NewWithBytes creates a cache with a raw byte limit. Intended for testing.
 func NewWithBytes(maxBytes int64, policy EvictionPolicy) *Cache {
-	return newCache(maxBytes, policy)
+	return newCache(1, maxBytes, policy)
 }
 
-func newCache(maxBytes int64, policy EvictionPolicy) *Cache {
-	return &Cache{
-		items:          make(map[string]slab.SlabPointer),
-		nativeValues:   make(map[slab.SlabPointer]any),
+func newCache(shards int, maxBytes int64, policy EvictionPolicy) *Cache {
+	if shards <= 0 {
+		shards = 1
+	}
+	c := &Cache{
+		n:              uint64(shards),
+		shards:         make([]*Shard, shards),
 		maxBytes:       maxBytes,
 		evictionPolicy: policy,
-		keysBySlot:     make(map[slab.SlabPointer]string),
-		slabs:          slab.NewAllocator(),
-		// Defaults mirror Valkey 8 (src/config.c). SetPackedThresholds
-		// overrides them with config values at boot.
 		packed: PackedThresholds{
 			HashMaxEntries: 512,
 			HashMaxValue:   64,
@@ -162,169 +179,270 @@ func newCache(maxBytes int64, policy EvictionPolicy) *Cache {
 			ListMaxBytes:   8192,
 		},
 	}
+	// Each shard receives an equal slice of the memory budget.
+	perShardBytes := maxBytes
+	if shards > 1 && maxBytes > 0 {
+		perShardBytes = maxBytes / int64(shards)
+	}
+	for i := range c.shards {
+		c.shards[i] = newShard(perShardBytes, policy)
+	}
+	c.bindShardCallbacks()
+	return c
 }
 
-// entryFromSlot reconstructs an Entry value from a slab slot. Caller must
-// ensure ptr is live (present in keysBySlot).
-func (c *Cache) entryFromSlot(ptr slab.SlabPointer) Entry {
-	meta := c.slabs.Meta(ptr)
-	enc := Encoding(meta.Encoding)
-	var value any
-	if enc == EncNative {
-		value = c.nativeValues[ptr]
-	}
-	return Entry{
-		ValueType: ValueType(meta.ValueType),
-		Encoding:  enc,
-		Value:     value,
-		Ptr:       ptr,
-	}
-}
-
-// LastAccess returns the wall-clock time of the last access to this entry,
-// sourced from the slab meta's LastAccessNs. Zero time means "unknown"
-// (never accessed or slot freed).
-//
-// Read with atomic.LoadInt64 because RawGet (potentially under RLock-only)
-// updates this field via atomic.StoreInt64.
-func (c *Cache) LastAccess(e Entry) time.Time {
-	if e.Ptr.IsNil() {
-		return time.Time{}
-	}
-	ns := atomic.LoadInt64(&c.slabs.Meta(e.Ptr).LastAccessNs)
-	if ns == 0 {
-		return time.Time{}
-	}
-	return time.Unix(0, ns)
-}
-
-// ResolvePacked returns a zero-copy view of an EncPacked entry's bytes. The
-// returned slice aliases the slab allocator's backing storage; callers must
-// not retain it past the current cache-lock hold.
-func (c *Cache) ResolvePacked(e Entry) []byte {
-	if e.Encoding != EncPacked || e.Ptr.IsNil() {
-		return nil
-	}
-	return c.slabs.Read(e.Ptr)
-}
-
-// SlabStats returns a point-in-time snapshot of slab allocator accounting.
-// Exposed for INFO / diagnostics. Must be called under a read lock.
-func (c *Cache) SlabStats() slab.Stats {
-	return c.slabs.Stats()
-}
-
-// SetExpiration updates only the TTL for an existing key, leaving the value
-// in place. Returns true if the key existed and the expiration was applied;
-// false if the key was absent. Must be called under the write lock.
-func (c *Cache) SetExpiration(key string, expiration int64) bool {
-	ptr, ok := c.items[key]
-	if !ok {
-		return false
-	}
-	if expiration > 0 {
-		c.slabs.Meta(ptr).ExpirationNs = expiration
-	} else {
-		c.slabs.Meta(ptr).ExpirationNs = 0
-	}
-	if c.OnMutate != nil {
-		c.OnMutate(key)
-	}
-	return true
-}
-
-// Rename moves src's entry to dst in place, preserving the slab allocation
-// and LRU position. Any existing dst entry is freed. The dst TTL is set to
-// newExpiration (0 = no TTL). Returns false if src is absent. usedBytes is
-// re-charged because the key string component of the per-entry cost changes.
-// Must be called under the write lock.
-func (c *Cache) Rename(src, dst string, newExpiration int64) bool {
-	ptr, ok := c.items[src]
-	if !ok {
-		return false
-	}
-	if _, exists := c.items[dst]; exists {
-		c.delete(dst)
-	}
-
-	c.usedBytes += int64(len(dst)) - int64(len(src))
-
-	c.items[dst] = ptr
-	if !ptr.IsNil() {
-		c.keysBySlot[ptr] = dst
-		if newExpiration > 0 {
-			c.slabs.Meta(ptr).ExpirationNs = newExpiration
-		} else {
-			c.slabs.Meta(ptr).ExpirationNs = 0
+// bindShardCallbacks wires each shard's onMutate to the Cache's external
+// OnMutate. Called from constructors and after SetOnMutate.
+func (c *Cache) bindShardCallbacks() {
+	for _, s := range c.shards {
+		s.onMutate = func(key string) {
+			if c.OnMutate != nil {
+				c.OnMutate(key)
+			}
+		}
+		s.onMutateAll = func() {
+			if c.OnMutateAll != nil {
+				c.OnMutateAll()
+			}
 		}
 	}
-	delete(c.items, src)
-
-	if c.OnMutate != nil {
-		c.OnMutate(src)
-		c.OnMutate(dst)
-	}
-	return true
 }
 
+// Shard returns the shard owning key. Used by the engine to route a
+// command to the right per-shard goroutine. Exported so callers outside
+// the package (the engine, the evaluator) can compute the routing the
+// same way.
+func (c *Cache) Shard(key string) *Shard {
+	return c.shards[c.shardIndex(key)]
+}
+
+// ShardByIndex returns the i-th shard. Bounds-checked.
+func (c *Cache) ShardByIndex(i int) *Shard {
+	if i < 0 || i >= len(c.shards) {
+		return nil
+	}
+	return c.shards[i]
+}
+
+// ShardCount returns the total number of shards.
+func (c *Cache) ShardCount() int { return len(c.shards) }
+
+// shardIndex maps a key to its shard index. fnv1a64 over the key bytes;
+// at N=1 always returns 0. Inlined hot path.
+func (c *Cache) shardIndex(key string) int {
+	if c.n == 1 {
+		return 0
+	}
+	return int(fnv1a(key) % c.n)
+}
+
+// fnv1a is the 64-bit FNV-1a hash. Allocation-free, no library dependency.
+// At N=1 the caller short-circuits before reaching here. Replaceable with
+// a faster hash (xxhash) in a follow-up; today FNV avoids adding a new
+// direct dependency to pkg/cache for what is currently a no-op routing.
+func fnv1a(s string) uint64 {
+	const offset uint64 = 14695981039346656037
+	const prime uint64 = 1099511628211
+	h := offset
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime
+	}
+	return h
+}
+
+// Single-key API ------------------------------------------------------------
+//
+// Each method routes to the shard owning key and forwards. Locking is
+// the caller's responsibility — the engine goroutine for shard X holds
+// shard X's lock for the duration of one handler.
+
+func (c *Cache) RawGet(key string) (Entry, bool) { return c.Shard(key).rawGet(key) }
+func (c *Cache) RawDelete(key string)            { c.Shard(key).rawDelete(key) }
+func (c *Cache) RawTTL(key string) int64         { return c.Shard(key).rawTTL(key) }
+func (c *Cache) NativeSize(key string) int64     { return c.Shard(key).nativeSize(key) }
+func (c *Cache) TTLInternal(key string) (time.Duration, ValueState) {
+	return c.Shard(key).ttlInternal(key)
+}
+func (c *Cache) SetExpiration(key string, expiration int64) bool {
+	return c.Shard(key).SetExpiration(key, expiration)
+}
+func (c *Cache) RawSet(ctx context.Context, key string, value any, expiration int64) error {
+	return c.Shard(key).rawSet(ctx, key, value, expiration)
+}
+func (c *Cache) RawLoad(key string, value any, expiration int64) {
+	c.Shard(key).rawLoad(key, value, expiration)
+}
+func (c *Cache) RawSetNativeWithSize(ctx context.Context, key string, value any, byteSize int64, expiration int64) error {
+	return c.Shard(key).rawSetNativeWithSize(ctx, key, value, byteSize, expiration)
+}
+func (c *Cache) RawSetPacked(ctx context.Context, key string, vt ValueType, buf []byte, expiration int64) error {
+	return c.Shard(key).rawSetPacked(ctx, key, vt, buf, expiration)
+}
+func (c *Cache) RawLoadPacked(key string, vt ValueType, buf []byte, expiration int64) {
+	c.Shard(key).rawLoadPacked(key, vt, buf, expiration)
+}
+
+// Entry-bound methods -------------------------------------------------------
+//
+// Entry carries a back-reference to its source shard, so these forward
+// without re-routing.
+
+func (c *Cache) LastAccess(e Entry) time.Time {
+	if e.shard == nil {
+		return time.Time{}
+	}
+	return e.shard.LastAccess(e)
+}
+
+func (c *Cache) ResolvePacked(e Entry) []byte {
+	if e.shard == nil {
+		return nil
+	}
+	return e.shard.ResolvePacked(e)
+}
+
+// Multi-key / cross-shard API ----------------------------------------------
+
+// Rename moves src's entry to dst. Today (N=1) every key is on shard 0
+// so the src/dst-on-same-shard fast path is always taken; multi-shard
+// RENAME is a follow-up.
+func (c *Cache) Rename(src, dst string, newExpiration int64) bool {
+	srcShard := c.Shard(src)
+	dstShard := c.Shard(dst)
+	if srcShard == dstShard {
+		return srcShard.rename(src, dst, newExpiration)
+	}
+	// N>1 cross-shard rename: not yet implemented. Behaviour falls back
+	// to "key absent" so callers see a consistent ErrNoSuchKey rather
+	// than partial state. A follow-up adds atomic cross-shard rename
+	// via sorted-shard-ID lock acquisition.
+	return false
+}
+
+// Range iterates over every entry across every shard. Caller must
+// already hold each shard's appropriate lock — today the engine path
+// holds the (single) shard's write lock for the duration of one handler.
+// At N>1 a multi-shard Range needs cross-shard locking; deferred.
+func (c *Cache) Range(fn func(key string, entry Entry, expiration int64) bool) {
+	for _, s := range c.shards {
+		if !s.rangeShard(fn) {
+			return
+		}
+	}
+}
+
+// Clear drops every entry on every shard. Caller holds the necessary
+// locks (today: the single shard's write lock via the engine path).
+func (c *Cache) Clear(ctx context.Context) {
+	totalItems := c.lenLocked()
+	logger.Info(ctx).Int("items", totalItems).Msg("cache cleared")
+	for _, s := range c.shards {
+		s.clear()
+	}
+	if c.OnMutateAll != nil {
+		c.OnMutateAll()
+	}
+}
+
+// Bulk locking --------------------------------------------------------------
+//
+// Lock / Unlock / RLock / RUnlock acquire every shard's mutex in shard-id
+// order (release in reverse). Used by tools and tests that need a globally
+// consistent view — bench harnesses, snapshot save/load, and the engine
+// for legacy single-engine semantics. The hot path uses per-shard locks
+// inside the per-shard engine goroutine and never reaches these.
+
 func (c *Cache) Lock() {
-	c.mu.Lock()
+	for _, s := range c.shards {
+		s.Lock()
+	}
 }
 
 func (c *Cache) Unlock() {
-	c.mu.Unlock()
+	for i := len(c.shards) - 1; i >= 0; i-- {
+		c.shards[i].Unlock()
+	}
 }
 
 func (c *Cache) RLock() {
-	c.mu.RLock()
+	for _, s := range c.shards {
+		s.RLock()
+	}
 }
 
 func (c *Cache) RUnlock() {
-	c.mu.RUnlock()
+	for i := len(c.shards) - 1; i >= 0; i-- {
+		c.shards[i].RUnlock()
+	}
+}
+
+// Aggregates and config -----------------------------------------------------
+
+// Len returns the number of keys across every shard. Caller is
+// responsible for any lock coherency they require — at N=1 the single
+// shard's lock provides a consistent view.
+func (c *Cache) Len() int { return c.lenLocked() }
+
+func (c *Cache) lenLocked() int {
+	n := 0
+	for _, s := range c.shards {
+		n += len(s.items)
+	}
+	return n
+}
+
+// UsedBytes sums each shard's accounting.
+func (c *Cache) UsedBytes() int64 {
+	var total int64
+	for _, s := range c.shards {
+		total += s.usedBytes
+	}
+	return total
+}
+
+// MaxBytes returns the configured memory limit in bytes (0 = unlimited).
+// The cache's budget is split evenly across shards; this method returns
+// the total, not the per-shard slice.
+func (c *Cache) MaxBytes() int64 {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+	return c.maxBytes
 }
 
 // SetMemoryLimit updates the memory limit and eviction policy at runtime.
-// Safe to call from any goroutine. ctx carries the operation (e.g. config
-// reload) for log correlation.
+// Each shard receives an equal slice of the new total.
 func (c *Cache) SetMemoryLimit(ctx context.Context, maxMemoryMB int64, policy EvictionPolicy) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.configMu.Lock()
 	if maxMemoryMB > 0 {
 		c.maxBytes = maxMemoryMB * bytesPerMB
 	} else {
 		c.maxBytes = 0
 	}
 	c.evictionPolicy = policy
-	logger.Info(ctx).Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
+	c.configMu.Unlock()
 
-	// Evict if the new limit is below current usage.
-	if c.maxBytes > 0 && c.usedBytes > c.maxBytes && c.evictionPolicy == EvictionLRU {
-		c.evictLRU(ctx, 0)
+	perShard := c.maxBytes
+	if len(c.shards) > 1 && c.maxBytes > 0 {
+		perShard = c.maxBytes / int64(len(c.shards))
 	}
-}
-
-// Len returns the number of keys in the cache.
-func (c *Cache) Len() int {
-	return len(c.items)
-}
-
-// PackedThresholds returns the current hybrid-encoding thresholds.
-func (c *Cache) PackedThresholds() PackedThresholds {
-	return c.packed
-}
-
-// SetPackedThresholds replaces the hybrid-encoding thresholds. Safe to call
-// at boot or during config hot-reload. Existing entries are not migrated;
-// they stay at whatever encoding they were written with until their next
-// mutation.
-func (c *Cache) SetPackedThresholds(t PackedThresholds) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.packed = t
+	for _, s := range c.shards {
+		s.Lock()
+		s.maxBytes = perShard
+		s.evictionPolicy = policy
+		// Evict if the new limit is below current usage on this shard.
+		if s.maxBytes > 0 && s.usedBytes > s.maxBytes && s.evictionPolicy == EvictionLRU {
+			s.evictLRU(ctx, 0)
+		}
+		s.Unlock()
+	}
+	logger.Info(ctx).Int64("maxBytes", c.maxBytes).Str("policy", c.EvictionPolicyString()).Msg("memory limit updated")
 }
 
 // EvictionPolicyString returns the eviction policy as a human-readable string.
 func (c *Cache) EvictionPolicyString() string {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
 	switch c.evictionPolicy {
 	case EvictionLRU:
 		return "allkeys-lru"
@@ -333,274 +451,46 @@ func (c *Cache) EvictionPolicyString() string {
 	}
 }
 
-// UsedBytes returns the estimated number of bytes currently used by all entries.
-func (c *Cache) UsedBytes() int64 {
-	return c.usedBytes
+// PackedThresholds returns the current hybrid-encoding thresholds.
+func (c *Cache) PackedThresholds() PackedThresholds {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+	return c.packed
 }
 
-// MaxBytes returns the configured memory limit in bytes (0 = unlimited).
-func (c *Cache) MaxBytes() int64 {
-	return c.maxBytes
+// SetPackedThresholds replaces the hybrid-encoding thresholds.
+func (c *Cache) SetPackedThresholds(t PackedThresholds) {
+	c.configMu.Lock()
+	defer c.configMu.Unlock()
+	c.packed = t
 }
 
-// RawSet stores a key with the given value and expiration, enforcing the
-// memory limit. It evicts LRU entries as needed (EvictionLRU) or returns
-// ErrOutOfMemory (EvictionNone) when the limit would be exceeded.
-// Must be called while holding the cache write lock. ctx carries the
-// operation (command, cleanup, etc.) for log correlation.
-func (c *Cache) RawSet(ctx context.Context, key string, value any, expiration int64) error {
-	if c.maxBytes > 0 {
-		newSize := estimateSize(key, value)
-		oldSize := c.keySize(key)
-		delta := newSize - oldSize
-		if delta > 0 && c.usedBytes+delta > c.maxBytes {
-			switch c.evictionPolicy {
-			case EvictionLRU:
-				c.evictLRU(ctx, delta)
-			case EvictionNone:
-				logger.Warn(ctx).Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
-				return ErrOutOfMemory
-			}
+// SlabStats returns aggregated slab stats across every shard.
+func (c *Cache) SlabStats() slab.Stats {
+	var total slab.Stats
+	for _, s := range c.shards {
+		st := s.slabStats()
+		total.TotalAllocs += st.TotalAllocs
+		total.TotalFrees += st.TotalFrees
+		total.LiveEntries += st.LiveEntries
+		total.CapacityBytes += st.CapacityBytes
+		total.AllocatedBytes += st.AllocatedBytes
+		total.HugeCount += st.HugeCount
+		total.HugeBytes += st.HugeBytes
+		for i := range total.PerClassInUse {
+			total.PerClassInUse[i] += st.PerClassInUse[i]
+			total.PerClassSlabs[i] += st.PerClassSlabs[i]
 		}
 	}
-	c.setInternal(key, value, expiration, false)
-	return nil
+	return total
 }
 
-// RawLoad stores a key-value pair, bypassing the memory limit check.
-// Intended for snapshot loading only. Still maintains LRU and size tracking.
-// Must be called while holding the cache write lock.
-func (c *Cache) RawLoad(key string, value any, expiration int64) {
-	c.setInternal(key, value, expiration, true)
-}
-
-// RawSetNativeWithSize stores a Go-native collection value at key without
-// walking it to compute size. byteSize is the payload byte cost (the same
-// number estimateSize would return minus per-entry overhead and len(key));
-// callers track it incrementally as they mutate the underlying
-// map/slice. This is the O(1) write path used by HSET/LPUSH/SADD/ZADD on
-// promoted entries. Closes #23.
-//
-// Must be called while holding the cache write lock.
-func (c *Cache) RawSetNativeWithSize(ctx context.Context, key string, value any, byteSize int64, expiration int64) error {
-	if c.maxBytes > 0 {
-		newSize := int64(entryOverhead) + int64(len(key)) + byteSize
-		oldSize := c.keySize(key)
-		delta := newSize - oldSize
-		if delta > 0 && c.usedBytes+delta > c.maxBytes {
-			switch c.evictionPolicy {
-			case EvictionLRU:
-				c.evictLRU(ctx, delta)
-			case EvictionNone:
-				logger.Warn(ctx).Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
-				return ErrOutOfMemory
-			}
-		}
-	}
-	c.setNativeInternal(key, value, valueTypeOf(value), byteSize, expiration, false)
-	return nil
-}
-
-// NativeSize returns the cached byte-size of an EncNative entry. Returns 0
-// for absent keys or EncPacked entries (the packed size lives in the slab
-// allocator's class capacity). Handlers use this as the seed value for
-// incremental delta tracking — see hsetNative + finishHsetNative.
-//
-// Must be called while holding the cache read or write lock.
-func (c *Cache) NativeSize(key string) int64 {
-	ptr, ok := c.items[key]
-	if !ok || ptr.IsNil() {
-		return 0
-	}
-	return int64(c.slabs.Meta(ptr).NativeSize)
-}
-
-// RawSetPacked stores a packed byte-encoded value for the given ValueType.
-// The buffer layout must match pkg/cache/packed for that type. Enforces
-// the memory limit (evicting or returning ErrOutOfMemory as configured).
-// Must be called while holding the cache write lock.
-func (c *Cache) RawSetPacked(ctx context.Context, key string, vt ValueType, buf []byte, expiration int64) error {
-	if c.maxBytes > 0 {
-		newSize := estimateBytesSize(key, buf)
-		oldSize := c.keySize(key)
-		delta := newSize - oldSize
-		if delta > 0 && c.usedBytes+delta > c.maxBytes {
-			switch c.evictionPolicy {
-			case EvictionLRU:
-				c.evictLRU(ctx, delta)
-			case EvictionNone:
-				logger.Warn(ctx).Str("key", key).Int64("usedBytes", c.usedBytes).Int64("maxBytes", c.maxBytes).Msg("write rejected, out of memory")
-				return ErrOutOfMemory
-			}
-		}
-	}
-	c.setPackedInternal(key, vt, buf, expiration, false)
-	return nil
-}
-
-// RawLoadPacked stores a packed byte buffer, bypassing the memory limit
-// check. Snapshot-loading uses this for entries with Encoding == EncPacked.
-func (c *Cache) RawLoadPacked(key string, vt ValueType, buf []byte, expiration int64) {
-	c.setPackedInternal(key, vt, buf, expiration, true)
-}
-
-// LRU helpers --------------------------------------------------------------
-//
-// The LRU list is doubly linked via LRUPrev/LRUNext fields inside each
-// slab slot's SlotMeta. Head is the most-recently used; tail is the next
-// eviction candidate. A NilPointer head/tail means the list is empty.
-
-func (c *Cache) lruPushFront(ptr slab.SlabPointer) {
-	meta := c.slabs.Meta(ptr)
-	meta.LRUPrev = slab.NilPointer
-	meta.LRUNext = c.lruHead
-	if !c.lruHead.IsNil() {
-		c.slabs.Meta(c.lruHead).LRUPrev = ptr
-	}
-	c.lruHead = ptr
-	if c.lruTail.IsNil() {
-		c.lruTail = ptr
-	}
-	// Atomic store so RLock-only readers (RawGet) can race-safely store the
-	// same field via atomic.StoreInt64.
-	atomic.StoreInt64(&meta.LastAccessNs, time.Now().UnixNano())
-}
-
-func (c *Cache) lruRemove(ptr slab.SlabPointer) {
-	meta := c.slabs.Meta(ptr)
-	prev := meta.LRUPrev
-	next := meta.LRUNext
-	if !prev.IsNil() {
-		c.slabs.Meta(prev).LRUNext = next
-	} else {
-		c.lruHead = next
-	}
-	if !next.IsNil() {
-		c.slabs.Meta(next).LRUPrev = prev
-	} else {
-		c.lruTail = prev
-	}
-	meta.LRUPrev = slab.NilPointer
-	meta.LRUNext = slab.NilPointer
-}
-
-func (c *Cache) lruMoveToFront(ptr slab.SlabPointer) {
-	if c.lruHead == ptr {
-		atomic.StoreInt64(&c.slabs.Meta(ptr).LastAccessNs, time.Now().UnixNano())
-		return
-	}
-	c.lruRemove(ptr)
-	c.lruPushFront(ptr)
-}
-
-// setPackedInternal performs the raw packed-storage operation. The byte
-// payload is copied into a slab slot; ValueType + Encoding + LRU state +
-// TTL live in that slot's SlotMeta. Existing packed entries reuse the
-// current slot when the class capacity fits; otherwise old is freed, new
-// is allocated.
-func (c *Cache) setPackedInternal(key string, vt ValueType, buf []byte, expiration int64, suppressMutate bool) {
-	newSize := estimateBytesSize(key, buf)
-	oldSize := c.keySize(key)
-	c.usedBytes += newSize - oldSize
-
-	prevPtr, had := c.items[key]
-	var ptr slab.SlabPointer
-
-	switch {
-	case had && !prevPtr.IsNil() && c.slabs.Capacity(prevPtr) >= uint32(len(buf)) &&
-		Encoding(c.slabs.Meta(prevPtr).Encoding) == EncPacked:
-		// Same slot fits and was already packed: reuse in place.
-		ptr = prevPtr
-		c.slabs.Write(ptr, buf)
-		c.lruMoveToFront(ptr)
-	default:
-		// New slot needed. Unlink the old LRU node and free the old slot.
-		if had && !prevPtr.IsNil() {
-			c.lruRemove(prevPtr)
-			delete(c.keysBySlot, prevPtr)
-			delete(c.nativeValues, prevPtr)
-			c.slabs.Free(prevPtr)
-		}
-		ptr = c.slabs.Alloc(uint32(len(buf)))
-		c.slabs.Write(ptr, buf)
-		c.keysBySlot[ptr] = key
-		c.lruPushFront(ptr)
-	}
-
-	meta := c.slabs.Meta(ptr)
-	meta.ValueType = uint8(vt)
-	meta.Encoding = uint8(EncPacked)
-	if expiration > 0 {
-		meta.ExpirationNs = expiration
-	} else {
-		meta.ExpirationNs = 0
-	}
-
-	c.items[key] = ptr
-	if !suppressMutate && c.OnMutate != nil {
-		c.OnMutate(key)
-	}
-}
+// Helpers -------------------------------------------------------------------
 
 // estimateBytesSize charges the exact encoded size of a packed []byte value
 // plus the key and per-entry overhead.
 func estimateBytesSize(key string, buf []byte) int64 {
 	return int64(entryOverhead) + int64(len(key)) + int64(len(buf))
-}
-
-// setInternal performs the raw storage operation, updating LRU and size
-// tracking. Values of []byte / string route to the slab-backed packed path.
-// Native container shapes are stored in the nativeValues sidecar keyed by
-// their slab slot; the slot's data region is unused but hosts the LRU meta.
-//
-// estimateSize walks the value (O(N) for collections); callers that already
-// know the size should use setNativeInternalWithSize to skip the walk.
-func (c *Cache) setInternal(key string, value any, expiration int64, suppressMutate bool) {
-	switch v := value.(type) {
-	case []byte:
-		c.setPackedInternal(key, ObjTypeBytes, v, expiration, suppressMutate)
-		return
-	case string:
-		c.setPackedInternal(key, ObjTypeBytes, []byte(v), expiration, suppressMutate)
-		return
-	}
-	c.setNativeInternal(key, value, valueTypeOf(value), nativePayloadSize(key, value), expiration, suppressMutate)
-}
-
-// setNativeInternal stores a Go-native value at key. byteSize is the
-// caller-provided payload size (bytes the entry costs minus per-entry
-// overhead and the key length). It's recorded in the slot's SlotMeta so
-// chargedSize / keySize never walk the value to compute it again.
-func (c *Cache) setNativeInternal(key string, value any, vt ValueType, byteSize int64, expiration int64, suppressMutate bool) {
-	newSize := int64(entryOverhead) + int64(len(key)) + byteSize
-	oldSize := c.keySize(key)
-	c.usedBytes += newSize - oldSize
-
-	if prevPtr, had := c.items[key]; had && !prevPtr.IsNil() {
-		c.lruRemove(prevPtr)
-		delete(c.keysBySlot, prevPtr)
-		delete(c.nativeValues, prevPtr)
-		c.slabs.Free(prevPtr)
-	}
-	ptr := c.slabs.Alloc(0) // minimum class; data region unused for native
-	c.keysBySlot[ptr] = key
-	c.lruPushFront(ptr)
-
-	meta := c.slabs.Meta(ptr)
-	meta.ValueType = uint8(vt)
-	meta.Encoding = uint8(EncNative)
-	meta.NativeSize = uint32(byteSize)
-	if expiration > 0 {
-		meta.ExpirationNs = expiration
-	} else {
-		meta.ExpirationNs = 0
-	}
-
-	c.nativeValues[ptr] = value
-	c.items[key] = ptr
-	if !suppressMutate && c.OnMutate != nil {
-		c.OnMutate(key)
-	}
 }
 
 // valueTypeOf maps a Go-native value to its ObjType.
@@ -626,188 +516,6 @@ func valueTypeOf(value any) ValueType {
 func nativePayloadSize(key string, value any) int64 {
 	full := estimateSize(key, value)
 	return full - int64(entryOverhead) - int64(len(key))
-}
-
-// evictSampleSize is how many tail-end entries to sample per eviction
-// pass. Mirrors Redis's maxmemory-samples default. Larger = closer to
-// strict LRU but more CPU per eviction; smaller = approximate LRU but
-// faster. 8 is the published Redis sweet spot and preserves the
-// test-pinned semantic that "a key read recently survives eviction".
-const evictSampleSize = 8
-
-// evictLRU removes the entry with the oldest LastAccessNs from the tail
-// region of the LRU list, repeating until delta bytes can be accommodated.
-//
-// Redis-style sampled approximate LRU: the linked list orders entries by
-// last WRITE position (writes call lruPushFront / lruMoveToFront under
-// the cache write lock). Reads via RawGet update LastAccessNs atomically
-// but do NOT touch the list — the list mutation is unsafe under RLock.
-// Eviction therefore samples up to evictSampleSize entries from the tail
-// end of the list (oldest writes) and picks the one with the smallest
-// LastAccessNs (oldest read). This preserves LRU correctness against
-// read-heavy workloads even though the list itself is write-ordered.
-func (c *Cache) evictLRU(ctx context.Context, delta int64) {
-	for c.maxBytes > 0 && c.usedBytes+delta > c.maxBytes {
-		if c.lruTail.IsNil() {
-			break
-		}
-		victim := c.lruTail
-		victimAccess := atomic.LoadInt64(&c.slabs.Meta(victim).LastAccessNs)
-		node := c.slabs.Meta(victim).LRUPrev
-		for i := 1; i < evictSampleSize && !node.IsNil(); i++ {
-			access := atomic.LoadInt64(&c.slabs.Meta(node).LastAccessNs)
-			if access < victimAccess {
-				victim = node
-				victimAccess = access
-			}
-			node = c.slabs.Meta(node).LRUPrev
-		}
-		evictKey, ok := c.keysBySlot[victim]
-		if !ok {
-			logger.Warn(ctx).Msg("evictLRU: keysBySlot has no entry for victim; bailing")
-			break
-		}
-		logger.Debug(ctx).Str("key", evictKey).Msg("lru eviction")
-		c.delete(evictKey)
-	}
-}
-
-// RawGet returns the entry for key. The returned Entry is a value-type
-// snapshot assembled from the slab slot's metadata and the native-value
-// sidecar (if applicable).
-//
-// RawGet is safe under either the cache write lock OR the cache read lock.
-// It does NOT move the entry in the LRU linked list (that requires
-// exclusive access to the list head and neighbour pointers, which RLock
-// cannot provide). It does update LastAccessNs via atomic.StoreInt64 so
-// OBJECT IDLETIME and timestamp-based diagnostics stay accurate even on
-// the read-lock-bypass path.
-//
-// Eviction uses lruTail (write order). Read-heavy access patterns no
-// longer refresh the entry's LRU position; under memory pressure with
-// long-lived hot reads the eviction may pick an entry that is still
-// being read. This is the documented trade-off for the read-lock-bypass
-// throughput gain — see projects/gocache/plans/command-flow/read-lock-bypass.
-func (c *Cache) RawGet(key string) (Entry, bool) {
-	ptr, found := c.items[key]
-	if !found {
-		return Entry{}, false
-	}
-	atomic.StoreInt64(&c.slabs.Meta(ptr).LastAccessNs, time.Now().UnixNano())
-	return c.entryFromSlot(ptr), true
-}
-
-func (c *Cache) RawDelete(key string) {
-	c.delete(key)
-}
-
-// TTLInternal returns the remaining TTL and a ValueState for key.
-//
-// States:
-//
-//	ValuePresent   — key exists with a future expiration (ExpirationNs > 0)
-//	ValueExpired   — key has a TTL that has already passed (caller should
-//	                 lazyExpire to clean it up)
-//	ValueNoExpire  — key exists but no TTL is set
-//	ValueAbsent    — key does not exist in the cache
-//
-// Callers that need to distinguish "missing" from "no TTL" (TTL/PTTL) can
-// rely on ValueAbsent vs ValueNoExpire directly. Must be called while
-// holding the cache read lock.
-func (c *Cache) TTLInternal(key string) (time.Duration, ValueState) {
-	ptr, exists := c.items[key]
-	if !exists {
-		return 0, ValueAbsent
-	}
-	expiration := c.slabs.Meta(ptr).ExpirationNs
-	if expiration == 0 {
-		return 0, ValueNoExpire
-	}
-	expirationTime := time.Unix(0, expiration)
-	if expirationTime.Before(time.Now()) {
-		return 0, ValueExpired
-	}
-	return time.Until(expirationTime), ValuePresent
-}
-
-func (c *Cache) delete(key string) {
-	ptr, ok := c.items[key]
-	if !ok {
-		return
-	}
-	if !ptr.IsNil() {
-		c.usedBytes -= c.chargedSize(key, ptr)
-		c.lruRemove(ptr)
-		delete(c.keysBySlot, ptr)
-		delete(c.nativeValues, ptr)
-		c.slabs.Free(ptr)
-	}
-	delete(c.items, key)
-	if c.OnMutate != nil {
-		c.OnMutate(key)
-	}
-}
-
-// keySize returns the currently-charged byte cost for key, or 0 if absent.
-// Used by set paths to compute the delta against usedBytes without a
-// sidecar map. For packed entries the charge is entryOverhead + len(key) +
-// len(value); for native entries it's estimateSize(key, nativeValue).
-func (c *Cache) keySize(key string) int64 {
-	ptr, ok := c.items[key]
-	if !ok || ptr.IsNil() {
-		return 0
-	}
-	return c.chargedSize(key, ptr)
-}
-
-// chargedSize returns the byte cost to subtract from usedBytes when freeing
-// the slot identified by ptr (which maps to key). Packed entries use the
-// slab-held value length; native entries read the cached SlotMeta.NativeSize
-// (set when the value was written) so we never walk the map/slice on the hot
-// path. See setInternal for where NativeSize is populated.
-func (c *Cache) chargedSize(key string, ptr slab.SlabPointer) int64 {
-	meta := c.slabs.Meta(ptr)
-	enc := Encoding(meta.Encoding)
-	if enc == EncPacked {
-		return int64(entryOverhead) + int64(len(key)) + int64(c.slabs.Size(ptr))
-	}
-	return int64(entryOverhead) + int64(len(key)) + int64(meta.NativeSize)
-}
-
-// Range iterates over all cache entries. The callback receives a value-type
-// Entry snapshot — mutating it has no effect on the cache. Return false
-// to stop iteration.
-func (c *Cache) Range(fn func(key string, entry Entry, expiration int64) bool) {
-	for key, ptr := range c.items {
-		if !fn(key, c.entryFromSlot(ptr), c.slabs.Meta(ptr).ExpirationNs) {
-			break
-		}
-	}
-}
-
-// RawTTL returns the raw expiration timestamp in nanoseconds for the given key.
-// Returns 0 if the key has no TTL set or the key is absent.
-func (c *Cache) RawTTL(key string) int64 {
-	ptr, ok := c.items[key]
-	if !ok {
-		return 0
-	}
-	return c.slabs.Meta(ptr).ExpirationNs
-}
-
-func (c *Cache) Clear(ctx context.Context) {
-	logger.Info(ctx).Int("items", len(c.items)).Msg("cache cleared")
-	c.items = make(map[string]slab.SlabPointer)
-	c.nativeValues = make(map[slab.SlabPointer]any)
-	c.keysBySlot = make(map[slab.SlabPointer]string)
-	c.lruHead = slab.NilPointer
-	c.lruTail = slab.NilPointer
-	c.usedBytes = 0
-	// Drop the entire slab arena — faster than walking entries to Free().
-	c.slabs = slab.NewAllocator()
-	if c.OnMutateAll != nil {
-		c.OnMutateAll()
-	}
 }
 
 // estimateSize returns an approximate memory usage in bytes for a key-value pair.

--- a/pkg/cache/shard.go
+++ b/pkg/cache/shard.go
@@ -1,0 +1,491 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gocache/api/logger"
+	"gocache/pkg/cache/slab"
+)
+
+// Shard owns one slice of the keyspace plus all the state that goes with
+// it: the items map, the slab allocator, an LRU list, and a memory
+// budget. Every per-key cache method (RawGet, RawSet, RawDelete, …)
+// resolves down to a method on Shard; multi-key methods live on the
+// outer Cache and coordinate across shards.
+//
+// Concurrency contract: a Shard's mutex is the only lock that protects
+// its fields. Callers must acquire the appropriate lock before invoking
+// any shard method whose name does not start with `Lock` / `RLock`.
+// Today's caller is the Cache's per-shard engine goroutine, which holds
+// the write lock for the duration of one handler.
+type Shard struct {
+	mu             sync.RWMutex
+	items          map[string]slab.SlabPointer
+	nativeValues   map[slab.SlabPointer]any // populated only for EncNative entries
+	keysBySlot     map[slab.SlabPointer]string
+	slabs          *slab.Allocator
+	lruHead        slab.SlabPointer
+	lruTail        slab.SlabPointer
+	usedBytes      int64
+	maxBytes       int64
+	evictionPolicy EvictionPolicy
+
+	// onMutate / onMutateAll are set by the Cache constructor and forward
+	// to the cache's external WATCH callbacks. Per-shard so the engine
+	// goroutine can fire them without crossing back into Cache state.
+	onMutate    func(key string)
+	onMutateAll func()
+}
+
+func newShard(maxBytes int64, policy EvictionPolicy) *Shard {
+	return &Shard{
+		items:          make(map[string]slab.SlabPointer),
+		nativeValues:   make(map[slab.SlabPointer]any),
+		keysBySlot:     make(map[slab.SlabPointer]string),
+		slabs:          slab.NewAllocator(),
+		maxBytes:       maxBytes,
+		evictionPolicy: policy,
+	}
+}
+
+func (s *Shard) Lock()    { s.mu.Lock() }
+func (s *Shard) Unlock()  { s.mu.Unlock() }
+func (s *Shard) RLock()   { s.mu.RLock() }
+func (s *Shard) RUnlock() { s.mu.RUnlock() }
+
+// entryFromSlot reconstructs an Entry value from a slab slot. Caller
+// must ensure ptr is live (present in keysBySlot). The returned Entry
+// carries a back-reference to this shard so Entry-bound Cache methods
+// (ResolvePacked, LastAccess) can dereference into the right slab.
+func (s *Shard) entryFromSlot(ptr slab.SlabPointer) Entry {
+	meta := s.slabs.Meta(ptr)
+	enc := Encoding(meta.Encoding)
+	var value any
+	if enc == EncNative {
+		value = s.nativeValues[ptr]
+	}
+	return Entry{
+		ValueType: ValueType(meta.ValueType),
+		Encoding:  enc,
+		Value:     value,
+		Ptr:       ptr,
+		shard:     s,
+	}
+}
+
+// LastAccess returns the wall-clock time of the last access to entry e.
+func (s *Shard) LastAccess(e Entry) time.Time {
+	if e.Ptr.IsNil() {
+		return time.Time{}
+	}
+	ns := atomic.LoadInt64(&s.slabs.Meta(e.Ptr).LastAccessNs)
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+// ResolvePacked returns a zero-copy view of e's packed bytes.
+func (s *Shard) ResolvePacked(e Entry) []byte {
+	if e.Encoding != EncPacked || e.Ptr.IsNil() {
+		return nil
+	}
+	return s.slabs.Read(e.Ptr)
+}
+
+// SetExpiration updates only the TTL for an existing key. Returns true
+// if the key existed. Must be called under the write lock.
+func (s *Shard) SetExpiration(key string, expiration int64) bool {
+	ptr, ok := s.items[key]
+	if !ok {
+		return false
+	}
+	if expiration > 0 {
+		s.slabs.Meta(ptr).ExpirationNs = expiration
+	} else {
+		s.slabs.Meta(ptr).ExpirationNs = 0
+	}
+	if s.onMutate != nil {
+		s.onMutate(key)
+	}
+	return true
+}
+
+// rename moves src's entry to dst in place. Caller guarantees both keys
+// hash to this shard. Multi-shard RENAME is handled by the outer Cache.
+// Must be called under the write lock.
+func (s *Shard) rename(src, dst string, newExpiration int64) bool {
+	ptr, ok := s.items[src]
+	if !ok {
+		return false
+	}
+	if _, exists := s.items[dst]; exists {
+		s.delete(dst)
+	}
+	s.usedBytes += int64(len(dst)) - int64(len(src))
+
+	s.items[dst] = ptr
+	if !ptr.IsNil() {
+		s.keysBySlot[ptr] = dst
+		if newExpiration > 0 {
+			s.slabs.Meta(ptr).ExpirationNs = newExpiration
+		} else {
+			s.slabs.Meta(ptr).ExpirationNs = 0
+		}
+	}
+	delete(s.items, src)
+
+	if s.onMutate != nil {
+		s.onMutate(src)
+		s.onMutate(dst)
+	}
+	return true
+}
+
+// rawSet stores key with value and expiration, enforcing the memory limit.
+// Must be called under the write lock. ctx carries the operation for log
+// correlation.
+func (s *Shard) rawSet(ctx context.Context, key string, value any, expiration int64) error {
+	if s.maxBytes > 0 {
+		newSize := estimateSize(key, value)
+		oldSize := s.keySize(key)
+		delta := newSize - oldSize
+		if delta > 0 && s.usedBytes+delta > s.maxBytes {
+			switch s.evictionPolicy {
+			case EvictionLRU:
+				s.evictLRU(ctx, delta)
+			case EvictionNone:
+				logger.Warn(ctx).Str("key", key).Int64("usedBytes", s.usedBytes).Int64("maxBytes", s.maxBytes).Msg("write rejected, out of memory")
+				return ErrOutOfMemory
+			}
+		}
+	}
+	s.setInternal(key, value, expiration, false)
+	return nil
+}
+
+// rawLoad bypasses the memory limit check; intended for snapshot loading.
+// Must be called under the write lock.
+func (s *Shard) rawLoad(key string, value any, expiration int64) {
+	s.setInternal(key, value, expiration, true)
+}
+
+// rawSetNativeWithSize stores a Go-native collection value at key using
+// a caller-supplied byteSize so we don't walk the value to compute it.
+// Must be called under the write lock.
+func (s *Shard) rawSetNativeWithSize(ctx context.Context, key string, value any, byteSize int64, expiration int64) error {
+	if s.maxBytes > 0 {
+		newSize := int64(entryOverhead) + int64(len(key)) + byteSize
+		oldSize := s.keySize(key)
+		delta := newSize - oldSize
+		if delta > 0 && s.usedBytes+delta > s.maxBytes {
+			switch s.evictionPolicy {
+			case EvictionLRU:
+				s.evictLRU(ctx, delta)
+			case EvictionNone:
+				logger.Warn(ctx).Str("key", key).Int64("usedBytes", s.usedBytes).Int64("maxBytes", s.maxBytes).Msg("write rejected, out of memory")
+				return ErrOutOfMemory
+			}
+		}
+	}
+	s.setNativeInternal(key, value, valueTypeOf(value), byteSize, expiration, false)
+	return nil
+}
+
+// rawSetPacked stores a packed byte-encoded value for the given ValueType.
+// Must be called under the write lock.
+func (s *Shard) rawSetPacked(ctx context.Context, key string, vt ValueType, buf []byte, expiration int64) error {
+	if s.maxBytes > 0 {
+		newSize := estimateBytesSize(key, buf)
+		oldSize := s.keySize(key)
+		delta := newSize - oldSize
+		if delta > 0 && s.usedBytes+delta > s.maxBytes {
+			switch s.evictionPolicy {
+			case EvictionLRU:
+				s.evictLRU(ctx, delta)
+			case EvictionNone:
+				logger.Warn(ctx).Str("key", key).Int64("usedBytes", s.usedBytes).Int64("maxBytes", s.maxBytes).Msg("write rejected, out of memory")
+				return ErrOutOfMemory
+			}
+		}
+	}
+	s.setPackedInternal(key, vt, buf, expiration, false)
+	return nil
+}
+
+// rawLoadPacked stores a packed byte buffer, bypassing the memory limit
+// check. Snapshot-loading uses this for entries with Encoding == EncPacked.
+func (s *Shard) rawLoadPacked(key string, vt ValueType, buf []byte, expiration int64) {
+	s.setPackedInternal(key, vt, buf, expiration, true)
+}
+
+// nativeSize returns the cached byte-size of an EncNative entry.
+// Must be called while holding the read or write lock.
+func (s *Shard) nativeSize(key string) int64 {
+	ptr, ok := s.items[key]
+	if !ok || ptr.IsNil() {
+		return 0
+	}
+	return int64(s.slabs.Meta(ptr).NativeSize)
+}
+
+// rawGet returns the entry for key. Safe under either RLock or Lock; it
+// updates LastAccessNs atomically without moving the entry in the LRU.
+func (s *Shard) rawGet(key string) (Entry, bool) {
+	ptr, found := s.items[key]
+	if !found {
+		return Entry{}, false
+	}
+	atomic.StoreInt64(&s.slabs.Meta(ptr).LastAccessNs, time.Now().UnixNano())
+	return s.entryFromSlot(ptr), true
+}
+
+// rawDelete removes key. Must be called under the write lock.
+func (s *Shard) rawDelete(key string) {
+	s.delete(key)
+}
+
+// ttlInternal returns the remaining TTL and a ValueState for key.
+func (s *Shard) ttlInternal(key string) (time.Duration, ValueState) {
+	ptr, exists := s.items[key]
+	if !exists {
+		return 0, ValueAbsent
+	}
+	expiration := s.slabs.Meta(ptr).ExpirationNs
+	if expiration == 0 {
+		return 0, ValueNoExpire
+	}
+	expirationTime := time.Unix(0, expiration)
+	if expirationTime.Before(time.Now()) {
+		return 0, ValueExpired
+	}
+	return time.Until(expirationTime), ValuePresent
+}
+
+// rawTTL returns the raw expiration timestamp in nanoseconds.
+func (s *Shard) rawTTL(key string) int64 {
+	ptr, ok := s.items[key]
+	if !ok {
+		return 0
+	}
+	return s.slabs.Meta(ptr).ExpirationNs
+}
+
+// rangeShard iterates over this shard's entries. Must be called while
+// holding the read or write lock.
+func (s *Shard) rangeShard(fn func(key string, entry Entry, expiration int64) bool) bool {
+	for key, ptr := range s.items {
+		if !fn(key, s.entryFromSlot(ptr), s.slabs.Meta(ptr).ExpirationNs) {
+			return false
+		}
+	}
+	return true
+}
+
+// clear drops every entry on this shard. Must be called under the write lock.
+func (s *Shard) clear() {
+	s.items = make(map[string]slab.SlabPointer)
+	s.nativeValues = make(map[slab.SlabPointer]any)
+	s.keysBySlot = make(map[slab.SlabPointer]string)
+	s.lruHead = slab.NilPointer
+	s.lruTail = slab.NilPointer
+	s.usedBytes = 0
+	s.slabs = slab.NewAllocator()
+}
+
+// LRU helpers (per-shard) ---------------------------------------------------
+
+func (s *Shard) lruPushFront(ptr slab.SlabPointer) {
+	meta := s.slabs.Meta(ptr)
+	meta.LRUPrev = slab.NilPointer
+	meta.LRUNext = s.lruHead
+	if !s.lruHead.IsNil() {
+		s.slabs.Meta(s.lruHead).LRUPrev = ptr
+	}
+	s.lruHead = ptr
+	if s.lruTail.IsNil() {
+		s.lruTail = ptr
+	}
+	atomic.StoreInt64(&meta.LastAccessNs, time.Now().UnixNano())
+}
+
+func (s *Shard) lruRemove(ptr slab.SlabPointer) {
+	meta := s.slabs.Meta(ptr)
+	prev := meta.LRUPrev
+	next := meta.LRUNext
+	if !prev.IsNil() {
+		s.slabs.Meta(prev).LRUNext = next
+	} else {
+		s.lruHead = next
+	}
+	if !next.IsNil() {
+		s.slabs.Meta(next).LRUPrev = prev
+	} else {
+		s.lruTail = prev
+	}
+	meta.LRUPrev = slab.NilPointer
+	meta.LRUNext = slab.NilPointer
+}
+
+func (s *Shard) lruMoveToFront(ptr slab.SlabPointer) {
+	if s.lruHead == ptr {
+		atomic.StoreInt64(&s.slabs.Meta(ptr).LastAccessNs, time.Now().UnixNano())
+		return
+	}
+	s.lruRemove(ptr)
+	s.lruPushFront(ptr)
+}
+
+func (s *Shard) setPackedInternal(key string, vt ValueType, buf []byte, expiration int64, suppressMutate bool) {
+	newSize := estimateBytesSize(key, buf)
+	oldSize := s.keySize(key)
+	s.usedBytes += newSize - oldSize
+
+	prevPtr, had := s.items[key]
+	var ptr slab.SlabPointer
+
+	switch {
+	case had && !prevPtr.IsNil() && s.slabs.Capacity(prevPtr) >= uint32(len(buf)) &&
+		Encoding(s.slabs.Meta(prevPtr).Encoding) == EncPacked:
+		ptr = prevPtr
+		s.slabs.Write(ptr, buf)
+		s.lruMoveToFront(ptr)
+	default:
+		if had && !prevPtr.IsNil() {
+			s.lruRemove(prevPtr)
+			delete(s.keysBySlot, prevPtr)
+			delete(s.nativeValues, prevPtr)
+			s.slabs.Free(prevPtr)
+		}
+		ptr = s.slabs.Alloc(uint32(len(buf)))
+		s.slabs.Write(ptr, buf)
+		s.keysBySlot[ptr] = key
+		s.lruPushFront(ptr)
+	}
+
+	meta := s.slabs.Meta(ptr)
+	meta.ValueType = uint8(vt)
+	meta.Encoding = uint8(EncPacked)
+	if expiration > 0 {
+		meta.ExpirationNs = expiration
+	} else {
+		meta.ExpirationNs = 0
+	}
+
+	s.items[key] = ptr
+	if !suppressMutate && s.onMutate != nil {
+		s.onMutate(key)
+	}
+}
+
+func (s *Shard) setInternal(key string, value any, expiration int64, suppressMutate bool) {
+	switch v := value.(type) {
+	case []byte:
+		s.setPackedInternal(key, ObjTypeBytes, v, expiration, suppressMutate)
+		return
+	case string:
+		s.setPackedInternal(key, ObjTypeBytes, []byte(v), expiration, suppressMutate)
+		return
+	}
+	s.setNativeInternal(key, value, valueTypeOf(value), nativePayloadSize(key, value), expiration, suppressMutate)
+}
+
+func (s *Shard) setNativeInternal(key string, value any, vt ValueType, byteSize int64, expiration int64, suppressMutate bool) {
+	newSize := int64(entryOverhead) + int64(len(key)) + byteSize
+	oldSize := s.keySize(key)
+	s.usedBytes += newSize - oldSize
+
+	if prevPtr, had := s.items[key]; had && !prevPtr.IsNil() {
+		s.lruRemove(prevPtr)
+		delete(s.keysBySlot, prevPtr)
+		delete(s.nativeValues, prevPtr)
+		s.slabs.Free(prevPtr)
+	}
+	ptr := s.slabs.Alloc(0)
+	s.keysBySlot[ptr] = key
+	s.lruPushFront(ptr)
+
+	meta := s.slabs.Meta(ptr)
+	meta.ValueType = uint8(vt)
+	meta.Encoding = uint8(EncNative)
+	meta.NativeSize = uint32(byteSize)
+	if expiration > 0 {
+		meta.ExpirationNs = expiration
+	} else {
+		meta.ExpirationNs = 0
+	}
+
+	s.nativeValues[ptr] = value
+	s.items[key] = ptr
+	if !suppressMutate && s.onMutate != nil {
+		s.onMutate(key)
+	}
+}
+
+// evictLRU evicts the entry with the oldest LastAccessNs (sampled from the
+// tail of the LRU list) until delta bytes can be accommodated.
+func (s *Shard) evictLRU(ctx context.Context, delta int64) {
+	for s.maxBytes > 0 && s.usedBytes+delta > s.maxBytes {
+		if s.lruTail.IsNil() {
+			break
+		}
+		victim := s.lruTail
+		victimAccess := atomic.LoadInt64(&s.slabs.Meta(victim).LastAccessNs)
+		node := s.slabs.Meta(victim).LRUPrev
+		for i := 1; i < evictSampleSize && !node.IsNil(); i++ {
+			access := atomic.LoadInt64(&s.slabs.Meta(node).LastAccessNs)
+			if access < victimAccess {
+				victim = node
+				victimAccess = access
+			}
+			node = s.slabs.Meta(node).LRUPrev
+		}
+		evictKey, ok := s.keysBySlot[victim]
+		if !ok {
+			logger.Warn(ctx).Msg("evictLRU: keysBySlot has no entry for victim; bailing")
+			break
+		}
+		logger.Debug(ctx).Str("key", evictKey).Msg("lru eviction")
+		s.delete(evictKey)
+	}
+}
+
+func (s *Shard) delete(key string) {
+	ptr, ok := s.items[key]
+	if !ok {
+		return
+	}
+	if !ptr.IsNil() {
+		s.usedBytes -= s.chargedSize(key, ptr)
+		s.lruRemove(ptr)
+		delete(s.keysBySlot, ptr)
+		delete(s.nativeValues, ptr)
+		s.slabs.Free(ptr)
+	}
+	delete(s.items, key)
+	if s.onMutate != nil {
+		s.onMutate(key)
+	}
+}
+
+func (s *Shard) keySize(key string) int64 {
+	ptr, ok := s.items[key]
+	if !ok || ptr.IsNil() {
+		return 0
+	}
+	return s.chargedSize(key, ptr)
+}
+
+func (s *Shard) chargedSize(key string, ptr slab.SlabPointer) int64 {
+	meta := s.slabs.Meta(ptr)
+	enc := Encoding(meta.Encoding)
+	if enc == EncPacked {
+		return int64(entryOverhead) + int64(len(key)) + int64(s.slabs.Size(ptr))
+	}
+	return int64(entryOverhead) + int64(len(key)) + int64(meta.NativeSize)
+}
+
+func (s *Shard) slabStats() slab.Stats { return s.slabs.Stats() }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,11 +1,12 @@
-// Package engine serialises all cache mutations through a single goroutine.
+// Package engine serialises all cache mutations through one goroutine
+// per shard. Callers submit work via Dispatch / DispatchWithResult; the
+// engine routes the work to the goroutine owning the shard the command's
+// key hashes to, where it runs under that shard's write lock.
 //
-// Callers submit work via Dispatch or DispatchWithResult. The engine goroutine
-// executes the work under the cache lock and returns the result through a
-// per-call channel. Callers pass a context.Context so shutdown and timeouts
-// propagate correctly; if the context expires before the work starts, the
-// engine returns ctx.Err() without executing the function. If the engine is
-// stopped before the work starts, ErrEngineStopped is returned.
+// Today's production configuration is N=1 (single shard, single engine
+// goroutine, identical behaviour to the pre-shard cache); the routing
+// machinery is in place so a follow-up can bump N without touching call
+// sites.
 package engine
 
 import (
@@ -17,75 +18,91 @@ import (
 	"gocache/pkg/cache"
 )
 
-// ErrEngineStopped is returned by Dispatch/DispatchWithResult when the engine
-// has been stopped before the work could be executed.
+// ErrEngineStopped is returned when the engine has been stopped before
+// the work could be executed.
 var ErrEngineStopped = errors.New("engine stopped")
 
-// cmdChanCapacity sizes the buffered submission channel. Writers block when
-// the engine goroutine is behind; a modest buffer smooths microbursts without
-// allowing unbounded queueing.
+// cmdChanCapacity sizes each shard's buffered submission channel.
 const cmdChanCapacity = 100
 
+// Command is the unit of work the engine executes under a shard's write lock.
 type Command struct {
 	Execute func() any
 	ResChan chan any
 }
 
-// resChanPool recycles the per-call result channel that sendAndWait creates
-// on every command submission. Capacity 1 — a single result. The channel
-// is only returned to the pool when sendAndWait observed the engine's
-// write (successful receive) or when the engine never received the
-// Command at all (cancellation/stop fired before submit).
-//
-// Critical safety rule: do NOT Put on the cancellation/stop branch of the
-// SECOND select, because the engine has already taken ownership of the
-// channel and may write to it before noticing stop. Re-issuing such a
-// channel would deliver a stale value to the next caller.
+// resChanPool recycles the per-call result channel sendAndWait creates
+// for every dispatch. Same Put-on-success-only safety rule as before:
+// once the engine goroutine takes ownership of the channel via the
+// receive on cmdChan, sendAndWait must NOT return the channel to the
+// pool from a stop / cancel branch — the engine may still write to it.
 var resChanPool = sync.Pool{
 	New: func() any { return make(chan any, 1) },
 }
 
-type Engine struct {
-	cache    *cache.Cache
+// shardEngine is one goroutine + cmdChan pair, owning a single Shard.
+// Each shard's goroutine runs handlers under that shard's write lock.
+type shardEngine struct {
+	shard    *cache.Shard
 	cmdChan  chan Command
 	stopChan chan struct{}
+}
+
+// Engine fans out commands to N shard engines. The Dispatch* methods
+// route by key hash so the right shard's goroutine processes the work.
+type Engine struct {
+	cache    *cache.Cache
+	shards   []*shardEngine
 	stopOnce sync.Once
 }
 
+// New constructs an Engine with one goroutine per cache shard.
 func New(c *cache.Cache) *Engine {
-	return &Engine{
-		cache:    c,
-		cmdChan:  make(chan Command, cmdChanCapacity),
-		stopChan: make(chan struct{}),
+	e := &Engine{cache: c, shards: make([]*shardEngine, c.ShardCount())}
+	for i := range e.shards {
+		e.shards[i] = &shardEngine{
+			shard:    c.ShardByIndex(i),
+			cmdChan:  make(chan Command, cmdChanCapacity),
+			stopChan: make(chan struct{}),
+		}
+	}
+	return e
+}
+
+// Run launches one goroutine per shard. Returns immediately.
+func (e *Engine) Run() {
+	logger.InfoNoCtx().Int("shards", len(e.shards)).Msg("engine dispatch loop started")
+	for _, se := range e.shards {
+		go se.run()
 	}
 }
 
-func (e *Engine) Run() {
-	logger.InfoNoCtx().Msg("engine dispatch loop started")
+// Stop signals every shard goroutine to exit. Safe to call multiple times.
+func (e *Engine) Stop() {
+	e.stopOnce.Do(func() {
+		logger.InfoNoCtx().Msg("engine stop signal received")
+		for _, se := range e.shards {
+			close(se.stopChan)
+		}
+	})
+}
+
+func (se *shardEngine) run() {
 	for {
 		select {
-		case cmd := <-e.cmdChan:
-			e.cache.Lock()
+		case cmd := <-se.cmdChan:
+			se.shard.Lock()
 			res := cmd.Execute()
-			e.cache.Unlock()
+			se.shard.Unlock()
 			cmd.ResChan <- res
-		case <-e.stopChan:
+		case <-se.stopChan:
 			return
 		}
 	}
 }
 
-func (e *Engine) Stop() {
-	e.stopOnce.Do(func() {
-		logger.InfoNoCtx().Msg("engine stop signal received")
-		close(e.stopChan)
-	})
-}
-
-// sendAndWait submits fn via the engine's command channel and blocks for its
-// result. Shared implementation behind Dispatch and DispatchWithResult.
-//
-// resChan is drawn from a sync.Pool. The Put rules:
+// sendAndWait submits fn to the named shard's goroutine and blocks for its
+// result. The Put rules:
 //   - submit-stage stop/cancel: engine never received the Command, so the
 //     channel is still privately owned by sendAndWait → safe to Put back.
 //   - successful receive: the buffer slot has just been drained → safe to
@@ -93,11 +110,12 @@ func (e *Engine) Stop() {
 //   - wait-stage stop/cancel: engine already owns the write end and may
 //     write to it before observing stop → DO NOT Put back. The channel
 //     becomes garbage; sync.Pool just won't see it.
-func (e *Engine) sendAndWait(ctx context.Context, fn func() any) (any, error) {
+func (e *Engine) sendAndWait(ctx context.Context, shard int, fn func() any) (any, error) {
+	se := e.shards[shard]
 	resChan := resChanPool.Get().(chan any)
 	select {
-	case e.cmdChan <- Command{Execute: fn, ResChan: resChan}:
-	case <-e.stopChan:
+	case se.cmdChan <- Command{Execute: fn, ResChan: resChan}:
+	case <-se.stopChan:
 		resChanPool.Put(resChan)
 		return nil, ErrEngineStopped
 	case <-ctx.Done():
@@ -108,7 +126,7 @@ func (e *Engine) sendAndWait(ctx context.Context, fn func() any) (any, error) {
 	case res := <-resChan:
 		resChanPool.Put(resChan)
 		return res, nil
-	case <-e.stopChan:
+	case <-se.stopChan:
 		// Engine owns the channel — orphan it.
 		return nil, ErrEngineStopped
 	case <-ctx.Done():
@@ -117,20 +135,36 @@ func (e *Engine) sendAndWait(ctx context.Context, fn func() any) (any, error) {
 	}
 }
 
-// Dispatch submits fn to the engine and blocks until it runs (or the engine
-// stops, or ctx is cancelled). Returns nil on success, ErrEngineStopped if
-// the engine stopped before execution, or ctx.Err() if ctx was cancelled.
+// Dispatch submits fn to the engine goroutine owning shard 0 and blocks
+// until it runs. Use DispatchToShard when the caller knows the routing.
+// Today (N=1) the two are equivalent; at N>1 this is the legacy multi-
+// shard path used by snapshot save / cleanup workers and is the
+// transition point where cross-shard coordination needs to be added.
 func (e *Engine) Dispatch(ctx context.Context, fn func()) error {
-	_, err := e.sendAndWait(ctx, func() any {
+	_, err := e.sendAndWait(ctx, 0, func() any {
 		fn()
 		return nil
 	})
 	return err
 }
 
-// DispatchWithResult submits fn to the engine and blocks until it runs.
-// Returns (result, nil) on success, (nil, ErrEngineStopped) if the engine
-// stopped before execution, or (nil, ctx.Err()) if ctx was cancelled.
+// DispatchWithResult is Dispatch with a return value. Same shard-0
+// routing as Dispatch.
 func (e *Engine) DispatchWithResult(ctx context.Context, fn func() any) (any, error) {
-	return e.sendAndWait(ctx, fn)
+	return e.sendAndWait(ctx, 0, fn)
 }
+
+// DispatchToShard routes fn to the goroutine owning the named shard.
+// Used by per-key handlers once the caller has computed the shard from
+// the command's key.
+func (e *Engine) DispatchToShard(ctx context.Context, shard int, fn func() any) (any, error) {
+	if shard < 0 || shard >= len(e.shards) {
+		return nil, errors.New("engine: shard index out of range")
+	}
+	return e.sendAndWait(ctx, shard, fn)
+}
+
+// ShardCount exposes the underlying cache's shard count for callers that
+// need to mirror the routing (the evaluator does this when computing
+// the destination shard from a command's key).
+func (e *Engine) ShardCount() int { return len(e.shards) }


### PR DESCRIPTION
## Summary

Structural refactor that moves per-key cache state into a new `Shard` type and turns the engine into N per-shard goroutines. **Default N=1, behaviorally identical to today.** Verified by `go test -race -count=1 ./...` clean across 25 packages and benchmarks within ±5% noise on every workload.

This is the second of three PRs implementing #34's per-shard locking design. PR 1 (#40) added the classification metadata; this PR sets up the structural machinery; the next PR bumps N and wires per-key routing.

## What moves into `pkg/cache/shard.go` (new, 437 lines)

`Shard` owns one slice of the keyspace plus everything that goes with it:

- `sync.RWMutex` + `items` / `nativeValues` / `keysBySlot` maps
- `slab.Allocator` (one per shard — slab is not thread-safe; per-shard avoids cross-engine contention)
- LRU head/tail SlabPointers + `lruPushFront`/`lruRemove`/`lruMoveToFront`
- `usedBytes` / `maxBytes` / `evictionPolicy`
- All per-key methods: `rawGet`/`rawSet`/`rawDelete`/`rawTTL`/`nativeSize`/`SetExpiration`
- All storage internals: `setInternal`/`setNativeInternal`/`setPackedInternal`/`delete`/`keySize`/`chargedSize`
- `evictLRU` (sampled approximate-LRU; same semantics as today)
- `onMutate` / `onMutateAll` per-shard callbacks bound to the parent Cache's external WATCH callbacks

## What stays on `pkg/cache.Cache` (rewritten, 470 lines, was 837)

`Cache` becomes a thin router:

- `shards []*Shard` + `n uint64`
- Shared config (`packed`, `evictionPolicy`, `maxBytes`, external `OnMutate` / `OnMutateAll`)
- Public per-key methods route via `c.Shard(key).method()`
- `LastAccess(e)` / `ResolvePacked(e)` route via the unexported `Entry.shard` back-reference (set by `Shard.entryFromSlot`) — zero handler-code change
- `Rename` / `Range` / `Clear` handle the same-shard case (always at N=1) and stub or aggregate for cross-shard
- Aggregate methods (`Len`, `UsedBytes`, `SlabStats`) sum across shards
- Bulk-locking (`Lock`/`Unlock`/`RLock`/`RUnlock`) acquires every shard's mutex in shard-id order — used by tools like `bench/gctrace` and any future cross-shard primitives

## What stays on `pkg/engine/engine.go` (rewritten, 175 lines, was 137)

`Engine` grows N `shardEngine` instances (one goroutine + cmdChan + stopChan each). Each goroutine acquires its shard's write lock before running a handler.

Three dispatch entrypoints:

- `Dispatch(ctx, fn)` / `DispatchWithResult(ctx, fn)` — route to shard 0. Legacy single-engine semantics; used by snapshot save / cleanup workers / current handler dispatch.
- `DispatchToShard(ctx, shard, fn)` — caller-specified shard. Will be used by per-key routing in the next PR.

The `resChanPool` Put-on-success-only safety rule from #28 carries through unchanged.

## Bench delta (N=1 post-refactor vs pre-refactor)

Two-run mean, `benchtime=5s -cpu=4`:

| Benchmark | Pre (ns/op) | Post (ns/op) | Δ |
|---|---:|---:|---:|
| TCP_GET_Pipelined | 12 669 | 13 447 | +6% (within noise — single-run spread is 12 584 → 14 827 = 16% range) |
| TCP_GET_Standard | 4 026 | 4 017 | -0.2% |
| TCP_Mixed_GetSet_Pipelined | 13 880 | 13 238 | -4.6% |
| TCP_Mixed_GetHset_Pipelined | 15 616 | 15 418 | -1.3% |
| TCP_Mixed_GetSet_Standard | 4 024 | 4 054 | +0.7% |
| TCP_SET_Standard | 4 235 | 4 219 | -0.4% |

Allocation count (`280 allocs/op`) and bytes (`9 845 B/op`) are byte-identical to pre-refactor on the GET_Pipelined hot path. The structural refactor adds zero detectable overhead at N=1.

## Why N=1

This PR is structural only. Bumping `N` to 16 (the prototype's optimal value, validated in #39) needs:

1. **Per-key routing**: single-key handlers must route through `DispatchToShard(shard, fn)` so each command lands on the goroutine owning its key. Currently they go through `Dispatch`/`DispatchWithResult` which routes to shard 0.
2. **Cross-shard coordination** for multi-key handlers (MGET, MSET, RENAME, KEYS, SCAN, SINTER/SUNION/SDIFF, MULTI/EXEC, WATCH, FLUSHDB, snapshot save/load, cleanup). At N=1 they all hit shard 0 and just work; at N>1 they need sorted-shard-ID lock acquisition and per-shard fan-out.

Both are the next PR's scope.

## Test plan

- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] `staticcheck -tags 'crashdump otlp' ./...` clean
- [x] `go test -race -count=1 ./...` green across 25 packages
- [x] No multi-key handler stubbed — every test passes unmodified
- [x] Bench at N=1 within ±5% of pre-refactor (run-to-run noise window)

## Reproduce

```bash
go test -race -count=1 ./...
go test -run=NONE -bench='^BenchmarkTCP_(Mixed|GET_Pipelined|GET_Standard|SET_Standard)' \
  -benchtime=5s -cpu=4 -count=2 ./pkg/server/
```

Refs #34