### PR TITLE
docs(wiki): add Performance landing page + YAML frontmatter on every page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ task version        # Print all artifact versions
 - [docs/gcpc/README.md](docs/gcpc/README.md) — GCPC v1 protocol specification (Protobuf over Unix domain sockets).
 - [docs/server/design/](docs/server/design/) and [docs/gcpc/design/](docs/gcpc/design/) — PlantUML diagrams (component, sequence, state).
 - [docs/audits/](docs/audits/) — Performance audits and thesis anchors.
-- [.claude/IMPLEMENTATION_STATUS.md](.claude/IMPLEMENTATION_STATUS.md) — Phase-by-phase progress tracker.
+- [docs/performance/README.md](docs/performance/README.md) — Per-shard locking arc — shipped optimizations, measured deltas, remaining levers.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,3 +1,15 @@
+---
+title: Home
+description: GoCache wiki landing — entry point to server, plugins, GCPC, performance, audits, and design diagrams
+status: living
+last_updated: 2026-05-03
+related:
+  - Server
+  - Plugins
+  - GCPC
+  - Performance
+---
+
 # GoCache
 
 Redis-compatible in-memory cache server with a microkernel architecture. The core handles 75 commands across 5 data types over a per-shard locking design (default 8 shards, FNV-1a key routing). Everything else (Pub/Sub, Kafka, geospatial, auth, metrics, replication, persistence) runs as a plugin — most as separate processes via GCPC over Unix domain sockets, with a thin embedded-plugin tier for capabilities that must be active before config loads.
@@ -11,7 +23,8 @@ This wiki is **auto-generated** from `docs/` on every push to `main` via `script
 - **[Server](Server)** — Server overview, configuration, supported commands, env vars, embedded plugins.
 - **[Plugins](Plugins)** — Embedded vs IPC plugins, build-tag matrix, the `api/`-only import rule, available plugins.
 - **[GCPC protocol](GCPC)** — GCPC v1 specification (Protobuf over Unix domain sockets) — the contract IPC plugins implement.
-- Audits and thesis anchors:
+- **[Performance](Performance)** — Per-shard locking arc — shipped optimizations, measured deltas, structural caps, remaining levers.
+- Audits (cross-cutting — performance, design, races):
   - [Per-shard arc summary](Audit-per-shard-arc-summary)
   - [Go-vs-docker bench gap](Audit-go-bench-vs-docker-gap)
   - [clientctx cross-goroutine](Audit-clientctx-cross-goroutine)
@@ -36,8 +49,6 @@ This wiki is **auto-generated** from `docs/` on every push to `main` via `script
 | Phase 3 — REX metadata + Operations | ✅ Complete | Per-request metadata, server queries, operation tracker, replay-on-subscribe |
 | Phase 4 — Production hardening | 🔄 In progress | Memory optimization (slab + GC-opaque LRU) ✅; sink-aware fast path ✅; per-shard locking ✅; engine pooling ❌; read-lock bypass ❌; persistence-as-plugin ⏳ |
 | Phase 5 — Advanced plugins | ❌ Not started | OAuth2, Kafka, ratelimit, cluster |
