### PR TITLE
fix(wiki): install graphviz + use upstream plantuml jar in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,10 +277,25 @@ jobs:
         with:
           ref: main
 
-      - name: Install plantuml
+      - name: Install plantuml + graphviz
         run: |
+          set -euo pipefail
+          # graphviz provides `dot`, which plantuml needs to lay out
+          # component / state / class diagrams. apt's `plantuml` package
+          # ships an outdated jar (mishandles some state-diagram syntax
+          # newer plantuml parses fine), so we pull a current jar from
+          # upstream and wrap it as a `plantuml` command on PATH.
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends plantuml
+          sudo apt-get install -y --no-install-recommends graphviz default-jre-headless
+          PLANTUML_JAR=/usr/local/lib/plantuml.jar
+          sudo curl -fsSL -o "$PLANTUML_JAR" \
+            https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar
+          sudo tee /usr/local/bin/plantuml > /dev/null <<'WRAPPER'
+          #!/bin/sh
+          exec java -jar /usr/local/lib/plantuml.jar "$@"
+          WRAPPER
+          sudo chmod +x /usr/local/bin/plantuml
+          plantuml -version
 
       - name: Build flat wiki layout (renders .puml -> .svg)
         run: bash scripts/build-wiki.sh wiki-staging


### PR DESCRIPTION
The user reported (with screenshots) that some wiki diagrams render but others show errors:

- Component diagrams (\`Server-Components-Diagrams\`) and some state diagrams render as embedded text reading: \`Dot Executable: /opt/local/bin/dot — File does not exist — Cannot find Graphviz. You should try ... testdot ...\`
- \`state_hook_execution\` shows a partial render with \`Syntax Error?\` marker.
- Sequence diagrams (gobservability shown) and most other diagrams render correctly.

## Root cause

\`\`\`yaml
- name: Install plantuml
  run: sudo apt-get install -y --no-install-recommends plantuml
\`\`\`

Two compounding problems:

1. **\`--no-install-recommends\` strips graphviz.** PlantUML uses \`dot\` (graphviz) for layout of component, state, and class diagrams. Without it, those diagrams render as the boilerplate \"Cannot find Graphviz\" instructions. Sequence diagrams don't need dot, which is why they rendered fine.
2. **apt's plantuml jar is outdated.** Ubuntu 24.04 ships a jar from ~1.2024.x that mishandles some state-diagram syntax (nested states, certain inline labels). Local plantuml 1.2026.2 renders the same files cleanly — verified by the user's gobservability sequence screenshot which uses similar but simpler state syntax.

## Fix

Replace \`apt-get install plantuml\` with:

\`\`\`yaml
sudo apt-get install -y --no-install-recommends graphviz default-jre-headless
sudo curl -fsSL -o /usr/local/lib/plantuml.jar \\
  https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar
# Wrap as 'plantuml' on PATH so build-wiki.sh works unchanged
sudo tee /usr/local/bin/plantuml > /dev/null <<'WRAPPER'
#!/bin/sh
exec java -jar /usr/local/lib/plantuml.jar \"\$@\"
WRAPPER
sudo chmod +x /usr/local/bin/plantuml
\`\`\`

Now CI gets:
- \`graphviz\` for the \`dot\` binary
- A current plantuml.jar from the upstream GitHub release (latest stable)
- A drop-in \`plantuml\` wrapper so \`scripts/build-wiki.sh\` doesn't need any changes

Pinning to \`latest\` not a fixed version: plantuml's release cadence is fast and the jar is backwards-compatible with our diagrams. If a future upstream change ever breaks rendering, switching to a fixed version is a one-line change.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: next push to main triggers wiki sync; check the affected pages:
  - [ ] \`Server-Components-Diagrams\` no longer shows \"Cannot find Graphviz\" text.
  - [ ] \`Server-State-Diagrams\` and \`GCPC-State-Diagrams\` render without \"Syntax Error?\" markers.
  - [ ] All 40 SVGs render cleanly with proper layout.