### PR TITLE
docs: refresh for per-shard arc, api/-only refactor, wiki sync fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,25 +269,58 @@ jobs:
   wiki:
     name: Sync Wiki
     runs-on: ubuntu-latest
+    # Skip cleanly when the PAT is not configured. The first time this runs
+    # after WIKI_SYNC_TOKEN is added the step will pick it up automatically.
+    if: ${{ github.event_name == 'push' }}
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.RELEASER_APP_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Pull latest
-        run: git pull origin main
+      - name: Sync docs/ to wiki
+        env:
+          # Classic PAT with public_repo scope. GitHub App tokens cannot push
+          # to wikis (no Wiki permission exists for Apps); this PAT is the
+          # only path. Add it as a repository secret named WIKI_SYNC_TOKEN.
+          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-      - name: Sync to wiki
-        uses: newrelic/wiki-sync-action@main
-        with:
-          source: docs/
-          destination: wiki
-          token: ${{ steps.app-token.outputs.token }}
+          if [[ -z "${WIKI_SYNC_TOKEN:-}" ]]; then
+            echo "::warning::WIKI_SYNC_TOKEN not set — skipping wiki sync."
+            echo "::warning::See docs/plugins/README.md or release.yml header for setup steps."
+            exit 0
+          fi
+
+          if [[ ! -d docs ]]; then
+            echo "::error::docs/ directory missing — nothing to sync."
+            exit 1
+          fi
+
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+
+          echo "Cloning wiki repo..."
+          git clone "https://x-access-token:${WIKI_SYNC_TOKEN}@github.com/${REPO}.wiki.git" "$tmp"
+
+          echo "Mirroring docs/ -> wiki (preserving .git)..."
+          rsync -a --delete --exclude='.git/' docs/ "$tmp/"
+
+          cd "$tmp"
+          git config user.name "gocache-wiki-sync[bot]"
+          git config user.email "actions@users.noreply.github.com"
+
+          if git diff --quiet && git diff --cached --quiet && [[ -z "$(git status --porcelain)" ]]; then
+            echo "No wiki changes to commit."
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "docs: sync from docs/ @ ${GITHUB_SHA::7} [skip ci]"
+          # Push fails fast if the PAT is rejected, so this catches every
+          # auth/perms regression instead of swallowing them like the prior
+          # newrelic/wiki-sync-action did.
+          git push origin master
+
+          echo "Wiki sync complete."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GoCache
 
-Redis-compatible in-memory cache server with a microkernel architecture. The core handles basic caching -- 69 commands across 5 data types. Everything else (Pub/Sub, Kafka, geospatial, auth, metrics, replication) runs as a plugin in a separate process. A crashing plugin cannot crash the core.
+Redis-compatible in-memory cache server with a microkernel architecture. The core handles basic caching — 75 commands across 5 data types over a per-shard locking design (default 8 shards, FNV-1a key routing). Everything else (Pub/Sub, Kafka, geospatial, auth, metrics, replication) runs as a plugin: most as separate processes via GCPC over Unix domain sockets, with a thin embedded-plugin tier (`-tags <name>`) for capabilities that must be active before config loads (crashdump, OTLP). A crashing IPC plugin cannot crash the core.
 
-> Bachelor's thesis project exploring whether safe extensibility and high performance can coexist.
+> Bachelor's thesis project exploring whether safe extensibility and high performance can coexist. See `docs/audits/per-shard-arc-summary.md` for the throughput/RSS deltas and `docs/plugins/README.md` for the plugin contract.
 
 ## Quick Start
 