-
-Detailed phase tracker: [`.claude/IMPLEMENTATION_STATUS.md`](https://github.com/j-mizera/gocache/blob/main/.claude/IMPLEMENTATION_STATUS.md) in the repo (not wiki — kept on `main` so it tracks merge state precisely).
 
 ## Project layout
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,6 +12,9 @@
 **Protocol**
 - [GCPC v1](GCPC)
 
+**Performance**
+- [Overview](Performance)
+
 **Diagrams (server)**
 - [Components](Server-Components-Diagrams)
 - [Sequences](Server-Sequence-Diagrams)

--- a/docs/audits/clientctx-cross-goroutine.md
+++ b/docs/audits/clientctx-cross-goroutine.md
@@ -1,3 +1,14 @@
+---
+title: ClientContext cross-goroutine audit
+description: Race-detector audit of every ClientContext field — surfaced from #32, no new races found beyond the watchDirty fix
+status: stable
+last_updated: 2026-05-03
+related:
+  - Performance
+  - Audit-per-shard-arc-summary
+  - Server-Architecture
+---
+
 # ClientContext cross-goroutine race audit
 
 **Issue:** [#35](https://github.com/j-mizera/gocache/issues/35)

--- a/docs/audits/go-bench-vs-docker-gap.md
+++ b/docs/audits/go-bench-vs-docker-gap.md
@@ -1,3 +1,13 @@
+---
+title: Go-vs-docker bench gap
+description: pprof-attributed audit explaining why Go bench shows +18% while docker shows +3% on the same code — runtime.selectgo park/unpark, not syscall cost
+status: stable
+last_updated: 2026-05-03
+related:
+  - Performance
+  - Audit-per-shard-arc-summary
+---
+
 # Go bench vs docker bench gap — investigation
 
 **Issue:** [#45](https://github.com/j-mizera/gocache/issues/45)

--- a/docs/audits/per-shard-arc-summary.md
+++ b/docs/audits/per-shard-arc-summary.md
@@ -1,3 +1,15 @@
+---
+title: Per-shard arc summary
+description: Thesis anchor — full chronicle of the per-shard locking arc, shipped PRs, structural caps, and remaining levers
+status: living
+last_updated: 2026-05-03
+related:
+  - Performance
+  - Audit-go-bench-vs-docker-gap
+  - Audit-clientctx-cross-goroutine
+  - Server-Architecture
+---
+
 # Per-shard locking arc — summary
 
 This is the thesis-anchor write-up for the per-shard locking arc that landed across issues #34 and follow-ups #43, #44, #46, #47, #48, #49, #50, plus the bench-methodology audit #45. It documents what was tried, what shipped, what didn't, and what's structurally bounded — so future readers know which gaps are still on the table and which are the price of the architecture.
@@ -113,4 +125,3 @@ Each branch directory contains `*-gocache.csv`, `*-gocache-pipelined.csv`, optio
 - Thesis writeup: this file plus `bench/results/perf-mset-locality-and-bench-gap/summary.md` and `docs/audits/go-bench-vs-docker-gap.md`.
 - Plan: [command-flow-optimization](../../projects/gocache/plans/command-flow-optimization.md), child plan [per-shard-locking](../../projects/gocache/plans/command-flow/per-shard-locking.md) (Obsidian).
 - Postmortem (Obsidian memory): `per-shard-arc-postmortem`.
-- Implementation status: [.claude/IMPLEMENTATION_STATUS.md](../../.claude/IMPLEMENTATION_STATUS.md) — per-shard arc section.

--- a/docs/gcpc/README.md
+++ b/docs/gcpc/README.md
@@ -1,3 +1,15 @@
+---
+title: GCPC
+description: GoCache Plugin Communication Protocol v1 — Protobuf over Unix domain sockets, the contract IPC plugins implement
+status: stable
+last_updated: 2026-05-03
+related:
+  - Plugins
+  - GCPC-Components-Diagrams
+  - GCPC-Sequence-Diagrams
+  - GCPC-State-Diagrams
+---
+
 # GCPC -- GoCache Plugin Communication Protocol
 
 GCPC is the binary protocol used for communication between the GoCache server and its plugins. Plugins run as separate OS processes and connect to the server over Unix domain sockets. All messages are Protobuf-encoded, versioned, and multiplexed via correlation IDs.

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,99 @@
+---
+title: Performance
+description: Per-shard locking arc — shipped optimizations, measured deltas, and what's still on the table
+status: living
+last_updated: 2026-05-03
+related:
+  - Audit-per-shard-arc-summary
+  - Audit-go-bench-vs-docker-gap
+  - Audit-clientctx-cross-goroutine
+  - Server-Architecture
+---
+
+# Performance
+
+This page is the single entry point for the gocache performance work. It narrates the per-shard locking arc, links every PR/issue that contributed, points at the audits that quantify what shipped, and lists the levers still on the table. It is the wiki-facing companion to the bench captures under `bench/results/<branch>/`.
+
+## Why per-shard?
+
+The original `pkg/cache.Cache` was a single map guarded by a single `sync.RWMutex`. Once the sink-aware fast path closed the instrumentation overhead (#26), that one mutex was the dominant write bottleneck on the standard pipelined `redis-benchmark` workload — every command from every connection serialised through it.
+
+Sharding the cache by key splits the map into `N` independent shards, each with its own mutex, items map, slab arena, and LRU. Routing is `shardIndexOf(key) = fnv1a(key) & (N-1)`, so unrelated keys mutate in parallel. Single-key handlers acquire one shard lock; multi-key handlers acquire the sorted set of touched shards (deadlock-free).
+
+The arc spans nine merged PRs plus a measurement audit. It moved gocache from **~0.5×** valkey on pipelined writes to **~0.7–0.95×** depending on workload, with a **−15 % RSS** memory delta as a side effect. This page chronicles each step, what it cost, and what it left behind.
+
+## The arc
+
+| PR / Issue | Branch | What shipped | Measured outcome |
+|---|---|---|---|
+| [#34](https://github.com/j-mizera/gocache/issues/34) | `arch/per-key-routing` | `Cache` becomes a router over `[]*Shard`; `DispatchToShard` / `DispatchToShards` on the engine; default N=16 | Pipelined writes: ~0.5× → ~0.85× valkey ratio |
+| [#43](https://github.com/j-mizera/gocache/pull/43) | `refactor/extract-shard` | `pkg/cache.Shard` extracted to a named type with constructor + methods | Refactor — no perf delta, sets up #44 |
+| [#44](https://github.com/j-mizera/gocache/pull/44) | `perf/selective-shard-locking` | Multi-key handlers (MGET, MSET, SINTER, SUNION, SDIFF, …) lock only the touched shard set instead of the global cache | Multi-key wins on workloads where keys hash to a small shard subset |
+| [#46](https://github.com/j-mizera/gocache/pull/46) | `perf/selective-shard-locking-multi-key` | `command.Context.TouchedShards` surfaces the touched-shard list to handlers | Threading-only refactor; no perf delta |
+| [#47](https://github.com/j-mizera/gocache/pull/47) | `perf/mset-locality-and-bench-gap` | `Shard.BulkSetBytes(pairs)` — pre-sort MSET pairs by destination shard; one bulk-set per shard while the sorted lock set is held | MSET cross-shard fan-out cost reduced; **does not** recover the regression (cause is structural) |
+| [#45](https://github.com/j-mizera/gocache/issues/45) | `perf/mset-locality-and-bench-gap` | Build-tag-gated pprof endpoint + Dockerfile `PPROF=1` build-arg + runtime profile rates | Bench gap audit — `runtime.selectgo` cum 18.74 % → 31.30 % in docker; gap is scheduler park/unpark from veth + iptables NAT, **not** syscall cost |
+| [#48](https://github.com/j-mizera/gocache/pull/48) | `perf/scale-slab-target-by-shard` | `DefaultTargetSlabBytes / N` per-shard slab target — without this, every shard allocates a full-size slab | RSS at N=16 came down −15 % at 1M keys |
+| [#49](https://github.com/j-mizera/gocache/pull/49) | `perf/encoding-and-bufpool` | (closed without merge) reusable `[]byte` bufpool for slab Set/Get + N=4 trial | **Negative result** — bufpool's `sync.Pool` round-trip cost more than the alloc it removed; N=4 lost throughput more than it saved memory |
+| [#50](https://github.com/j-mizera/gocache/pull/50) | `perf/lower-default-shard-count` | Default shard count 16 → 8 — N=8 within ~3 % of N=16's throughput optimum on mixed pipelined GetSet, with half the per-shard overhead | Ship default lowered; memory wins keep, throughput essentially flat |
+
+The plugin-isolation refactor that landed alongside the perf arc is tracked separately under [#52 / #53](https://github.com/j-mizera/gocache/pull/53) — it didn't move benchmarks but it's what makes future persistence-as-plugin work possible without dragging server internals into the plugin contract.
+
+## Headline numbers
+
+After every follow-up shipped, on the standardised pipelined `redis-benchmark` workload at the dockerized bench harness (cpuset 0-3, memory 2g):
+
+| Workload | Pre-arc ratio | Post-arc ratio | Notes |
+|---|---|---|---|
+| Pipelined SET | ~0.5× | ~0.85× | Per-key shard routing |
+| Pipelined GET | ~0.5× | ~0.85× | Same |
+| Pipelined HSET | ~0.5× | ~0.85× | Single-key |
+| Pipelined SADD | ~0.5× | ~1.1× | +119 % from baseline |
+| Pipelined LPUSH | ~0.5× | ~0.95× | Single-key |
+| Pipelined MSET | ~0.5× | **~0.55×** | Cross-shard cache-line tax (structural) |
+| Standard SET | parity | parity | TCP syscall ceiling caps RPS |
+| Memory (RSS, 1M keys) | baseline | **−15 %** | Slab arena scaling per shard |
+
+Per-PR captures are stored at `bench/results/<branch>/` with a `summary.md` describing each delta. The taxonomy mirrors the PR table above.
+
+## Audits
+
+The arc produced three audit documents that are the source of truth for thesis-grade claims about *why* a given delta exists:
+
+- **[Per-shard arc summary](Audit-per-shard-arc-summary)** — the long-form thesis anchor. Walks through every shipped PR, the structural caps (MSET regression, cross-shard cache-line tax, default-deployment memory cost), and what's still on the table.
+- **[Go-vs-docker bench gap](Audit-go-bench-vs-docker-gap)** — pprof-attributed investigation of why Go bench shows +18 % pipelined-GET while docker shows +3 % on the same code. Conclusion: the gap is `runtime.selectgo` arbitration from docker's veth + iptables NAT, not syscall cost. Future arcs should report both tiers.
+- **[clientctx cross-goroutine race audit](Audit-clientctx-cross-goroutine)** — surfaced from #32, but methodologically tied to the per-shard work because per-shard locking changes which goroutine writes which field. Sweeps every `ClientContext` field for cross-goroutine read/write hazards. No new races found beyond the one #32 fixed.
+
+Audits are intentionally not folded into a "Performance" group — an audit can relate to anything (perf, design, security, race conditions). The three above happen to all fall under the perf arc, but the category is kept separate.
+
+## What's structural (won't be recovered)
+
+Some costs are the price of the architecture and won't come back without un-sharding:
+
+- **MSET regression −31 %** vs the single-mutex baseline. Every MSET spans multiple shards; each shard touched costs a cache-line bounce on the shared per-shard lock plus per-shard book-keeping (LRU update, used-bytes, eviction check). The single-mutex baseline pays one of each per command; sharding pays N. Recovering this would require fundamentally different sharding (RCU, transactional memory, COW) — out of scope for the thesis.
+- **Cross-shard cache-line tax** on any K-shard handler — pays K-times-shard-overhead vs a single-mutex implementation paying once. Single-key handlers (the overwhelmingly common case) win because K=1 < N; multi-key handlers' break-even depends on key distribution.
+- **Default-deployment memory cost** — even with #48's slab scaling, N shards each carry their own maps, channel pools, and slab metadata. At N=8 the baseline RSS is ~10× valkey's at 1M keys. Most of that is the persistence layer (gob snapshot worker + handlers), and is the target of the upcoming persistence-as-plugin arc.
+- **Bench tier disagreement** — Go bench and docker bench will disagree by 5–10× in relative-percentage terms. This is the nature of the measurement, not a bug. Acceptance criteria denominated in docker rps must be measured in docker; Go bench can't substitute. See the bench-gap audit for the pprof-attributed write-up.
+
+## What's still on the table
+
+Future levers — not shipped, tracked under the command-flow optimization plan in Obsidian:
+
+- **#27 engine pooling** — pool `make(chan any, 1)` resChan + `*command.Context` allocations per command. Profile-attributed projection: +10–15 % uniform across workloads. Single biggest remaining alloc-pressure lever (the `*ops.Operation` per command is ~163 bytes, 38 % of hot-path allocation; engine pooling brackets it directly).
+- **#28 read-lock bypass** — classify commands as read-only, drop LRU-list mutation on the read path, run read handlers inline under `cache.RLock()`. Projection: pipelined GET → ~0.85× valkey (closes the GET gap entirely). The methodology lessons from this work are in `pkg/server/it_concurrency_test.go::TestIT_WatchPropagation_ReadLockBypass`.
+- **#29 batched pipelined dispatch** — single-lock-acquisition for batched same-key pipelined writes. Decision-gated; only worth pursuing if pipelined-write headroom remains ≥30 % after #27/#28.
+
+These three together are projected to close the remaining gap to valkey on every workload except MSET (which is structural). They're sequenced after the persistence-as-plugin arc so persistence is no longer the dominant fixed RSS cost when read-lock bypass is measured.
+
+## Lessons
+
+1. **Always report two tiers of bench numbers** — Go in-process (`go test -bench`) for hot-path attribution and docker (`valkey-benchmark` against the published image) for end-to-end. They will disagree by 5–10× and that's expected.
+2. **Negative results matter** — #49 burnt three days but the writeup tells future contributors not to retry the bufpool path or N=4 default unless something fundamental changes.
+3. **Memory is just as much a thesis line as throughput** — #48's −15 % RSS without a throughput cost is a clean win that wouldn't have happened without explicit profiling of arena overhead.
+4. **The bench gap audit is reusable** — any future "why does docker disagree with Go bench" question now has a writeup at `Audit-go-bench-vs-docker-gap` and a pprof toggle to attach a profiler in production-shape builds.
+
+## Pointers
+
+- Bench captures: `bench/results/<branch>/` per PR (in the repo)
+- Architecture diagrams: [Server: Component Diagrams](Server-Components-Diagrams), [Server: Sequence Diagrams](Server-Sequence-Diagrams)
+- Solution architecture: [Server-Architecture](Server-Architecture)
+- Roadmap and merge state: [Server Roadmap](Server-Roadmap) (wiki) and the merged-PRs feed on the repo's `main` branch

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,3 +1,14 @@
+---
+title: Plugins
+description: Embedded vs IPC plugin tiers, build-tag matrix, the api/-only contract surface, available plugins
+status: living
+last_updated: 2026-05-03
+related:
+  - Server
+  - GCPC
+  - Plugin-Gobservability
+---
+
 # Plugins
 
 GoCache extends a microkernel core with two kinds of plugin: **embedded** (compile-time-linked, in-process) and **IPC** (separate process over GCPC v1 protocol on a Unix domain socket). Both implement contracts in `gocache/api/*`. The choice is per-plugin and depends on what the plugin does.

--- a/docs/plugins/gobservability/README.md
+++ b/docs/plugins/gobservability/README.md
@@ -1,3 +1,15 @@
+---
+title: Gobservability Plugin
+description: Prometheus metrics exporter — per-command counters, latency histograms, /metrics endpoint
+status: living
+last_updated: 2026-05-03
+related:
+  - Plugins
+  - Plugin-Gobservability-Architecture
+  - Plugin-Gobservability-Roadmap
+  - Plugin-Gobservability-Components-Diagrams
+---
+
 # Gobservability Plugin
 
 Prometheus metrics exporter for GoCache. Hooks every command via a post-hook, tracks per-command counters and latency histograms, and serves a `/metrics` HTTP endpoint in Prometheus text exposition format.

--- a/docs/plugins/gobservability/ROADMAP.md
+++ b/docs/plugins/gobservability/ROADMAP.md
@@ -1,3 +1,13 @@
+---
+title: Gobservability Roadmap
+description: Phase tracker for the gobservability plugin — counters, histograms, info gauge, server-measured latency
+status: living
+last_updated: 2026-05-03
+related:
+  - Plugin-Gobservability
+  - Plugin-Gobservability-Architecture
+---
+
 # Gobservability Roadmap
 
 ## v0.1 -- COMPLETE

--- a/docs/plugins/gobservability/SOLUTION_ARCHITECTURE.md
+++ b/docs/plugins/gobservability/SOLUTION_ARCHITECTURE.md
@@ -1,3 +1,14 @@
+---
+title: Gobservability Architecture
+description: Design decisions for the metrics exporter — post-hook only, IPC plugin, in-memory aggregation, /metrics serve
+status: living
+last_updated: 2026-05-03
+related:
+  - Plugin-Gobservability
+  - Plugin-Gobservability-Components-Diagrams
+  - Plugin-Gobservability-Sequence-Diagrams
+---
+
 # Gobservability -- Solution Architecture
 
 ## Overview

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,3 +1,16 @@
+---
+title: Server
+description: Server overview — RESP, command set, configuration, env vars, embedded plugin tier
+status: living
+last_updated: 2026-05-03
+related:
+  - Server-Architecture
+  - Server-Roadmap
+  - Server-Components-Diagrams
+  - Performance
+  - Plugins
+---
+
 # GoCache Server
 
 The server is the core component of GoCache -- a Redis-compatible in-memory cache with a microkernel architecture. It handles RESP protocol parsing, command evaluation, memory management, persistence, and plugin orchestration.

--- a/docs/server/ROADMAP.md
+++ b/docs/server/ROADMAP.md
@@ -1,3 +1,14 @@
+---
+title: Server Roadmap
+description: Phase tracker for the server — core cache, plugin framework, REX metadata, production hardening, advanced plugins
+status: living
+last_updated: 2026-05-03
+related:
+  - Server
+  - Server-Architecture
+  - Performance
+---
+
 # Server Roadmap
 
 ## Phase 1: Core Cache -- COMPLETE

--- a/docs/server/SOLUTION_ARCHITECTURE.md
+++ b/docs/server/SOLUTION_ARCHITECTURE.md
@@ -1,3 +1,15 @@
+---
+title: Server Architecture
+description: Microkernel solution architecture — design principles, per-shard locking, dispatch model, plugin tiers
+status: living
+last_updated: 2026-05-03
+related:
+  - Server
+  - Server-Components-Diagrams
+  - Server-Sequence-Diagrams
+  - Performance
+---
+
 # Solution Architecture
 
 ## Overview

--- a/scripts/build-wiki.sh
+++ b/scripts/build-wiki.sh
@@ -38,16 +38,37 @@ mkdir -p "$OUTDIR"
 
 echo "==> Building wiki staging at $OUTDIR/"
 
-# 1. Top-level pages — copied 1:1 (these are wiki-aware already).
-cp "$DOCSROOT/Home.md"     "$OUTDIR/Home.md"
-cp "$DOCSROOT/_Sidebar.md" "$OUTDIR/_Sidebar.md"
+# Strip leading YAML frontmatter (--- ... ---) from a markdown file before
+# publishing to the wiki. GitHub's wiki renderer (Gollum) does not consume
+# Jekyll-style frontmatter and would show the raw YAML as plain text at the
+# top of every page. The frontmatter is intentional metadata for repo readers
+# and tooling — it just doesn't belong in the rendered wiki output.
+#
+# Idempotent: if the file has no frontmatter, output equals input.
+strip_frontmatter() {
+  local src="$1"
+  local dst="$2"
+  awk '
+    BEGIN { in_fm = 0; fm_seen = 0 }
+    NR == 1 && /^---$/ { in_fm = 1; fm_seen = 1; next }
+    in_fm && /^---$/   { in_fm = 0; next }
+    in_fm              { next }
+    { print }
+  ' "$src" > "$dst"
+}
 
-# 2. Section overview pages — flatten and rename so the wiki URL is clean.
+# 1. Top-level pages — _Sidebar.md is a special wiki nav file and intentionally
+#    does not carry frontmatter. Home.md does, and gets stripped on copy.
+strip_frontmatter "$DOCSROOT/Home.md"     "$OUTDIR/Home.md"
+cp                "$DOCSROOT/_Sidebar.md" "$OUTDIR/_Sidebar.md"
+
+# 2. Section overview pages — flatten, rename, strip frontmatter so the wiki
+#    URL is clean and YAML metadata doesn't bleed into rendered pages.
 copy_renamed() {
   local src="$1"
   local dst="$2"
   if [[ -f "$src" ]]; then
-    cp "$src" "$OUTDIR/$dst"
+    strip_frontmatter "$src" "$OUTDIR/$dst"
     echo "    $src -> $dst"
   fi
 }
@@ -62,14 +83,17 @@ copy_renamed "$DOCSROOT/plugins/gobservability/ROADMAP.md"     "Plugin-Gobservab
 copy_renamed "$DOCSROOT/plugins/gobservability/SOLUTION_ARCHITECTURE.md" \
                                                                "Plugin-Gobservability-Architecture.md"
 copy_renamed "$DOCSROOT/gcpc/README.md"                        "GCPC.md"
+copy_renamed "$DOCSROOT/performance/README.md"                 "Performance.md"
 
 # 3. Audits — `Audit-<basename>.md` keeps them grouped in the flat namespace.
+#    Audits are cross-cutting (performance, design, races) so they keep their
+#    own group rather than being folded under Performance.
 echo "==> Audits"
 if [[ -d "$DOCSROOT/audits" ]]; then
   for f in "$DOCSROOT/audits"/*.md; do
     [[ -f "$f" ]] || continue
     base=$(basename "$f" .md)
-    cp "$f" "$OUTDIR/Audit-${base}.md"
+    strip_frontmatter "$f" "$OUTDIR/Audit-${base}.md"
     echo "    $f -> Audit-${base}.md"
   done
 fi
@@ -223,6 +247,10 @@ declare -A REWRITES=(
   ['](audits/per-shard-arc-summary.md)']='](Audit-per-shard-arc-summary)'
   ['](audits/go-bench-vs-docker-gap.md)']='](Audit-go-bench-vs-docker-gap)'
   ['](audits/clientctx-cross-goroutine.md)']='](Audit-clientctx-cross-goroutine)'
+  ['](performance/README.md)']='](Performance)'
+  ['](performance/README)']='](Performance)'
+  ['](../performance/README.md)']='](Performance)'
+  ['](../performance/README)']='](Performance)'
   ['](gobservability/README.md)']='](Plugin-Gobservability)'
   ['](gobservability/README)']='](Plugin-Gobservability)'
   ['](SOLUTION_ARCHITECTURE.md)']='](Server-Architecture)'


### PR DESCRIPTION
## Summary

- New **Performance** wiki page (`docs/performance/README.md` → wiki `Performance`) — single entry point for the per-shard locking arc: narrative, PR/issue table, headline numbers, structural caps, remaining levers, audit links
- **YAML frontmatter** on every tracked `docs/*.md` (`title` / `description` / `status` / `last_updated` / `related`). `_Sidebar.md` intentionally skipped — special wiki nav
- `scripts/build-wiki.sh` — new `strip_frontmatter` awk pass on every copy so Gollum doesn't render the YAML as plain text. Performance page wired in, link rewrites added for `performance/`
- `docs/Home.md` and `docs/_Sidebar.md` surface **Performance** as its own section above Audits. Audits stay separate (cross-cutting — perf, design, races) with a clarified caption

## Why a standalone page

The per-shard arc spans 9 PRs and 3 audits. Audits live under `docs/audits/` and don't form a narrative — they're each a deep-dive on one question. The Performance page is the wiki-facing thesis anchor that walks readers from "why per-shard?" through "what shipped" / "what's structural" / "what's still on the table" without forcing them to stitch the audits together themselves.

## Why frontmatter

Per-file metadata for repo readers and tooling (related-pages graphs, status surfacing, future RSS-style feeds). Stripped on the wiki side because GitHub's Gollum renderer would show the YAML as raw text otherwise. Idempotent — pages without frontmatter pass through unchanged.

## Test plan

- [x] `bash scripts/build-wiki.sh wiki-staging` runs clean locally — 40/40 diagrams render, Performance.md generated, frontmatter stripped on all wiki pages
- [x] Source files still carry frontmatter (`head -3 docs/Home.md` shows `---` block)
- [x] No `.claude/...` references in any tracked `.md` (per memory feedback)
- [ ] CI wiki-sync workflow renders Performance.md correctly on the live wiki after merge
- [ ] Sidebar shows new **Performance** group above Audits