### PR TITLE
fix(docs): align @startuml name with filename in components_hooks_priority

### DIFF
--- a/docs/gcpc/design/component/components_hooks_priority.puml
+++ b/docs/gcpc/design/component/components_hooks_priority.puml
@@ -1,4 +1,4 @@
-@startuml components_permission_priority
+@startuml components_hooks_priority
 !include ../../../design/theme.iuml
 
 frame "Plugin Hook & Priority System" as F {


### PR DESCRIPTION
The user spotted in the wiki: GCPC Components Diagrams page shows 8 of 9 expected diagrams. \`components_hooks_priority\` is missing.

## Diagnosis

\`\`\`bash
$ ls /tmp/gocache-wiki/*.svg | wc -l
39

$ find docs -name '*.puml' | wc -l
40

$ for p in $(find docs -name '*.puml' -printf '%f\n' | sed 's/.puml//'); do
    grep -q \"\$p\\.svg\$\" wiki-svgs.txt || echo \"\$p\";
  done
components_hooks_priority
\`\`\`

The .puml file's directive was \`@startuml components_permission_priority\` but the file is \`components_hooks_priority.puml\`. PlantUML writes its output under the \`@startuml\` name, not the filename, so it produced \`components_permission_priority.svg\` while the build script looked up \`components_hooks_priority.svg\`. SVG dropped silently — the build script's count stayed at 40/40 (one extra orphan SVG covering one missing one) so this slipped through.

## Fix

Rename the directive to match the filename. The diagram is a hook-priority diagram (matching its filename), not a permission diagram — the \`@startuml\` directive was stale from an earlier rename. Audit confirmed this is the only mismatch in the repo.

## Verification

\`\`\`bash
$ rm -rf wiki-staging && bash scripts/build-wiki.sh
…
    rendered 40 of 40 diagram(s)

$ ls wiki-staging/diagram-GCPC-Components-Diagrams-components_hooks_priority.svg
wiki-staging/diagram-GCPC-Components-Diagrams-components_hooks_priority.svg
\`\`\`

After merge: next push to main triggers wiki sync, GCPC Components Diagrams page will include \`components_hooks_priority\`.

## Test plan

- [x] Locally: 40/40 render, expected SVG name now exists.
- [ ] CI green.
- [ ] Wiki page \`GCPC-Components-Diagrams\` includes the hooks priority diagram after merge.