@@ -51,3 +51,12 @@ task vet            # Static analysis
 task proto          # Regenerate protobuf code
 task version        # Print all artifact versions
 ```
+
+## Documentation
+
+- [docs/server/README.md](docs/server/README.md) — Server overview, configuration, supported commands, env vars.
+- [docs/plugins/README.md](docs/plugins/README.md) — Plugin system: embedded vs IPC, build-tag matrix, the `api/`-only import rule.
+- [docs/gcpc/README.md](docs/gcpc/README.md) — GCPC v1 protocol specification (Protobuf over Unix domain sockets).
+- [docs/server/design/](docs/server/design/) and [docs/gcpc/design/](docs/gcpc/design/) — PlantUML diagrams (component, sequence, state).
+- [docs/audits/](docs/audits/) — Performance audits and thesis anchors.
+- [.claude/IMPLEMENTATION_STATUS.md](.claude/IMPLEMENTATION_STATUS.md) — Phase-by-phase progress tracker.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,58 @@
+# GoCache
+
+Redis-compatible in-memory cache server with a microkernel architecture. The core handles 75 commands across 5 data types over a per-shard locking design (default 8 shards, FNV-1a key routing). Everything else (Pub/Sub, Kafka, geospatial, auth, metrics, replication, persistence) runs as a plugin — most as separate processes via GCPC over Unix domain sockets, with a thin embedded-plugin tier for capabilities that must be active before config loads.
+
+> Bachelor's thesis project exploring whether safe extensibility and high performance can coexist.
+
+This wiki is **auto-generated** from `docs/` on every push to `main`. To edit a page, edit the corresponding file in the repo's `docs/` directory and open a PR.
+
+## Where to start
+
+- **[Server](server/README)** — Server overview, configuration, supported commands, env vars, embedded plugins.
+- **[Plugins](plugins/README)** — Embedded vs IPC plugins, build-tag matrix, the `api/`-only import rule, available plugins.
+- **[GCPC protocol](gcpc/README)** — GCPC v1 specification (Protobuf over Unix domain sockets) — the contract IPC plugins implement.
+- **[Audits](audits)** — Performance audits and thesis anchors (per-shard arc summary, Go-vs-docker bench gap).
+- **[Design diagrams](server/design)** — Component, sequence, and state diagrams in PlantUML.
+
+## Active development
+
+| Phase | Status | Tracking |
+|---|---|---|
+| Phase 1 — Core cache | ✅ Complete | 75 commands, RESP2/3, transactions, persistence (gob), AUTH, OBJECT introspection, hot reload |
+| Phase 2 — Plugin framework | ✅ Complete | GCPC v1, IPC transport, command routing, hooks, scopes, query channels, operation hooks |
+| Phase 3 — REX metadata + Operations | ✅ Complete | Per-request metadata, server queries, operation tracker, replay-on-subscribe |
+| Phase 4 — Production hardening | 🔄 In progress | Memory optimization (slab + GC-opaque LRU) ✅; sink-aware fast path ✅; per-shard locking ✅; engine pooling ❌; read-lock bypass ❌; persistence-as-plugin ⏳ |
+| Phase 5 — Advanced plugins | ❌ Not started | OAuth2, Kafka, ratelimit, cluster |
+
+Detailed phase tracker: [`.claude/IMPLEMENTATION_STATUS.md`](https://github.com/j-mizera/gocache/blob/main/.claude/IMPLEMENTATION_STATUS.md) in the repo (not wiki — kept on `main` so it tracks merge state precisely).
+
+## Project layout
+
+```
+api/        Public contract surface — plugins import only from here
+sdk/        Plugin author SDK
+cmd/        Entry points (server, cli)
+pkg/        Server internals — depends on api/, never on sdk/, never imported by plugins/
+plugins/    Plugin implementations (embedded + IPC)
+docs/       This wiki — auto-synced on push to main
+bench/      Benchmarks and results per branch
+scripts/    Build/test/CI helpers
+```
+
+## Build
+
+```bash
+# Default (no embedded plugins, ~15 MB binary)
+go build -o bin/gocache-server ./cmd/server
+
+# With embedded plugins (crashdump + OTLP from t=0)
+go build -tags "crashdump otlp" -o bin/gocache-server ./cmd/server
+
+# With pprof endpoint enabled
+go build -tags "crashdump otlp pprof" -o bin/gocache-server ./cmd/server
+
+# Docker (multi-arch, signed, on every main push)
+docker build --build-arg PLUGINS=crashdump,otlp -t gocache:full .
+```
+
+See [Server / build](server/README#building) for details.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,26 @@
+**[Home](Home)**
+
+**Server**
+- [Overview](server/README)
+- [Roadmap](server/ROADMAP)
+- [Solution architecture](server/SOLUTION_ARCHITECTURE)
+
+**Plugins**
+- [Overview](plugins/README)
+- [gobservability (IPC)](plugins/gobservability/README)
+
+**Protocol**
+- [GCPC v1](gcpc/README)
+
+**Design diagrams**
+- [Server components](server/design/component)
+- [Server sequences](server/design/sequence)
+- [Server states](server/design/state)
+- [GCPC components](gcpc/design/component)
+- [GCPC sequences](gcpc/design/sequence)
+- [GCPC states](gcpc/design/state)
+
+**Audits**
+- [Per-shard arc summary](audits/per-shard-arc-summary)
+- [Go-vs-docker bench gap](audits/go-bench-vs-docker-gap)
+- [clientctx cross-goroutine](audits/clientctx-cross-goroutine)

--- a/docs/audits/per-shard-arc-summary.md
+++ b/docs/audits/per-shard-arc-summary.md
@@ -1,0 +1,116 @@
+# Per-shard locking arc — summary
+
+This is the thesis-anchor write-up for the per-shard locking arc that landed across issues #34 and follow-ups #43, #44, #46, #47, #48, #49, #50, plus the bench-methodology audit #45. It documents what was tried, what shipped, what didn't, and what's structurally bounded — so future readers know which gaps are still on the table and which are the price of the architecture.
+
+## Goal
+
+The single-mutex `Cache` was the dominant pipelined-write bottleneck once the sink-aware fast path (#26) closed the instrumentation overhead. Sharding the cache by key (FNV-1a → mask) lets unrelated keys mutate in parallel without a global write lock.
+
+## Headline result
+
+After every follow-up shipped, the gocache vs valkey ratio on the standardised pipelined redis-benchmark moves from **~0.5×** (pre-arc) to **~0.7×–0.95×** depending on workload:
+
+| Workload | Pre-arc ratio | Post-arc ratio | Notes |
+|---|---|---|---|
+| Pipelined SET | ~0.5× | ~0.85× | Per-key shard routing |
+| Pipelined GET | ~0.5× | ~0.85× | Same |
+| Pipelined HSET | ~0.5× | ~0.85× | Single-key |
+| Pipelined SADD | ~0.5× | ~1.1× | +119% from baseline |
+| Pipelined LPUSH | ~0.5× | ~0.95× | Single-key |
+| Pipelined MSET | ~0.5× | **~0.55×** | Cross-shard cache-line tax |
+| Standard SET | parity | parity | TCP syscall ceiling caps RPS |
+| Memory (RSS, 1M keys) | baseline | **−15%** | Slab arena scaling per shard |
+
+Memory and RSS numbers measured at N=8 (the ship default) on the dockerized harness. Full per-PR captures live under `bench/results/` (taxonomy in [Bench layout](#bench-layout) below).
+
+## What shipped
+
+### #34 — per-key shard routing (`arch/per-key-routing`)
+Initial cut: `Cache` becomes a router over `[]*Shard`; each shard has its own mutex, items map, slab arena, LRU list. `shardIndexOf(key) = fnv1a(key) & (N-1)`. Engine grows `DispatchToShard(ctx, shardIdx, fn)` and `DispatchToShards(ctx, shardIDs, fn)`. Single-key handlers route to one shard; multi-key handlers compute `cache.TouchedShards(keys)` and acquire the sorted shard set (deadlock-free).
+
+Default N=16 at first.
+
+### #43 — `pkg/cache.Shard` extraction (`refactor/extract-shard`)
+Moved per-shard state from inline anonymous struct into a named `Shard` type with its own constructor and methods. Pure refactor; sets up the surface for #44.
+
+### #44 — selective shard locking for multi-key handlers (`perf/selective-shard-locking`)
+Multi-key handlers (MGET, MSET, SINTER, SUNION, SDIFF, …) now lock only the touched shard set instead of taking the full cache lock. Net win on workloads where keys hash to a small number of shards.
+
+### #46 — multi-key locking via `command.Context.TouchedShards` (`perf/selective-shard-locking-multi-key`)
+Surface the touched-shard list on `command.Context` so handlers don't recompute it. Threading-only refactor; the locking strategy is the same as #44.
+
+### #47 — MSET shard-batched bulkSet (`perf/mset-locality-and-bench-gap`)
+`Shard.BulkSetBytes(pairs []BulkPair)` pre-sorts pairs by destination shard inside `HandleMset`, then issues one bulk-set call per shard while the sorted shard-lock set is already held. Saves cross-shard fan-out overhead but **does not recover the MSET regression** — the residual cost is structural cache-line bounce, not algorithmic.
+
+### #45 — Go-vs-docker bench gap audit (`perf/mset-locality-and-bench-gap`)
+Build-tag-gated pprof endpoint (`-tags pprof`) added to the docker image; `Dockerfile`'s `PPROF=1` build-arg publishes port 6060. Runtime profile rate setup (`SetBlockProfileRate(10000)`, `SetMutexProfileFraction(10)`).
+
+Measured: docker bench shows `runtime.selectgo` cumulative jumping from 18.74 % (Go bench) → 31.30 % (docker bench), and `Syscall6` flat dropping 25.93 % → 19.47 %. Conclusion: the gap is scheduler park/unpark from docker's veth + iptables NAT, **not** syscall cost. Future arcs should report both Go-bench and docker-bench numbers — 5–10× absolute disagreement is the nature of measurement, not a bug.
+
+Full audit: `docs/audits/go-bench-vs-docker-gap.md`.
+
+### #48 — slab target scales by shard count (`perf/scale-slab-target-by-shard`)
+`DefaultTargetSlabBytes / N` per-shard slab target. Without this, every shard allocates a full-size slab and the total arena footprint scales linearly with N — at N=16 we'd doubled RSS for no win. With scaling, RSS at N=16 came down 15 %.
+
+### #49 — bufpool experiment + N=4 trial (negative result, `perf/encoding-and-bufpool`)
+Tried (a) reusable `[]byte` buffer pool for slab `Set`/`Get` and (b) lowering N to 4 to reduce per-shard arena overhead further. Both **regressed vs N=8 + no bufpool**: the bufpool path added a hot-loop sync.Pool round-trip that cost more than the alloc it removed; N=4 lost throughput on multi-shard workloads more than it gained on single-shard. Branch closed without merge. Memory note: [49-followup-bufpool-n4-negative](../../projects/gocache/memory/49-followup-bufpool-n4-negative.md) in Obsidian.
+
+### #50 — default shard count 16 → 8 (`perf/lower-default-shard-count`)
+The N-sweep prototype showed N=8 within ~3 % of N=16's throughput optimum on mixed pipelined GetSet, while halving the per-shard memory overhead (slab arenas, maps, channel pools, slab metadata). Ship default lowered.
+
+## What's structural (won't be recovered without un-sharding)
+
+### MSET regression
+Pipelined MSET is **−31 %** vs the single-mutex baseline even after #47. Cause: every MSET spans multiple shards; each shard touched costs a cache-line bounce on the shared per-shard lock plus per-shard book-keeping (LRU update, used-bytes update, eviction check). The single-mutex baseline pays one of each per command; sharding pays N. This is the price of the design and would only come back via a fundamentally different sharding strategy (RCU, transactional memory, copy-on-write, …) that is out of scope for the thesis.
+
+### Cross-shard cache-line tax
+The same effect generalises. Any handler that touches K shards pays K-times-shard-overhead vs a single-mutex implementation paying once. Single-key handlers (the overwhelmingly common case) win because K=1 < N; multi-key handlers' break-even depends on workload key distribution.
+
+### Default-deployment memory cost
+Even with #48's slab scaling, N shards each carry their own maps, channel pools, and slab metadata. At N=8 the baseline RSS is ~10× valkey's at 1M keys — most of which is the persistence layer (gob snapshot worker + handlers; coordinated for replacement in [persistence-as-plugin](../../projects/gocache/plans/persistence-as-plugin.md)).
+
+## What's still on the table (future levers, not in this arc)
+
+Tracked under the [command-flow optimization plan](../../projects/gocache/plans/command-flow-optimization.md):
+
+- **#27 engine pooling** — pool `make(chan any, 1)` resChan + `*command.Context` allocations. Profile-attributed projection: +10–15 % uniform.
+- **#28 read-lock bypass** — classify commands as read-only, drop LRU-list mutation on read path, run read handlers inline under `cache.RLock()`. Projection: pipelined GET → ~0.85× valkey.
+- **#29 batched pipelined dispatch** — single-lock-acquisition for batched same-key pipelined writes. Decision-gated; only if pipelined-write headroom remains ≥30 % after #27/#28.
+
+## Bench layout
+
+Per-branch captures live under `bench/results/<branch-name>/` so the diff is clean per-PR. The taxonomy:
+
+```
+bench/results/
+├── arch-per-key-routing/        ← #34 baseline + per-key routing
+├── refactor-extract-shard/      ← #43 pure-refactor parity check
+├── perf-arc-followups/          ← #44/#46 selective shard locking
+├── perf-mset-locality-and-bench-gap/ ← #47 MSET bulkset + #45 bench gap audit
+├── perf-memory-reduction/       ← #48 slab target scaling
+├── perf-memory-reduction-combined/  ← combined N=8 + slab scaling
+├── perf-sharded-followups/      ← #50 default-N change validation
+├── perf-engine-pooling/         ← #27 (planned)
+├── perf-read-lock-bypass/       ← #28 (planned)
+├── perf-sink-aware-fast-path/   ← #26 (already shipped)
+├── feat-memory-optimization/    ← cross-arc memory writeup
+├── fix-issues-23-24/            ← diagnosis baseline
+├── diag-per-shard-locking/      ← prototype N-sweep
+└── proto-per-shard-locking/     ← prototype before refactor
+```
+
+Each branch directory contains `*-gocache.csv`, `*-gocache-pipelined.csv`, optional `*-gocache-memory.txt`, and a `summary.md` describing the deltas.
+
+## Lessons
+
+1. **Always report two tiers of bench numbers**: Go in-process (`go test -bench`) for hot-path attribution and docker (`valkey-benchmark` against the published image) for end-to-end. They will disagree by 5–10× and that's expected.
+2. **Negative results matter**: #49 burnt three days but the writeup tells future-us not to retry the bufpool path or N=4 default unless something fundamental changes. Memory note exists for this reason.
+3. **Memory is just as much a thesis line as throughput**: #48's −15 % RSS without a throughput cost is a clean win that would not have happened without explicit profiling of arena overhead.
+4. **The bench gap audit (#45) is reusable**: any future "why does docker disagree with Go bench" question now has a writeup at `docs/audits/go-bench-vs-docker-gap.md` and a pprof toggle to attach a profiler in production-shape builds.
+
+## Pointers
+
+- Thesis writeup: this file plus `bench/results/perf-mset-locality-and-bench-gap/summary.md` and `docs/audits/go-bench-vs-docker-gap.md`.
+- Plan: [command-flow-optimization](../../projects/gocache/plans/command-flow-optimization.md), child plan [per-shard-locking](../../projects/gocache/plans/command-flow/per-shard-locking.md) (Obsidian).
+- Postmortem (Obsidian memory): `per-shard-arc-postmortem`.
+- Implementation status: [.claude/IMPLEMENTATION_STATUS.md](../../.claude/IMPLEMENTATION_STATUS.md) — per-shard arc section.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,107 @@
+# Plugins
+
+GoCache extends a microkernel core with two kinds of plugin: **embedded** (compile-time-linked, in-process) and **IPC** (separate process over GCPC v1 protocol on a Unix domain socket). Both implement contracts in `gocache/api/*`. The choice is per-plugin and depends on what the plugin does.
+
+## Embedded vs IPC at a glance
+
+| Property | Embedded | IPC |
+|---|---|---|
+| Process model | Linked into the server binary | Separate process, fork/exec'd by the manager |
+| Activation | Build tag (`-tags <name>`) | YAML `plugins.enabled: true` + binary in `plugins.dir` |
+| Configuration | Env vars (no YAML at boot, since they run before `config.Load`) | YAML config block + GCPC `RegisterV1` |
+| Isolation | None — a panic in the plugin can kill the server unless `embedded.invoke` recovers | Process boundary; a plugin crash does not kill the server (configurable via `failure_policy: halt_server` for the rare critical cases) |
+| Hot-swap | No (compile time) | Yes (manager restarts on crash, up to `max_restarts`) |
+| Scope sandbox | None — embedded plugins can do anything the server can | Permission/scope system (`read`, `write`, `admin`, `hook:pre`, `hook:post`, `keys:<pattern>`) |
+| Latency overhead | None — direct function call | One IPC round-trip per call (~tens of microseconds) |
+| Best for | Things that must run before `config.Load`, or that need direct access to cache internals (snapshot dumps, AOF mutation feed, crash dumps, OTLP from t=0) | Anything with heavy dependencies (database drivers, network clients), anything that must isolate failure (metrics exporters, custom auth, rate limiting) |
+
+Both modes use the **same `api/*` interfaces**. The difference is registration and transport — embedded plugins call `embedded.Register(p)` from `init()`, IPC plugins run `pluginsdk.Run(p)` and the manager handshakes them over Unix socket.
+
+## The api/-only import rule
+
+Plugins under `plugins/` may import only `gocache/api/*`. They may **not** import `gocache/pkg/*` (server internals) or `gocache/cmd/*` (entry points). This is enforced by `scripts/check-plugin-isolation.sh`, which runs in CI as part of the lint job.
+
+The contract surface (what plugins are allowed to depend on) lives entirely under `gocache/api/`:
+
+```
+api/
+├── command/        Hook context constants, Result types, HookExecutor interface
+├── config/         Config data structs (Config, ServerConfig, PersistenceConfig, MemoryConfig, ...)
+├── context/        4-tier context security (FilterForPlugin, MergeFromPlugin, RedactSecrets)
+├── crashdump/      Dump types + Write/Scan/Delete (used by the crashdump embedded plugin)
+├── embedded/       Embedded plugin lifecycle interface + registry (BootInit, ConfigLoaded, ProcessShutdown)
+├── events/         Event types + Emitter interface
+├── gcpc/v1/        GCPC v1 Protobuf types + helpers (the IPC wire format)
+├── logger/         Shared logger (server + plugins write JSON to stdout)
+├── operations/     Operation struct, Type constants, ID generation
+├── plugin/         PluginsConfig, PluginOverride, FailurePolicy* — pure data
+├── scope/          Scope hierarchy + parsing
+└── transport/      Conn (framed protobuf I/O) + Listener (Unix domain socket)
+```
+
+When a plugin needs a symbol that currently lives in `pkg/`, the right move is to extract the data/interface portion to `api/` and leave the implementation in `pkg/` (with type aliases for back-compat where needed). #52/#53 established this pattern.
+
+## Build-tag matrix (embedded plugins)
+
+Embedded plugins are gated by build tags so default builds carry zero cost. Each plugin's package contains a tagless `doc.go` (so blank imports always resolve) and a tag-gated `<name>.go` that holds the `init()` registration.
+
+| Tag | Plugin | What it does | Configured via |
+|---|---|---|---|
+| `crashdump` | `plugins/crashdump` | Scans `<dir>/crashes/` on `ConfigLoaded` and emits crash events into the event bus | `GOCACHE_CRASHDUMP_DIR`, `GOCACHE_CRASHDUMP_DISABLED` |
+| `otlp` | `plugins/otlp` | Exports a root `process_start` OTEL span from `BootInit`; `ForceFlush` in `ProcessShutdown` so panics still land in Grafana | `GOCACHE_EMBEDDED_OTLP_ENDPOINT`, `GOCACHE_EMBEDDED_OTLP_SERVICE`, `GOCACHE_EMBEDDED_OTLP_TIMEOUT_MS`, `GOCACHE_EMBEDDED_OTLP_INSECURE`, `GOCACHE_EMBEDDED_OTLP_DISABLED` |
+| `pprof` | `cmd/server/pprof_on.go` | Boots a `net/http/pprof` endpoint on `0.0.0.0:6060` (overridable via `GOCACHE_PPROF_ADDR`); sets `BlockProfileRate` and `MutexProfileFraction` so contention shows up in profiles | `GOCACHE_PPROF_ADDR` |
+
+Combine multiple tags via go's space-separated syntax: `-tags "crashdump otlp"`. The Docker image accepts a `PLUGINS=` build arg that maps to space-separated tags; `PPROF=1` adds the `pprof` tag.
+
+```bash
+# Plain binary — no embedded plugins linked.
+go build -o bin/gocache-server ./cmd/server
+
+# With embedded plugins (crashdump + OTLP from t=0).
+go build -tags "crashdump otlp" -o bin/gocache-server ./cmd/server
+
+# Docker (production shape — multi-arch, signed, on every main push).
+docker build --build-arg PLUGINS=crashdump,otlp -t gocache:full .
+
+# Docker with pprof port published.
+docker build --build-arg PLUGINS=crashdump,otlp --build-arg PPROF=1 -t gocache:profiling .
+```
+
+## IPC plugins
+
+IPC plugins are separate executables in `plugins.dir`. The plugin manager (`pkg/plugin/manager`) discovers them at boot, fork/execs each one, hands it a `GOCACHE_PLUGIN_SOCK` env var pointing at a per-plugin Unix domain socket, then handshakes via GCPC v1 (`RegisterV1` → `RegisterAckV1`). The plugin's main loop reads envelopes (commands, hooks, queries, events, operation hooks), dispatches them to handlers, and writes responses.
+
+The plugin author SDK (`sdk/pluginsdk/`) wraps the GCPC handshake and message loop. Authors implement one or more interfaces:
+
+| Interface | Provides |
+|---|---|
+| `Plugin` (required) | `Name`, `Version`, `Critical`, `OnHealthCheck`, `OnShutdown` |
+| `CommandPlugin` | Plugin commands (REX-namespaced or main-namespace) |
+| `HookPlugin` | Pre/Post command hooks |
+| `OperationHookPlugin` | Operation lifecycle hooks (start/complete) |
+| `EventPlugin` | Subscription to server events |
+| `QueryPlugin` | Server introspection (`server:query:health`, `server:query:plugins`, `server:query:stats`) |
+| `ScopePlugin` | Declares requested scopes |
+
+Bundled IPC plugins:
+
+| Plugin | What it does |
+|---|---|
+| `plugins/dummy` | Lifecycle-only test plugin |
+| `plugins/gobservability` | Prometheus `/metrics`, OTEL tracing, `/healthz`/`/readyz`, log-line → span events |
+
+## Permissions and scopes
+
+IPC plugins declare `requested_scopes` in `RegisterV1`. The server validates them against config-allowed scopes (or the default `["read"]`) and grants a subset back in `RegisterAckV1`. Scopes are hierarchical: `admin > write > read`; `hook:pre`/`hook:post` are independent; `keys:<pattern>` restricts access to a key namespace.
+
+Hooks are silently dropped if the plugin lacks the matching `hook:pre`/`hook:post` scope. Operation hooks need `operation:hook`. Server queries follow the `server:query:*` hierarchy (e.g., `server:query` grants all topics).
+
+Embedded plugins are not scope-checked — they run with full server privilege. Use them only when the trade-off is acceptable.
+
+## See also
+
+- [docs/server/README.md](../server/README.md) — Server overview, build, run, configuration, env vars.
+- [docs/server/design/component/](../server/design/component/) — Component diagrams (core, memory eviction, event bus ring).
+- [docs/server/design/sequence/](../server/design/sequence/) — Sequence diagrams (command flow, persistence, transactions, graceful shutdown).
+- [docs/gcpc/README.md](../gcpc/README.md) — GCPC v1 protocol specification.
+- [docs/plugins/gobservability/README.md](gobservability/README.md) — Reference IPC plugin.

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -53,6 +53,7 @@ persistence:
 memory:
   max_memory_mb: 1024
   eviction_policy: "lru"
+  cache_shards: 8                    # default; must be a positive power of two
 
 workers:
   cleanup_interval: 1m
@@ -80,7 +81,7 @@ Configuration is hot-reloadable via fsnotify. Changes to memory limits, eviction
 
 ### Embedded plugins (compile-time-linked)
 
-A narrow set of capabilities must be active before config loads or before any IPC plugin can connect — crashdump collection, OTLP emission from t=0. These ship as **embedded plugins** linked in via build tags:
+A narrow set of capabilities must be active before config loads or before any IPC plugin can connect — crashdump collection, OTLP emission from t=0, pprof endpoint for production-shape profiling. These ship as **embedded plugins** linked in via build tags. See [docs/plugins/README.md](../plugins/README.md) for the full embedded-vs-IPC story and the api/-only import rule.
 
 ```bash
 # Default: no embedded plugins (15 MB).
@@ -88,6 +89,9 @@ go build ./cmd/server
 
 # With embedded crashdump scanner and OTLP exporter (~24 MB).
 go build -tags "crashdump otlp" ./cmd/server
+
+# With pprof endpoint enabled (binds 0.0.0.0:6060).
+go build -tags "crashdump otlp pprof" ./cmd/server
 
 # Docker: per-variant image matrix published to GHCR on every main push.
 docker pull ghcr.io/<org>/gocache:minimal   # no embedded
@@ -108,6 +112,7 @@ Embedded-plugin env vars (all optional):
 | `GOCACHE_EMBEDDED_OTLP_TIMEOUT_MS` | `3000` | Export timeout |
 | `GOCACHE_EMBEDDED_OTLP_INSECURE` | auto | True for `http://` endpoints |
 | `GOCACHE_EMBEDDED_OTLP_DISABLED` | `false` | Hard off-switch |
+| `GOCACHE_PPROF_ADDR` | `0.0.0.0:6060` | pprof bind address (only with `-tags pprof`) |
 
 ## Supported Commands
 
@@ -199,7 +204,10 @@ task test
 
 ## Design Documentation
 
-- Server diagrams: `docs/server/design/` — components, sequences, state machines (including `state_embedded_plugin_lifecycle.puml`, `components_event_bus_ring.puml`, `sequence_boot_crash_survivability.puml`)
+- Server diagrams: `docs/server/design/` — components, sequences, state machines (including `components_core.puml` for the multi-shard architecture, `state_embedded_plugin_lifecycle.puml`, `components_event_bus_ring.puml`, `sequence_boot_crash_survivability.puml`)
 - GCPC protocol diagrams: `docs/gcpc/design/` (including `sequence_ophook_replay_on_subscribe.puml`, `state_ophook_replay_suppression.puml`)
 - Full diagram index with links: [SOLUTION_ARCHITECTURE.md](SOLUTION_ARCHITECTURE.md#design-diagrams)
 - GCPC protocol specification: [docs/gcpc/README.md](../gcpc/README.md)
+- Plugin overview (embedded vs IPC, build tags, layering rule): [docs/plugins/README.md](../plugins/README.md)
+- Per-shard locking arc summary (thesis anchor): [docs/audits/per-shard-arc-summary.md](../audits/per-shard-arc-summary.md)
+- Go-vs-docker bench gap audit: [docs/audits/go-bench-vs-docker-gap.md](../audits/go-bench-vs-docker-gap.md)

--- a/docs/server/design/component/components_core.puml
+++ b/docs/server/design/component/components_core.puml
@@ -13,19 +13,21 @@ frame "GoCache Core System HLD" as F {
         rectangle "Evaluator Boundary" as eval {
             component [Evaluator] as Evaluator <<Dispatch>>
             component [Hook Executor] as HookExec <<Pre/Post Hooks>>
+            component [Operation Tracker] as OpTracker <<Op lifecycle>>
             component [Command Router] as CmdRouter <<Plugin Fallback>>
         }
 
         rectangle "Engine Boundary" as eng {
-            component [Engine\n(serial dispatch)] as Engine <<Serialization>>
+            component [Engine\n(per-shard goroutines)] as Engine <<Serial dispatch>>
             component [Transaction\nManager] as TransactionMgr <<MULTI/EXEC>>
             component [Watch Manager] as WatchMgr <<WATCH/UNWATCH>>
             component [Blocking Registry] as BlockingReg <<BLPOP/BRPOP>>
         }
 
         rectangle "Storage Boundary" as storage {
+            component [Cache Router\nshardIndexOf(key) =\nfnv1a(key) & (N-1)] as CacheRouter <<Shard fan-out>>
+            component [Shard 0 .. Shard N-1\n{mu, items, slab arena,\nLRU, usedBytes, maxBytes}] as Shards <<Per-shard state>>
             component [Persistence\nManager] as PersistenceMgr <<gob Snapshots>>
-            component [Cache\n(in-memory)] as InMemCache <<Maps + LRU>>
         }
 
         rectangle "Background Workers" as workers {
@@ -39,16 +41,27 @@ frame "GoCache Core System HLD" as F {
     ProtocolHandler --> Evaluator : Parsed command
 
     Evaluator --> HookExec : Pre/Post hooks
+    Evaluator --> OpTracker : Start/Complete op
     Evaluator --> CmdRouter : Plugin fallback
     Evaluator --> Engine : Core commands
     Evaluator --> TransactionMgr : MULTI/EXEC/DISCARD
 
-    Engine --> InMemCache : Lock -> fn() -> Unlock
+    Engine --> CacheRouter : DispatchToShard / DispatchToShards / DispatchWithResult
+    CacheRouter --> Shards : Lock(shardIDs) -> fn() -> Unlock
     Engine --> WatchMgr : Mutation notify
     Engine --> BlockingReg : Unblock waiters
 
-    SnapshotWorker --> PersistenceMgr : Periodic save
-    TTLWorker --> InMemCache : Sweep expired
+    SnapshotWorker --> PersistenceMgr : Periodic save (full lock)
+    TTLWorker --> Shards : Per-shard sweep
 }
+
+note right of Shards
+  **Default N = 8** (power-of-two; per-key fast path masks).
+  Single-key handlers take only the touched shard's lock.
+  Multi-key handlers acquire the sorted shard set
+  (deadlock-free); full-bulk handlers (FLUSHDB,
+  SAVE, KEYS) take all shards. Cross-shard cost
+  is the structural sharding tax — see audits/.
+end note
 
 @enduml

--- a/docs/server/design/component/components_memory_eviction.puml
+++ b/docs/server/design/component/components_memory_eviction.puml
@@ -1,72 +1,72 @@
 @startuml components_memory_eviction
 !include ../../../design/theme.iuml
 
-mainframe **cmp** Memory Management & LRU Eviction
+mainframe **cmp** Memory Management & LRU Eviction (per shard)
 
-package "Cache Internals" {
-    component "items\nmap[string]*Entry" as Items
-    component "ttl\nmap[string]int64" as TTL
-    component "sizes\nmap[string]int64" as Sizes
-    component "lruList\ncontainer/list.List" as LRU
-    component "lruMap\nmap[string]*Element" as LRUMap
+package "Cache" as cache {
+    component "shards []*Shard\nN = 8 (default)" as ShardArr
+    component "configMu sync.Mutex\nmaxBytes / evictionPolicy /\npacked thresholds" as Cfg
 }
 
-rectangle "Memory Tracking" {
-    component "usedBytes int64" as Used
-    component "maxBytes int64\n(0 = unlimited)" as Max
+package "Shard (one per fan-out slot)" as shard {
+    component "items\nmap[string]SlabPointer" as Items
+    component "nativeValues\nmap[SlabPointer]any\n(EncNative only)" as NV
+    component "keysBySlot\nmap[SlabPointer]string\n(reverse index for evict)" as KBS
+    component "slabs *slab.Allocator\n(per-shard arena)" as Slabs
+    component "lruHead / lruTail\nSlabPointer" as LRUEnds
+    component "usedBytes int64\nmaxBytes int64\n(per-shard share)" as Mem
 }
 
-rectangle "Eviction Policy" {
-    component "EvictionLRU\nallkeys-lru" as LRUPolicy
-    component "EvictionNone\nnoeviction" as NoEviction
+package "Slab metadata (slab.SlotMeta)" as meta {
+    component "LRUPrev / LRUNext\nSlabPointer" as LRULinks
+    component "LastAccessNs int64" as Last
+    component "ExpirationNs int64\n(0 = no TTL)" as Exp
+    component "NativeSize uint32\n(EncNative only)" as NS
+    component "ValueType / Encoding\nuint8 / uint8" as TypeEnc
 }
 
-rectangle "RawSet Flow" as SetFlow {
+ShardArr --> shard : shardIndexOf(key) = fnv1a(key) & (N-1)
+Items --> Slabs : SlabPointer resolves\nto slab slot bytes
+Items --> NV : EncNative entries\nside-tabled
+Items --> KBS : reverse for eviction
+Slabs --> meta : per-slot metadata array
+LRUEnds --> LRULinks : per-shard MRU/LRU\nthreaded through SlotMeta
+
+rectangle "Eviction Policy" as Policy {
+    component "EvictionLRU\n(allkeys-lru)" as LRUPolicy
+    component "EvictionNone\n(noeviction)" as NoEviction
+}
+
+rectangle "RawSet flow (per shard, write lock held)" as SetFlow {
     component "1. estimateSize(key, value)" as EstSize
-    component "2. Check usedBytes + delta > maxBytes" as Check
-    component "3a. evictLRU(delta)" as Evict
-    component "3b. return ErrOutOfMemory" as OOM
-    component "4. setInternal(key, value, exp)" as Store
+    component "2. delta = newSize - oldSize" as Delta
+    component "3. shard.usedBytes + delta\n   > shard.maxBytes ?" as Check
+    component "4a. evictLRU(delta)\n   walk lruTail backwards" as Evict
+    component "4b. return ErrOutOfMemory" as OOM
+    component "5. setPackedInternal /\n   setNativeInternal" as Store
 }
 
-EstSize -down-> Check
-Check -down-> Evict : policy = LRU
-Check -down-> OOM : policy = noeviction
+EstSize -down-> Delta
+Delta -down-> Check
+Check -down-> Evict : LRU
+Check -down-> OOM : noeviction
 Evict -down-> Store
 Check -down-> Store : within limit
 
-rectangle "evictLRU Loop" as EvictLoop {
-    component "lruList.Back()" as Back
-    component "delete(evictKey)" as Del
-}
-
-Evict --> Back : while over limit
-Back --> Del : remove oldest entry
-
-rectangle "estimateSize" as SizeCalc {
-    component "entryOverhead = 128 bytes" as Overhead
-    component "+ len(key)" as KeyLen
-    component "+ type-specific value size" as ValSize
-}
-
-note bottom of SizeCalc
-  string: len(s)
-  list: sum(len(s) + 16) per element
-  hash: sum(len(k) + len(v) + 32) per pair
-  set: sum(len(k) + 16) per member
-  zset: EstimateSize() method
+note right of Slabs
+  Per-shard slab arena. Default target
+  slab size scales by shard count
+  (DefaultTargetSlabBytes / N) so the
+  total in-process arena footprint stays
+  constant as N grows.
 end note
 
-LRU -[hidden]down- LRUMap
-Items -[hidden]right- TTL
-TTL -[hidden]right- Sizes
-
-note as N1
-  **LRU Ordering:**
-  Front = most recently used
-  Back = least recently used
-  Every RawGet/setInternal
-  moves key to front
+note bottom of meta
+  SlotMeta is the GC-opaque hot path for
+  LRU + TTL. The cache's main map went
+  from `map[string]*Entry` to
+  `map[string]SlabPointer` so the GC
+  scans far fewer pointers per cycle.
 end note
 
 @enduml

--- a/docs/server/design/sequence/sequence_command_flow.puml
+++ b/docs/server/design/sequence/sequence_command_flow.puml
@@ -1,7 +1,7 @@
 @startuml sequence_command_flow
 !include ../../../design/theme.iuml
 
-mainframe **sd** Core Command Flow (Hot Path)
+mainframe **sd** Core Command Flow (Hot Path, per-shard locking)
 
 actor Client
     participant "TCP Listener\n(net.Listener)" as Listener
@@ -10,8 +10,9 @@ actor Client
     participant "Evaluator\n(BaseEvaluator)" as Evaluator
     participant "Hook Executor" as HookExec
     participant "Command Router\n(plugin fallback)" as CmdRouter
-    participant "Engine\n(serial dispatch loop)" as Engine
-    participant "Cache\n(in-memory maps)" as Cache
+    participant "Engine\n(per-shard goroutines)" as Engine
+    participant "Cache Router\n(shardIndexOf)" as Router
+    participant "Shard(s)\n(write lock held)" as Shards
     participant "RESP Writer\n(resp.NewWriter)" as Writer
 
     Client -> Listener : TCP connect
@@ -45,8 +46,11 @@ actor Client
             ConnHandler -> Evaluator : Evaluate(ctx, op, args)
 
             hnote over Evaluator
-              Lookup handler in map
-              Validate arg count via commandSpecs
+              Lookup handler in map.
+              Validate arg count via commandSpecs.
+              Classify by sharding behavior:
+              KeyArgIndex (single-key) or
+              MultiKey (touched-shard set).
             end note
 
             alt Unknown command (not in core handlers)
@@ -70,16 +74,38 @@ actor Client
                 else Pre-hook allows (or no hooks)
                     HookExec --> Evaluator : OK
 
-                    Evaluator -> Engine : DispatchWithResult(fn)
-
-                    hnote over Engine : cmdChan <- Command{Execute, ResChan}
-
-                    Engine -> Cache : cache.Lock()
-                    activate Cache
-                    Engine -> Cache : fn() executes handler logic
-                    Cache --> Engine : result
-                    Engine -> Cache : cache.Unlock()
-                    deactivate Cache
+                    alt Single-key handler (most common)
+                        Evaluator -> Engine : DispatchToShard(ctx, shardIdx, fn)
+                        Engine -> Router : forward to shard goroutine
+                        Router -> Shards : shard.Lock()
+                        activate Shards
+                        Router -> Shards : fn() reads/mutates shard state
+                        Shards --> Router : result
+                        Router -> Shards : shard.Unlock()
+                        deactivate Shards
+                        Router --> Engine : result
+                    else Multi-key handler (MGET / MSET / SINTER ...)
+                        Evaluator -> Evaluator : touched := cache.TouchedShards(keys)
+                        Evaluator -> Engine : DispatchToShards(ctx, touched, fn)
+                        Engine -> Router : acquire touched shards in sorted order
+                        Router -> Shards : Lock all in touched set
+                        activate Shards
+                        Router -> Shards : fn() runs across the locked subset
+                        Shards --> Router : result
+                        Router -> Shards : Unlock in reverse
+                        deactivate Shards
+                        Router --> Engine : result
+                    else Full-bulk handler (KEYS / FLUSHDB / SAVE)
+                        Evaluator -> Engine : DispatchWithResult(ctx, fn)
+                        Engine -> Router : acquire ALL shards
+                        Router -> Shards : Lock(0..N-1)
+                        activate Shards
+                        Router -> Shards : fn() across the whole keyspace
+                        Shards --> Router : result
+                        Router -> Shards : Unlock all
+                        deactivate Shards
+                        Router --> Engine : result
+                    end
 
                     Engine --> Evaluator : result via ResChan
 
@@ -95,5 +121,14 @@ actor Client
             Writer --> Client : RESP-encoded response
         end
     end
+
+note right of Engine
+  **Sharding tax**: cross-shard handlers
+  (MSET, SINTER, MGET) pay a structural
+  cache-line bounce per shard touched.
+  Audit at docs/audits/per-shard-arc-summary.md
+  measures the residual MSET regression
+  vs the single-mutex baseline.
+end note
 
 @enduml


### PR DESCRIPTION
Phase 0 of the [persistence-as-plugin](https://github.com/j-mizera/gocache/issues — Obsidian plan) arc. Sweeps documentation that drifted across the per-shard locking arc + bench-gap audit + plugins-api-isolation refactor, fixes the long-broken wiki sync, and lays the foundation for ADRs 0001–0006 (next PR).

## Summary

- Diagrams refreshed for the multi-shard architecture (components_core, components_memory_eviction, sequence_command_flow).
- New \`docs/audits/per-shard-arc-summary.md\` — thesis anchor: every PR in the arc, measured deltas, what's structural vs fixable.
- New \`docs/plugins/README.md\` — top-level explainer for embedded vs IPC, build-tag matrix, the \`api/\`-only import rule.
- New \`docs/Home.md\` + \`docs/_Sidebar.md\` — wiki landing + nav, source-controlled.
- README + \`docs/server/README.md\` defaults updated (N=8 cache shards, \`GOCACHE_PPROF_ADDR\`, doc index).
- Wiki sync fixed: replaced \`newrelic/wiki-sync-action@main\` (silent failure) with explicit bash that fails visibly. Switches from GitHub App token (no Wiki permission exists for Apps — confirmed in app permissions UI) to classic PAT \`WIKI_SYNC_TOKEN\`. Skips cleanly with a warning if the secret is missing.

## What changed (file by file)

| File | Change |
|---|---|
| \`docs/server/design/component/components_core.puml\` | Cache router → \`shardIndexOf(key) = fnv1a(key) & (N-1)\` → per-shard state. Engine now per-shard goroutines. Three Dispatch variants documented. |
| \`docs/server/design/component/components_memory_eviction.puml\` | \`map[string]SlabPointer\` (not \`*Entry\`); per-shard slab arenas; LRU threaded through \`slab.SlotMeta\`; \`keysBySlot\` reverse index. |
| \`docs/server/design/sequence/sequence_command_flow.puml\` | New shard-routing branch: single-key (DispatchToShard), multi-key (DispatchToShards via TouchedShards), full-bulk (DispatchWithResult). |
| \`docs/audits/per-shard-arc-summary.md\` (new) | Thesis-anchor write-up: every issue in the arc, valkey ratios pre/post, structural-vs-fixable breakdown. |
| \`docs/plugins/README.md\` (new) | Embedded vs IPC matrix, build-tag table, \`api/\`-only rule, IPC plugin SDK overview. |
| \`docs/Home.md\` (new) | Wiki landing page (action does \`rsync --delete\`, source-controlled). |
| \`docs/_Sidebar.md\` (new) | Wiki nav. |
| \`README.md\` | 69 → 75 commands; per-shard mention; docs index. |
| \`docs/server/README.md\` | \`cache_shards: 8\` in YAML; \`GOCACHE_PPROF_ADDR\` env var; links to docs/plugins/, docs/audits/. |
| \`.github/workflows/release.yml\` | Wiki sync rewritten — explicit bash, \`set -euo pipefail\`, classic PAT auth, fails visibly. |

\`.claude/IMPLEMENTATION_STATUS.md\` updated locally with the same arc summary but not staged (\`.claude/\` is gitignored per project convention).

## Wiki sync — required admin action

Wiki sync will run on the next push to \`main\` and will skip cleanly with a workflow warning until the PAT is provisioned. To enable real sync:

## Test plan

- [x] \`go vet ./...\`
- [x] \`go build ./...\`
- [x] \`plantuml -checkonly\` on the three refreshed \`.puml\` files (clean output).
- [x] \`bash scripts/check-plugin-isolation.sh\` (still OK — no \`pkg/*\` imports under \`plugins/\`).
- [ ] CI green on the docs/lint/build/test/proto-check matrix.
- [ ] After merge: classic PAT added by you → next push triggers a successful wiki sync → wiki populated from \`docs/\`.

## Next

After merge:
- ADR scaffolding PR (\`docs/adr/\` README + template + 6 proposed ADRs for the persistence arc).
- \`feat/persistence-contract\` PR (api/persistence/ surface + coordinator skeleton).