### PR TITLE
docs(adr): scaffold docs/adr/ + 6 proposed ADRs for persistence-as-plugin (closes #60)

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -24,6 +24,7 @@ This wiki is **auto-generated** from `docs/` on every push to `main` via `script
 - **[Plugins](Plugins)** — Embedded vs IPC plugins, build-tag matrix, the `api/`-only import rule, available plugins.
 - **[GCPC protocol](GCPC)** — GCPC v1 specification (Protobuf over Unix domain sockets) — the contract IPC plugins implement.
 - **[Performance](Performance)** — Per-shard locking arc — shipped optimizations, measured deltas, structural caps, remaining levers.
+- **[Decisions (ADR)](ADR)** — Architecture Decision Records — the durable record of significant architectural choices.
 - Audits (cross-cutting — performance, design, races):
   - [Per-shard arc summary](Audit-per-shard-arc-summary)
   - [Go-vs-docker bench gap](Audit-go-bench-vs-docker-gap)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -15,6 +15,15 @@
 **Performance**
 - [Overview](Performance)
 
+**Decisions (ADR)**
+- [Index](ADR)
+- [0001 — Pluggable log+snapshot](ADR-0001-persistence-as-pluggable-log-snapshot)
+- [0002 — Source/Sink contract](ADR-0002-source-sink-contract)
+- [0003 — Mutation feed + fsync](ADR-0003-mutation-feed-and-fsync)
+- [0004 — Command namespacing](ADR-0004-command-namespacing)
+- [0005 — Snapshot wire format](ADR-0005-snapshot-wire-and-file-format)
+- [0006 — Built-in vs IPC transport](ADR-0006-builtin-vs-third-party-transport)
+
 **Diagrams (server)**
 - [Components](Server-Components-Diagrams)
 - [Sequences](Server-Sequence-Diagrams)

--- a/docs/adr/0001-persistence-as-pluggable-log-snapshot.md
+++ b/docs/adr/0001-persistence-as-pluggable-log-snapshot.md
@@ -1,0 +1,72 @@
+---
+title: ADR-0001 Persistence as pluggable log+snapshot+LSN
+description: Persistence moves from in-tree gob snapshot worker to a pluggable log+snapshot model with monotonic LSNs, allowing built-in and third-party providers
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0002-source-sink-contract
+  - ADR-0003-mutation-feed-and-fsync
+  - ADR-0006-builtin-vs-third-party-transport
+  - Server-Architecture
+  - Performance
+---
+
+# ADR-0001: Persistence as pluggable log+snapshot+LSN
+
+## Context
+
+The current persistence implementation lives inside the server binary: a single goroutine drives gob-encoded snapshots, plus a planned in-tree AOF that never shipped. That layout has three problems. First, persistence is the dominant fixed RSS cost in a default deployment (~10× valkey at 1M keys, per the per-shard arc summary), and its memory shape is tied to the gob encoder's internals. Second, the snapshot/AOF dichotomy is hard-wired — users can pick `snapshot` or `aof` in YAML but cannot mix, replace, or extend the persistence layer. Third, third-party use cases like "boot from PostgreSQL", "stream mutations to Kafka", or "replicate to S3" have no extension point at all.
+
+Prior art for the durability shape: etcd / Raft (log + periodic snapshot, both keyed by Raft index), PostgreSQL (WAL + base backup, LSN-keyed), Redis 7 (multi-part AOF — base + incremental files, replication-id-keyed), WiredTiger (pluggable storage `Env` for source-of-truth backends), Cassandra (commitlog + memtable flush + sstable). All five share the same primitives: an append-only mutation log, periodic full snapshots, and a monotonic position cursor that ties them together.
+
+## Decision
+
+Persistence becomes a pluggable subsystem keyed by **log + snapshot + LSN** (Log Sequence Number). The server emits a totally-ordered stream of mutations, each tagged with a monotonic 64-bit LSN; persistence providers consume that stream however they like (durable log, replication channel, archive). On boot, providers replay state from a snapshot at LSN=N and re-apply mutations from N+1 forward. Built-in snapshot and AOF become embedded plugins implementing the same contract; third-party providers (Postgres, S3, Kafka, custom) implement the contract via the public `api/persistence/` surface.
+
+## Alternatives Considered
+
+### Alternative 1: Keep gob snapshot in-tree, add AOF in-tree
+
+- **Pros**: Smallest diff. No new contract surface. Familiar to anyone who's read the codebase.
+- **Cons**: Doesn't fix the RSS overhead. Doesn't enable third-party providers. The "pick snapshot or AOF" toggle stays single-choice. Future work to add replication / archival starts from the same in-tree dead end.
+- **Why not**: This was the original Phase 1 plan and is exactly what the per-shard arc summary identifies as the *next* major bottleneck (default-deployment memory cost). Sinking effort here doesn't move the thesis line.
+
+### Alternative 2: Pure WAL (no snapshots)
+
+- **Pros**: Simplest provider contract — providers consume a single mutation stream. No bifurcated state. Matches Postgres logical decoding directly.
+- **Cons**: Recovery time grows with log length. Without snapshots, every cold boot re-applies the full mutation history — unbounded for long-running deployments. Compaction has to live somewhere, which reintroduces the snapshot concept under a different name.
+- **Why not**: Recovery time is bounded only by snapshot cadence. Pure-WAL works at Postgres scale because the underlying store is durable B-trees that don't need replay; for an in-memory cache, snapshots aren't optional.
+
+### Alternative 3: Pure snapshot (no log)
+
+- **Pros**: Matches the current gob model. Simple recovery: load the latest snapshot, done.
+- **Cons**: Recovery loses everything between the last snapshot and the crash. AOF exists in Redis specifically because snapshot-only durability is unacceptable for many workloads. Third-party "stream mutations" use cases have no hook point.
+- **Why not**: Re-implements the same gap that motivated Redis to add AOF in 2010. Not a step forward.
+
+### Alternative 4: External durability service (e.g., always-on Kafka)
+
+- **Pros**: Offloads durability entirely. Leaner server binary.
+- **Cons**: Hard external dependency for a basic cache. Drops the "single binary, no infrastructure" property that makes gocache approachable. Forces a transport choice on every user.
+- **Why not**: The contract should *allow* this (third-party plugin) without *requiring* it. Built-in providers must work standalone.
+
+## Consequences
+
+### Positive
+
+- Built-in snapshot and AOF can ship without bloating the core. They live as embedded plugins (see ADR-0006), share the same contract as third-party providers, and can be selectively excluded at build time.
+- Third-party providers (Postgres source, Kafka sink, S3 archive) are first-class. They plug into the same `api/persistence/` surface as built-ins.
+- Recovery is bounded by snapshot cadence regardless of mutation rate. Long-running deployments don't accumulate unbounded replay time.
+- LSN cursoring lets multiple providers coexist (e.g., snapshot to disk + replicate to S3) without each duplicating the mutation stream.
+- The persistence layer's RSS shape is no longer hardwired to gob's encoder internals — see ADR-0005.
+
+### Negative
+
+- More contract surface to design, document, and version. The `api/persistence/` package becomes a public-stability target.
+- Two-stage provider boot (snapshot replay → log replay) is more complex than gob's one-shot load. This is the cost of bounded recovery time.
+- Coordinating multiple providers (primary + replicas) introduces ordering questions that single-provider gob never had.
+
+### Risks
+
+- **Risk**: The contract turns out to be too narrow once real third-party providers are written. **Mitigation**: Status `proposed` until the built-in snapshot and AOF plugins both ship against the contract — that's two very different implementations exercising the same surface. If they reveal gaps, the contract revises before flipping to `accepted`.
+- **Risk**: LSN allocation under per-shard locking re-introduces the global-mutex bottleneck the per-shard arc removed. **Mitigation**: ADR-0003 discusses fsync batching at the LSN-allocation site; the mutation feed is intentionally async from the cache write path.

--- a/docs/adr/0002-source-sink-contract.md
+++ b/docs/adr/0002-source-sink-contract.md
@@ -1,0 +1,83 @@
+---
+title: ADR-0002 Source/Sink contract with BootMode trichotomy
+description: Persistence contract splits into Source (recovery-side, supplies state on boot) and Sink (mutation-side, consumes ongoing writes), with a BootMode trichotomy of Snapshot/Replay/Initial
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0003-mutation-feed-and-fsync
+  - ADR-0006-builtin-vs-third-party-transport
+---
+
+# ADR-0002: Source/Sink contract with BootMode trichotomy
+
+## Context
+
+ADR-0001 establishes that persistence is a pluggable subsystem keyed by log+snapshot+LSN. The next decision is the *shape* of the contract: what interfaces does a provider implement, and how do they cooperate with the server?
+
+A persistence provider does two distinct jobs. On boot, it supplies whatever recovery state the server needs to reconstitute — a snapshot, a replay log, or a signal that there's nothing to load. During steady-state operation, it consumes the mutation feed as commands execute, and is responsible for whatever durability semantics the user signed up for (fsync-every-second, async write-behind, replicate to a remote endpoint, etc.).
+
+These are different responsibilities with different lifetimes (boot-only vs always-on), different failure semantics (boot failure aborts startup; sink failure can be recoverable), and different concurrency requirements (boot is single-threaded by definition; sinks see the full mutation stream and must handle it without blocking the cache write path). Mashing them into one interface forces every provider author to think about both even when they only care about one.
+
+## Decision
+
+The contract splits into two interfaces in `api/persistence/`:
+
+- **`Source`** — boot-side. Returns a `BootMode` indicating what kind of state it has, plus the corresponding artefact (snapshot reader, log replay iterator, or nothing). Used exactly once per server lifetime.
+- **`Sink`** — runtime-side. Receives the ongoing mutation feed. Used for the entire server lifetime after boot.
+
+Both interfaces share an LSN cursor so providers that implement both (the common case for built-ins) can advance the cursor coherently across snapshot + log.
+
+`BootMode` is a closed trichotomy:
+
+- `BootModeSnapshot` — provider supplies a point-in-time snapshot at LSN=N. Server loads the snapshot, then resumes the mutation feed from LSN=N+1.
+- `BootModeReplay` — provider supplies an iterator over the mutation log starting from LSN=0 (or the lowest available LSN). Server replays each mutation in order.
+- `BootModeInitial` — provider has nothing to load. Server starts from an empty cache.
+
+A provider can implement both `Source` and `Sink` (built-ins do); third-party providers can implement only one (a pure archival sink, or a one-shot Postgres-as-cache loader).
+
+## Alternatives Considered
+
+### Alternative 1: Single bidirectional `Persistence` interface
+
+- **Pros**: Fewer types to learn. One mental model.
+- **Cons**: Forces every provider to implement boot logic even when it only ever consumes the mutation feed, and vice versa. Encourages no-op stubs. Harder to evolve — adding a method affects every implementor.
+- **Why not**: The two responsibilities have different lifetimes and failure semantics; bundling them into one interface optimizes for the wrong axis.
+
+### Alternative 2: Monolithic `Provider` plugin (Kafka-Connect style)
+
+- **Pros**: Matches a familiar pattern (Kafka source/sink connectors). Each provider is one self-contained unit.
+- **Cons**: The Connect framework's source/sink terminology actually matches what we're doing — splitting them is the *right* lesson from Connect, not the wrong one. A monolithic Provider would re-bundle them. Also: the user pushed back on the Kafka-Connect framing explicitly during plan review.
+- **Why not**: User feedback during plan review was explicit: "it doesn't have to be kafka source/sink like, I want it to be efficient and a good design". The split-interface design is the efficient version of the same idea.
+
+### Alternative 3: Boolean BootMode (snapshot vs no-snapshot)
+
+- **Pros**: Fewer states to handle. Matches gob's current "load if file exists, else start empty" model.
+- **Cons**: No room for a pure-replay provider (e.g., AOF without a snapshot, or a third-party WAL source). Forces every replay-style provider to fake a synthetic snapshot at LSN=0 — confusing and error-prone.
+- **Why not**: Closed trichotomy is the smallest set of states that distinguishes the three legitimate boot paths. Two states forces unnatural workarounds.
+
+### Alternative 4: `BootMode` as an open interface with custom modes
+
+- **Pros**: Maximally flexible. Future providers could add new modes (e.g., `BootModePartial` for incremental boot).
+- **Cons**: Open enums prevent the server from exhaustively handling all cases at boot time. Every new mode would need server-side dispatch. Defeats the point of a closed contract.
+- **Why not**: Boot complexity should be bounded; if a fourth mode is genuinely needed later, it can be added to the closed enum (and that's a contract revision worth its own ADR).
+
+## Consequences
+
+### Positive
+
+- Provider authors only implement the half they care about. A pure archival sink doesn't have to write a `Source` stub.
+- Boot failure semantics are localized to `Source` — sinks can fail and recover without aborting the server.
+- The `BootMode` trichotomy makes server-side boot dispatch exhaustive: a `switch BootMode` covers every case at compile time.
+- Built-ins (snapshot, AOF) implement both interfaces and share the LSN cursor coherently.
+
+### Negative
+
+- Two interface types instead of one. Slightly more surface to document.
+- Providers that implement both have to maintain LSN coordination between their `Source` and `Sink` halves. The contract documents this; the built-ins demonstrate the pattern.
+
+### Risks
+
+- **Risk**: A real-world provider needs a fourth boot mode we didn't anticipate. **Mitigation**: Closed trichotomy is intentional — adding a fourth mode is an explicit contract revision (new ADR). The cost of "I have to write a new ADR" is the right gate for "we're broadening the contract".
+- **Risk**: Providers implement `Source` and `Sink` with subtly inconsistent LSN semantics. **Mitigation**: The contract documents the LSN invariants; the built-in implementations are the reference. ADR-0003 covers the mutation-feed side of the same coordination.

--- a/docs/adr/0003-mutation-feed-and-fsync.md
+++ b/docs/adr/0003-mutation-feed-and-fsync.md
@@ -1,0 +1,84 @@
+---
+title: ADR-0003 Mutation feed — group commit and fsync policy
+description: Mutations flow to Sinks via a buffered group-commit channel (1ms or 64KB triggers); fsync is a per-Sink policy with three levels (Always, EverySec, No)
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0002-source-sink-contract
+---
+
+# ADR-0003: Mutation feed — group commit and fsync policy
+
+## Context
+
+ADR-0002 establishes that `Sink` implementations consume the mutation feed during steady-state operation. The hot question is *how* mutations flow to sinks: synchronously (every command waits for every sink to acknowledge), asynchronously (fire-and-forget, sink runs on its own clock), or batched somewhere in between.
+
+The constraints. The cache write path is now per-shard locked (default N=8) and serves ~0.7-0.95× valkey on pipelined writes; making every command block on a sink would erase that gain. But pure async with no backpressure means a slow sink silently desynchronizes from the cache, and durability claims become aspirational. There's also a cross-cutting decision: durability semantics for built-in sinks (snapshot, AOF) need to map cleanly to user-facing config — Redis has trained users to expect `appendfsync: always | everysec | no` and the corresponding latency/durability trade-offs.
+
+Prior art: Redis MP-AOF uses group commit with the same three fsync policies. PostgreSQL synchronous_commit has a similar trichotomy (on / off / local). etcd batches WAL appends at the Raft batching boundary. All three converge on the same shape: buffer mutations, flush on a time-or-size trigger, fsync per a policy that the user chose.
+
+## Decision
+
+The mutation feed flows to sinks through a **group-commit channel** with two trigger conditions:
+
+- **Time trigger**: 1 ms since the last flush
+- **Size trigger**: 64 KB of buffered mutations
+
+Whichever fires first flushes the buffer to all registered sinks. This decouples the cache write path from sink latency: commands don't wait for sinks; sinks see batched writes that amortise their own per-flush cost.
+
+Fsync is a **per-sink policy** with three levels matching Redis convention:
+
+- **`FsyncAlways`** — fsync after every flushed batch. Highest durability, highest latency. Equivalent to Redis `appendfsync always`.
+- **`FsyncEverySec`** — fsync at most once per second, on a separate goroutine. Loses up to 1s of writes on crash. Default for built-in AOF. Equivalent to Redis `appendfsync everysec`.
+- **`FsyncNo`** — no explicit fsync; rely on the OS page cache flush. Loses up to 30s of writes on crash. For dev or non-durable workloads. Equivalent to Redis `appendfsync no`.
+
+Each sink declares its policy at registration; the coordinator dispatches per sink without forcing one global policy across all sinks.
+
+## Alternatives Considered
+
+### Alternative 1: Per-mutation synchronous dispatch
+
+- **Pros**: Strongest durability semantics — every command's success implies every sink acknowledged. No buffering to lose on crash.
+- **Cons**: Erases the per-shard locking gain. Pipelined writes drop from ~0.85× valkey to whatever the slowest sink can sustain. A slow third-party sink (e.g., Postgres) would tank cache throughput.
+- **Why not**: The cache's value proposition is in-memory speed; persistence shouldn't dictate it. Users who want per-mutation durability run a database, not a cache.
+
+### Alternative 2: Pure async fire-and-forget
+
+- **Pros**: Maximum cache throughput — sinks see writes when they see them.
+- **Cons**: No backpressure means a slow sink silently falls behind. On crash, the gap between cache state and sink state is unbounded. Durability claims become unverifiable.
+- **Why not**: Without backpressure the system can't surface "your sink is failing" to users until something else crashes. The 1ms / 64KB triggers give enough batching to amortise sink overhead while keeping the buffer bounded.
+
+### Alternative 3: Single global fsync policy
+
+- **Pros**: Simpler config (one knob). Matches Redis 6.x exactly.
+- **Cons**: Mixed-sink deployments can't express "fsync local AOF every second AND replicate to remote S3 with no fsync". Forces every sink to the strictest policy in the set.
+- **Why not**: Once we accept that multiple sinks coexist (ADR-0001), each sink's durability needs are independent. Per-sink policy is a small cost on top of per-sink registration.
+
+### Alternative 4: Different group-commit triggers (e.g., 10ms, 256KB)
+
+- **Pros**: Larger batches → lower per-flush amortised cost.
+- **Cons**: Larger time window → larger crash window for `FsyncEverySec`. 1ms is the boundary where most burst traffic gets coalesced without adding meaningful latency to the rare under-1ms-pipeline case. 64KB is the standard kernel write-coalescing block.
+- **Why not**: 1ms / 64KB are Redis 7's actual values, validated against real workloads. Reasonable defaults; tunable per-sink if a deployment has different needs.
+
+## Consequences
+
+### Positive
+
+- Cache write path stays decoupled from sink latency — pipelined throughput is unaffected by sink choice.
+- Group commit amortises per-flush overhead, so sinks like AOF (one fsync per batch) and S3 (one PUT per batch) both benefit.
+- Per-sink fsync policy lets users mix durability needs (e.g., `FsyncEverySec` for local AOF + `FsyncNo` for archival S3 sink).
+- Maps cleanly to Redis-trained user expectations.
+
+### Negative
+
+- A bounded-latency upper bound on writes (1ms group-commit window) means the durability-vs-latency trade-off is the same for every sink unless the user explicitly tunes it. Most workloads won't notice; some latency-sensitive ones will.
+- Sink errors during a group commit are batched too — one failing sink in a batch means the whole batch's error attribution is fuzzier than per-mutation dispatch would give.
+- Slow sinks fill the buffer and eventually block the producer (the cache write path). Backpressure is real but bounded; users get a knob (buffer size) but not unlimited absorption.
+
+### Risks
+
+- **Risk**: A single misbehaving sink stalls all sinks via shared group-commit batching. **Mitigation**: Each sink consumes from its own buffer; the group-commit batches are per-sink, not shared across sinks. A slow Postgres sink doesn't slow down a healthy AOF sink.
+- **Risk**: `FsyncEverySec` background goroutine drift on heavy load means the "1 second" promise is actually 1.5-2 seconds. **Mitigation**: Same risk Redis has; documented in user-facing config so expectations match implementation.
+- **Risk**: Buffer fills under a write spike, causing the write path to block. **Mitigation**: Buffer size is configurable. The fact that backpressure exists is a feature, not a bug — silent unbounded buffering would be worse.

--- a/docs/adr/0004-command-namespacing.md
+++ b/docs/adr/0004-command-namespacing.md
@@ -1,0 +1,79 @@
+---
+title: ADR-0004 Persistence command namespacing
+description: Universal persistence commands (SAVE, BGSAVE, LASTSAVE, BGREWRITEAOF) stay in the core RESP namespace; third-party connector commands go in the REX namespace
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0006-builtin-vs-third-party-transport
+  - GCPC
+---
+
+# ADR-0004: Persistence command namespacing
+
+## Context
+
+Once persistence is pluggable (ADR-0001), the question becomes: where do persistence-related *commands* live in the protocol surface? Redis has a small set of universal persistence commands (`SAVE`, `BGSAVE`, `BGREWRITEAOF`, `LASTSAVE`) that every client library knows about. Pluggable persistence introduces a tension: users expect these commands regardless of which provider they're using, but pluggable providers might also want their own commands (`POSTGRES.SYNC`, `S3.ARCHIVE`, etc.).
+
+The codebase has a clean rule for plugin-introduced commands: they go in the **REX namespace** with a `PLUGIN.COMMAND` shape (e.g., `OBSERVE.STATS`). REX is a RESP3 superset and cleanly separates plugin surface from core protocol. The default-routing rule prevents a plugin from claiming `SET` or `GET`.
+
+The decision splits two cases. Case A: commands that are universal across persistence providers (start a save, ask when the last save was, request an AOF rewrite). Case B: commands that are specific to one provider (Postgres sync state, S3 manifest, custom replication position). Mashing both into REX would force users to learn `PERSISTENCE.SAVE` instead of `SAVE` — a regression for users expecting Redis compatibility. Mashing both into the core namespace would require every plugin author to fight the core for keyspace.
+
+## Decision
+
+Persistence commands are namespaced by **whether they are universal or provider-specific**:
+
+- **Universal commands stay in core RESP namespace**, dispatched by the engine to the configured primary persistence provider:
+  - `SAVE` — synchronous full snapshot
+  - `BGSAVE` — asynchronous full snapshot
+  - `LASTSAVE` — Unix timestamp of last successful snapshot
+  - `BGREWRITEAOF` — async AOF rewrite (when AOF sink is registered)
+- **Provider-specific commands go in the REX namespace** with the plugin's chosen prefix (e.g., `S3.ARCHIVE`, `POSTGRES.SYNC.STATUS`). These are surfaced to clients only when the corresponding plugin is loaded.
+
+The engine routes universal commands to the registered "primary" sink for that command type (one snapshot-capable sink for SAVE/BGSAVE, one AOF-capable sink for BGREWRITEAOF). Sinks declare which universal commands they handle at registration; if no sink claims a universal command, it returns the appropriate error (`PERSISTENCE_DISABLED`).
+
+## Alternatives Considered
+
+### Alternative 1: All persistence commands in REX namespace
+
+- **Pros**: Clean separation — core RESP stays minimal, every persistence command goes through the same plugin surface.
+- **Cons**: Breaks Redis client compatibility. `redis-cli SAVE` would have to become `redis-cli PERSISTENCE.SAVE`. Every Redis client library would need patching to call gocache. The "Redis-compatible" property in the project pitch is broken at the protocol surface.
+- **Why not**: Redis compatibility is a top-level project goal; the universal commands are exactly the surface where Redis compatibility matters most.
+
+### Alternative 2: All persistence commands in core RESP namespace
+
+- **Pros**: No namespace split to learn.
+- **Cons**: Every plugin author who wants a custom persistence command (Postgres source state, S3 manifest, etc.) has to fight the core for command names. The microkernel philosophy explicitly rejects this — extensions must be namespaced so the core stays small.
+- **Why not**: REX exists for exactly this reason — it's the discriminator between "core surface" and "plugin surface". Skipping it for persistence-specific commands violates the rule for no good reason.
+
+### Alternative 3: Universal commands as REX with core aliasing
+
+- **Pros**: Maximally consistent — every persistence command is a REX command, but `SAVE` aliases to `PERSISTENCE.SAVE` for Redis compatibility.
+- **Cons**: Aliasing adds a hop in the dispatch path for every command. The aliasing layer needs its own protocol surface and edge cases. `MONITOR` output, error messages, and command completion all have to handle the alias.
+- **Why not**: Aliasing solves a problem we don't have — the universal commands' definitions are the same regardless of which sink answers them. Aliasing adds ceremony for no benefit.
+
+### Alternative 4: Core RESP namespace with provider-name prefix at command level
+
+- **Pros**: One namespace; provider-specific commands naturally namespaced by provider name (`AOF.REWRITE` instead of `BGREWRITEAOF`).
+- **Cons**: Same problem as Alternative 1 for universal commands — `SAVE` becomes `SNAPSHOT.SAVE` and Redis compatibility breaks. Plus the existing REX namespace is already the canonical extension point; introducing a parallel one duplicates the concept.
+- **Why not**: Reuses the existing REX mechanism for the right thing (extension-specific commands) and keeps the core surface stable.
+
+## Consequences
+
+### Positive
+
+- Redis client libraries see expected command names for the Redis-compatible commands.
+- Plugin authors get a clean extension point for provider-specific commands without fighting the core.
+- The "primary sink for SAVE" routing is explicit, so users with multiple sinks aren't surprised by which one a plain `SAVE` hits.
+- REX permission scopes already exist and apply to provider-specific commands automatically.
+
+### Negative
+
+- Two routing rules to document: universal commands route by command name to a registered primary; provider commands route by REX prefix to the plugin.
+- Users with multiple snapshot-capable sinks have to configure which is "primary" for SAVE. If they don't, gocache picks deterministically (registration order) and that surprises some users.
+
+### Risks
+
+- **Risk**: Two plugins both claim "primary AOF sink" capability, and the user expects both to be hit by `BGREWRITEAOF`. **Mitigation**: Configuration must declare which sink is primary for each universal command; if both claim by default, registration fails fast at startup with a clear error. No silent winner-takes-all.
+- **Risk**: A future Redis adds a new universal persistence command that gocache hasn't routed. **Mitigation**: Universal commands are a closed list maintained alongside the protocol layer. Adding one is a contract change with its own ADR — not a silent degradation.

--- a/docs/adr/0005-snapshot-wire-and-file-format.md
+++ b/docs/adr/0005-snapshot-wire-and-file-format.md
@@ -1,0 +1,92 @@
+---
+title: ADR-0005 Snapshot wire and file format
+description: Snapshots use a custom binary format (varint, magic header, CRC32, optional zstd) replacing Go's gob encoder
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0002-source-sink-contract
+  - Performance
+---
+
+# ADR-0005: Snapshot wire and file format
+
+## Context
+
+The current snapshot format is `encoding/gob`. Gob is convenient for Go-only interop and trivial to wire up — `gob.NewEncoder(file).Encode(state)` and the inverse on load. It's also the dominant fixed RSS cost in the persistence layer and has structural problems that show up under the new pluggable model.
+
+The problems with gob in this role:
+
+1. **Encoder state lives forever**: a single `gob.Encoder` accumulates type metadata for every type it has ever seen. The snapshot worker holds one for the process lifetime, so encoder memory grows monotonically.
+2. **Decoder type-coupling**: gob bakes Go type names into the wire format. Renaming `pkg/cache.Item` to `api/cache.Item` (which is in scope for the api/-only refactor) breaks every existing snapshot file. There's no version negotiation.
+3. **Not portable**: third-party providers in other languages (a Rust archival sink, a Python migration tool) can't read gob without writing a Go decoder. The pluggable persistence model assumes wire-format portability; gob actively works against it.
+4. **No per-record framing**: gob streams are opaque; you can't seek, you can't validate one record without reading the whole file, and corruption mid-file makes the rest unreadable.
+5. **No compression hook**: gob has no native compression. Adding it means wrapping the writer, which complicates streaming reads.
+
+## Decision
+
+Snapshots use a **custom binary format** with these properties:
+
+- **Varint encoding** for all length-prefixed fields (keys, values, counts) — same shape as Protobuf and Redis RDB
+- **Magic header** `GCDB\x01` (4-byte magic + 1-byte format-version) — version negotiation from byte 0
+- **CRC32 footer** over the whole file — corruption detection on load
+- **Per-record framing**: each record is `<varint-length><record-bytes>`, so partial-file recovery and incremental validation are possible
+- **Optional zstd compression** at the record level, signalled by a per-record flag — compression is pluggable per record (text-heavy records compress; binary blobs may not)
+- **Type-tagged records**: each record starts with a 1-byte type tag (`STRING`, `LIST`, `HASH`, `SET`, `ZSET`, `META`) — type metadata travels with the record, no global type registry needed
+
+The format is documented in `api/persistence/format.md` and exercised by the built-in snapshot plugin. Third-party providers can use it directly or layer their own (e.g., Postgres source produces snapshot records via a custom path that constructs the same on-the-fly).
+
+## Alternatives Considered
+
+### Alternative 1: Keep gob
+
+- **Pros**: Smallest diff. Already works for the existing snapshot worker.
+- **Cons**: Every problem listed in Context above. The Go-only assumption blocks third-party portability; the global encoder state blocks the RSS reduction goal; the type-name coupling blocks the api/-only refactor.
+- **Why not**: This is the format whose problems motivate the rewrite. Keeping it loses the thesis-line memory win.
+
+### Alternative 2: Protobuf
+
+- **Pros**: Battle-tested. Schema-versioned. Cross-language support out of the box. Codegen toolchain already in the project (used for GCPC).
+- **Cons**: Schema-driven format adds a build dependency for every snapshot read — even third-party migration tools would need the .proto. Per-record framing is awkward (proto is record-oriented but doesn't natively chain). Compression is external. The on-the-wire size of a `repeated bytes` field for a large value is the same as the raw bytes plus a header — no win there. And proto's evolution rules (field numbers, reserved tags) are overkill for a format we control end-to-end.
+- **Why not**: Protobuf earns its complexity when the schema is shared across many parties with independent release cycles. Gocache's snapshot is read by gocache plus migration tools we ship — the schema-evolution story is internal to one team. The ceremony doesn't pay for itself.
+
+### Alternative 3: FlatBuffers
+
+- **Pros**: Zero-copy reads. Well suited to mmap'd snapshot loads.
+- **Cons**: FlatBuffers is even more schema-bound than Protobuf — the schema language and the codegen are non-trivial. Zero-copy reads are an interesting property for an in-memory cache, but the snapshot load path is one-shot at boot; per-cmd hot path doesn't touch it.
+- **Why not**: Zero-copy doesn't help the boot path enough to pay for the schema toolchain. If the persistence layer ever does mmap-style hot reads (e.g., a "warm cache from snapshot file directly" mode), this is worth revisiting in a new ADR.
+
+### Alternative 4: Redis RDB format
+
+- **Pros**: Direct compatibility with Redis tooling. `redis-cli --rdb` style backup interop.
+- **Cons**: RDB is undocumented for stability — it's an implementation detail of Redis, not a public format. Decoders exist (rdb-tools, etc.) but they tail the implementation. Tying gocache's persistence to a moving Redis-internal target is a long-term maintenance liability.
+- **Why not**: The Redis-compatibility goal applies to the protocol (RESP, command semantics), not to the on-disk format. Adopting RDB would couple gocache to Redis's internals far beyond what protocol compat requires.
+
+### Alternative 5: JSON with optional gzip
+
+- **Pros**: Maximum portability. Human-readable for debugging.
+- **Cons**: Catastrophic size and parse-cost overhead for binary values. Can't represent raw `[]byte` without base64 encoding (33% size penalty). Parse cost dominates load time on large snapshots.
+- **Why not**: A cache's snapshot is binary-heavy by nature; JSON's text orientation is a structural mismatch.
+
+## Consequences
+
+### Positive
+
+- Snapshot RSS no longer holds gob's encoder state for the process lifetime — encoders are local to one snapshot operation, GC'd after.
+- Per-record framing enables partial-file recovery, snapshot validation tools, and (later) incremental snapshots.
+- Magic + version header makes wire-format evolution explicit. We can add a new record type at version 2 without breaking version-1 readers.
+- Format is documented in `api/persistence/format.md`, so third-party producers (e.g., a Postgres-source plugin generating snapshots on the fly) can target it directly.
+- Optional zstd at record level gives the right knob — text-heavy records compress 3-5×; binary blobs skip compression.
+
+### Negative
+
+- A custom format means we own format compatibility forever. A bug in the version-1 reader is on us, not on a vendor.
+- Migration from gob requires a one-time tool (`gocache-migrate gob-to-v1`) that ships with the first release of the new format. Users with existing gob snapshots have to run it once.
+- Documentation cost: `api/persistence/format.md` becomes a living spec that must stay in sync with the implementation.
+
+### Risks
+
+- **Risk**: A format-version-2 change breaks existing tools. **Mitigation**: Magic + version header allows readers to refuse unknown versions explicitly. Migration tools are versioned. Old readers fail closed (refuse to load), not open (corrupt loads).
+- **Risk**: CRC32 isn't strong enough — accepting a corrupted snapshot. **Mitigation**: CRC32 catches the overwhelming majority of disk-flip and truncation cases. For paranoia (e.g., archival use case), the format reserves room for a future stronger checksum signalled by version-bump.
+- **Risk**: zstd library dependency. **Mitigation**: zstd is opt-in per record; uncompressed records work without the library. Pure-Go zstd implementations exist (`github.com/klauspost/compress/zstd`) — no cgo requirement.

--- a/docs/adr/0006-builtin-vs-third-party-transport.md
+++ b/docs/adr/0006-builtin-vs-third-party-transport.md
@@ -1,0 +1,84 @@
+---
+title: ADR-0006 Built-in vs third-party plugin transport
+description: Built-in persistence plugins (snapshot, AOF) ship as embedded plugins (in-process, build-tag-gated); third-party providers run via IPC over GCPC
+status: proposed
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0002-source-sink-contract
+  - Plugins
+  - GCPC
+---
+
+# ADR-0006: Built-in vs third-party plugin transport
+
+## Context
+
+Once persistence is pluggable (ADR-0001) with a Source/Sink contract (ADR-0002), the next question is *how* a plugin runs. Gocache already has two plugin transports:
+
+- **Embedded plugins** — compiled into the server binary, gated by Go build tags (e.g., `-tags crashdump,otlp`). Same process; no IPC overhead. Examples: `crashdump`, `otlp`. Activation is at build time.
+- **IPC plugins** — separate OS processes connected over Unix domain sockets, speaking GCPC v1 (Protobuf). Enabled via YAML at runtime. Example: `gobservability`. Crash isolation between server and plugin.
+
+Persistence is unique among plugin domains because it sits squarely on the durability path. A snapshot or AOF crash that loses writes is much worse than a metrics-plugin crash that loses telemetry. At the same time, the third-party use cases enabled by ADR-0001 — Postgres-as-cache, Kafka archival, S3 replication — are exactly the cases where running an external connector in a separate process is the *right* shape (different runtime, different deploy cycle, different blast radius).
+
+The two transports have different strengths. Embedded plugins win on latency, simplicity (no IPC framing), and bootstrapping (active before config loads). IPC plugins win on isolation, language-flexibility (an IPC plugin could be Rust, Python, anything that speaks Protobuf), and deploy-independence (update the plugin without restarting the server).
+
+## Decision
+
+Built-in persistence plugins **ship as embedded plugins** (compile-time-linked, build-tag-gated):
+
+- `snapshot` build tag — built-in snapshot Source/Sink (the gob replacement using ADR-0005's format)
+- `aof` build tag — built-in AOF Source/Sink with the group-commit/fsync model from ADR-0003
+
+Third-party persistence providers **run as IPC plugins** over GCPC, implementing the same `api/persistence/` Source/Sink contract surfaced through the GCPC v1 protocol's plugin-callable methods. The contract is transport-neutral — a Source method has the same signature whether it's invoked in-process (embedded) or over a UDS (IPC).
+
+Default release builds include `snapshot` (matches the existing default behaviour). `aof` is opt-in. Stripped builds (`-tags ''`) ship without persistence and rely on a configured IPC provider — useful for niche deployments (test rigs, ephemeral caches, external-source-of-truth setups).
+
+## Alternatives Considered
+
+### Alternative 1: All persistence plugins as IPC
+
+- **Pros**: One transport story. Maximum isolation — a snapshot plugin crash doesn't take down the server.
+- **Cons**: Built-in snapshot becomes an external process the user has to deploy alongside the server. Default deployment goes from "run the binary" to "run the binary AND the snapshot sidecar". The latency floor on every persistence operation is now a UDS round-trip. The bootstrapping problem: snapshot Source has to run *before* config is fully loaded (to recover state), which fights the IPC plugin lifecycle (IPC plugins start after config).
+- **Why not**: The default deployment story matters. Users picking up the binary expect it to persist out of the box; making them wire up an external snapshot daemon for the basic case is a significant regression.
+
+### Alternative 2: All persistence plugins as embedded
+
+- **Pros**: One transport story (the other direction). Lowest possible latency for every plugin.
+- **Cons**: Third-party providers (Postgres, S3, Kafka) would have to be linked into the server binary at build time. Every deployment that wants a third-party connector has to cut a custom binary. Crash isolation is gone — a Postgres connector bug crashes the cache.
+- **Why not**: The third-party use cases enabled by ADR-0001 are exactly the cases where the connector is heavy, language-diverse, and benefits from process isolation. Forcing them in-process undoes the value.
+
+### Alternative 3: Auto-select transport based on a per-plugin policy
+
+- **Pros**: Flexibility. A plugin author could ship the same code to run either embedded or IPC.
+- **Cons**: The Source/Sink contract is already transport-neutral; the *deployment model* of a given plugin is what differs. Auto-selection means the plugin author writes the same code twice (for cgo restrictions, runtime dependencies, etc.) and the user has to understand which mode they're in.
+- **Why not**: The transport choice is a property of the plugin's deployment shape, not the user's runtime config. Built-ins ship as embedded because we control their lifecycle; third-parties ship as IPC because they control theirs. Auto-select adds complexity for no user benefit.
+
+### Alternative 4: Embedded built-ins with optional IPC mode for development
+
+- **Pros**: Same as the chosen decision, plus an IPC fallback for users who want to debug snapshot/AOF in isolation.
+- **Cons**: Two activation paths for the same plugin (build tag + YAML). Doubled test surface. The "optional IPC mode" is rarely used and rots when the embedded path is the hot path.
+- **Why not**: If a user wants to debug snapshot/AOF in isolation, they can build a one-off binary that omits the embedded version and add an IPC sidecar that wraps the same code. The contract is transport-neutral; the test rig can use it either way without us shipping a second activation path.
+
+## Consequences
+
+### Positive
+
+- Default deployment ("run the binary") works with snapshot persistence out of the box — no sidecars, no extra processes.
+- Third-party connectors plug in as IPC plugins over GCPC, with full crash isolation and language flexibility.
+- Build-tag matrix grows by 2 (`snapshot`, `aof`) — small enough to keep the existing CI matrix tractable.
+- The Source/Sink contract being transport-neutral means the same `api/persistence/` types describe both built-in and third-party plugins. One mental model.
+- AOF being opt-in means users who don't want it pay nothing for it (no goroutines, no buffer allocations, no fsync ticker).
+
+### Negative
+
+- Built-in plugins crash the server if they crash. Snapshot/AOF code has to meet a higher reliability bar than the metrics plugin does.
+- Two transport paths means two test paths. The contract is shared, but the GCPC marshalling for IPC and the in-process direct call for embedded both need exercise.
+- Build matrix complexity: a release with `crashdump,otlp,snapshot,aof` is the "full" build; a release without any of these is the "minimal" build; users picking subsets get something in between. CI has to cover at least the corners.
+
+### Risks
+
+- **Risk**: A built-in plugin's bug crashes the server *because* it's embedded. **Mitigation**: Built-in plugins are held to higher reliability — extra test coverage, defensive error handling around the durability path, code review focused on the crash blast radius. Same standard as the cache core.
+- **Risk**: A third-party IPC plugin's crash leaves the server in a state where Sinks have stale state. **Mitigation**: ADR-0003's group-commit model already handles bounded backpressure; the coordinator detects sink failure and surfaces it. The contract documents that Sinks can fail and recover; users running flaky third-party connectors should expect occasional log noise, not silent data loss.
+- **Risk**: GCPC's IPC overhead makes third-party persistence sinks too slow for high-throughput workloads. **Mitigation**: Group-commit batching (ADR-0003) amortises the per-flush IPC cost. For workloads where even batched IPC is too slow, the alternative is to write an embedded plugin (i.e., rebuild the server with the connector code linked in). The escape hatch exists.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,58 @@
+---
+title: Architecture Decision Records
+description: Index of architectural decisions captured for gocache — Nygard-format ADRs, one per significant decision
+status: living
+last_updated: 2026-05-03
+related:
+  - Server-Architecture
+  - Performance
+  - Plugins
+---
+
+# Architecture Decision Records
+
+This directory captures architectural decisions as Nygard-format records. Each ADR is a short document describing one significant decision: the context that motivated it, the decision itself, the alternatives that were rejected, and the consequences (positive, negative, and the risks that come with them).
+
+ADRs are the durable record of the *why* behind the code. They live alongside the source so future contributors can read them without context-switching to a separate doc system.
+
+## Lifecycle
+
+```
+proposed → accepted → [deprecated | superseded by ADR-NNNN]
+```
+
+- **proposed** — under discussion; the matching code may not be merged yet. The PR that introduces the ADR is the review surface.
+- **accepted** — in effect and being followed. Flipped from `proposed` once the matching contract / implementation lands.
+- **deprecated** — no longer relevant (e.g. the feature was removed). Kept for historical record.
+- **superseded** — a newer ADR replaces this one. The replacement link is mandatory.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](0001-persistence-as-pluggable-log-snapshot.md) | Persistence as pluggable log+snapshot+LSN | proposed | 2026-05-03 |
+| [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | proposed | 2026-05-03 |
+| [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | proposed | 2026-05-03 |
+| [0004](0004-command-namespacing.md) | Persistence command namespacing | proposed | 2026-05-03 |
+| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | proposed | 2026-05-03 |
+| [0006](0006-builtin-vs-third-party-transport.md) | Built-in vs third-party plugin transport | proposed | 2026-05-03 |
+
+## Writing a new ADR
+
+1. Copy `template.md` to `NNNN-decision-title.md` (next available number, kebab-case slug)
+2. Fill in every section of the template — empty sections defeat the purpose
+3. Add an entry to the index above
+4. Open a PR — the PR review is where `proposed` ADRs get challenged
+5. Flip to `accepted` once the matching code merges (separate commit, often in the same PR as the implementation)
+
+## When to write one
+
+| Worth recording | Not worth recording |
+|---|---|
+| Choice of database, transport, framework | Variable naming, formatting |
+| Architecture pattern (microkernel, layered, event-driven) | Function refactor scope |
+| API shape (REST vs gRPC, command namespacing) | Local optimizations |
+| Auth strategy, encryption approach | Test framework choice (unless thesis-relevant) |
+| Persistence model, data layout | Build-tool flag |
+
+If the decision will outlive the people who made it and shapes how future code gets written, it belongs here.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,50 @@
+---
+title: ADR-NNNN Decision Title
+description: One-line summary of the decision
+status: proposed
+date: YYYY-MM-DD
+deciders: [name, name]
+related:
+  - related-page-1
+  - related-page-2
+---
+
+# ADR-NNNN: Decision Title
+
+## Context
+
+What is the issue or change motivating this decision? 2-5 sentences describing the situation, constraints, and forces at play. Cover what the system currently does (or doesn't do), what's prompting the change, and any non-obvious constraints (deadline, prior decision, external dependency).
+
+## Decision
+
+What is the change being made? 1-3 sentences stating the decision clearly and concretely. Use present tense ("We use X") not future ("We will use X").
+
+## Alternatives Considered
+
+### Alternative 1: Name
+
+- **Pros**: ...
+- **Cons**: ...
+- **Why not**: One specific reason this was rejected — not a generic dismissal.
+
+### Alternative 2: Name
+
+- **Pros**: ...
+- **Cons**: ...
+- **Why not**: ...
+
+## Consequences
+
+What becomes easier or harder because of this decision?
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Risks
+
+- **Risk**: What could go wrong. **Mitigation**: How we plan to handle it if it does.

--- a/scripts/build-wiki.sh
+++ b/scripts/build-wiki.sh
@@ -85,18 +85,78 @@ copy_renamed "$DOCSROOT/plugins/gobservability/SOLUTION_ARCHITECTURE.md" \
 copy_renamed "$DOCSROOT/gcpc/README.md"                        "GCPC.md"
 copy_renamed "$DOCSROOT/performance/README.md"                 "Performance.md"
 
-# 3. Audits — `Audit-<basename>.md` keeps them grouped in the flat namespace.
-#    Audits are cross-cutting (performance, design, races) so they keep their
-#    own group rather than being folded under Performance.
-echo "==> Audits"
-if [[ -d "$DOCSROOT/audits" ]]; then
-  for f in "$DOCSROOT/audits"/*.md; do
+# Dynamic-rewrite accumulator. Indexed sections push wiki-link rewrites here
+# so cross-references resolve after flattening. Static (hand-curated) rewrites
+# live in the REWRITES associative array further down. Two parallel arrays
+# (rather than one delimited string) keep "from" / "to" robust against any
+# special characters that might appear in either side.
+declare -a DYNAMIC_FROM=()
+declare -a DYNAMIC_TO=()
+
+# Process an "indexed" section: a directory containing an optional README.md
+# (rendered as <prefix>.md) plus any number of leaf .md files (rendered as
+# <prefix>-<basename>.md). `template.md` is skipped — it is a manual scaffold,
+# not wiki content.
+#
+# Usage:  process_indexed_section <source-dir> <wiki-prefix>
+#
+# Example: process_indexed_section docs/adr ADR
+#   docs/adr/README.md           -> wiki-staging/ADR.md
+#   docs/adr/template.md         -> (skipped)
+#   docs/adr/0001-foo.md         -> wiki-staging/ADR-0001-foo.md
+#   plus link rewrites:
+#     ](README.md)               -> ](ADR)             (path-prefixed forms)
+#     ](0001-foo.md)             -> ](ADR-0001-foo)    (sibling cross-refs)
+#
+# Adding a new indexed section is a single function call below. The directory
+# can grow new files without further script edits.
+process_indexed_section() {
+  local src_dir="$1"
+  local prefix="$2"
+
+  if [[ ! -d "$src_dir" ]]; then
+    return 0
+  fi
+
+  echo "==> $prefix (from $src_dir)"
+
+  local dir_basename
+  dir_basename=$(basename "$src_dir")
+
+  if [[ -f "$src_dir/README.md" ]]; then
+    strip_frontmatter "$src_dir/README.md" "$OUTDIR/${prefix}.md"
+    echo "    $src_dir/README.md -> ${prefix}.md"
+    # README cross-refs (path-prefixed forms typical from sibling docs).
+    DYNAMIC_FROM+=("](${dir_basename}/README.md)")
+    DYNAMIC_TO+=("](${prefix})")
+    DYNAMIC_FROM+=("](../${dir_basename}/README.md)")
+    DYNAMIC_TO+=("](${prefix})")
+  fi
+
+  for f in "$src_dir"/*.md; do
     [[ -f "$f" ]] || continue
+    local base
     base=$(basename "$f" .md)
-    strip_frontmatter "$f" "$OUTDIR/Audit-${base}.md"
-    echo "    $f -> Audit-${base}.md"
+    case "$base" in
+      README|template) continue ;;
+    esac
+    strip_frontmatter "$f" "$OUTDIR/${prefix}-${base}.md"
+    echo "    $f -> ${prefix}-${base}.md"
+    # Sibling cross-refs (bare slug — the common shape inside the section).
+    DYNAMIC_FROM+=("](${base}.md)")
+    DYNAMIC_TO+=("](${prefix}-${base})")
+    # Path-prefixed cross-refs from sibling docs.
+    DYNAMIC_FROM+=("](${dir_basename}/${base}.md)")
+    DYNAMIC_TO+=("](${prefix}-${base})")
+    DYNAMIC_FROM+=("](../${dir_basename}/${base}.md)")
+    DYNAMIC_TO+=("](${prefix}-${base})")
   done
-fi
+}
+
+# 3. Indexed sections — README + numbered/named children flattened with a
+#    section prefix. Adding a new section is a single function call.
+process_indexed_section "$DOCSROOT/audits" "Audit"
+process_indexed_section "$DOCSROOT/adr"    "ADR"
 
 # 4. Render every .puml to .svg into a tmp area, then bundle by section.
 TMPRENDER=$(mktemp -d)
@@ -241,12 +301,6 @@ declare -A REWRITES=(
   ['](../server/README)']='](Server)'
   ['](../gcpc/README.md)']='](GCPC)'
   ['](../gcpc/README.md#rex-metadata)']='](GCPC#rex-metadata)'
-  ['](../audits/per-shard-arc-summary.md)']='](Audit-per-shard-arc-summary)'
-  ['](../audits/go-bench-vs-docker-gap.md)']='](Audit-go-bench-vs-docker-gap)'
-  ['](../audits/clientctx-cross-goroutine.md)']='](Audit-clientctx-cross-goroutine)'
-  ['](audits/per-shard-arc-summary.md)']='](Audit-per-shard-arc-summary)'
-  ['](audits/go-bench-vs-docker-gap.md)']='](Audit-go-bench-vs-docker-gap)'
-  ['](audits/clientctx-cross-goroutine.md)']='](Audit-clientctx-cross-goroutine)'
   ['](performance/README.md)']='](Performance)'
   ['](performance/README)']='](Performance)'
   ['](../performance/README.md)']='](Performance)'
@@ -270,9 +324,16 @@ declare -A REWRITES=(
 )
 
 for md in "$OUTDIR"/*.md; do
+  # Static rewrites first (hand-curated section pages, design subdirs, etc.).
   for from in "${!REWRITES[@]}"; do
     to="${REWRITES[$from]}"
     # Use a delimiter that won't appear in either string. ASCII 0x01 is safe.
+    sed -i "s$(printf '\1')${from//\//\\/}$(printf '\1')${to//\//\\/}$(printf '\1')g" "$md"
+  done
+  # Dynamic rewrites (registered by indexed sections — audits, adr, …).
+  for i in "${!DYNAMIC_FROM[@]}"; do
+    from="${DYNAMIC_FROM[$i]}"
+    to="${DYNAMIC_TO[$i]}"
     sed -i "s$(printf '\1')${from//\//\\/}$(printf '\1')${to//\//\\/}$(printf '\1')g" "$md"
   done
 done


### PR DESCRIPTION
Closes #60.

## Summary

- `docs/adr/README.md` — Nygard-format index with lifecycle table and "when to write one" guidance
- `docs/adr/template.md` — blank scaffold for manual ADR creation
- 6 ADRs at `status: proposed` capturing the persistence-as-plugin architectural decisions:
  - **0001** — Persistence as pluggable log+snapshot+LSN (etcd / Postgres / Redis 7 prior art)
  - **0002** — Source/Sink contract with BootMode trichotomy (Snapshot/Replay/Initial)
  - **0003** — Group-commit mutation feed (1ms ‖ 64KB) + per-sink FsyncPolicy (Always/EverySec/No)
  - **0004** — Universal commands (SAVE / BGSAVE / LASTSAVE / BGREWRITEAOF) in core RESP; provider-specific in REX
  - **0005** — Custom binary format (varint + magic + CRC32 + optional zstd) replaces gob
  - **0006** — Built-in snapshot+AOF as embedded plugins; third-party connectors via IPC over GCPC

Each ADR follows Nygard format strictly: Context (2-5 sentences), Decision (1-3 sentences), Alternatives (with Pros/Cons/Why-not — each rejection has a *specific* reason, not a generic dismissal), and Consequences split into Positive / Negative / Risks (with Mitigation).

## Why proposed (not accepted)

The contract code lands separately — `api/persistence/` interfaces, coordinator skeleton, LSN ring, then the built-in snapshot and AOF plugins. ADRs flip from `proposed` to `accepted` once the matching code merges. PR review here is the chance to challenge the decisions before they harden.

## Script refactor

`scripts/build-wiki.sh` now has a generic `process_indexed_section <dir> <prefix>` helper that flattens any `docs/<dir>/{README.md, *.md}` into `<Prefix>.md` and `<Prefix>-<basename>.md` wiki pages, and auto-registers cross-page link rewrites for sibling slugs and path-prefixed forms. Adding a new ADR or audit is just dropping a file in the directory — no more script edits per page.

The static `REWRITES` table now only carries hand-curated exceptions (section-page renames like `SOLUTION_ARCHITECTURE.md` → `Server-Architecture`); the audits-related entries that used to be hardcoded are now generated dynamically.

## Test plan

- [x] `bash scripts/build-wiki.sh wiki-staging` runs clean — 40/40 diagrams, all 6 ADRs flatten, frontmatter stripped, no `.claude` references
- [x] Index links in `ADR.md` resolve to `ADR-NNNN-...` (rewritten by dynamic helper, not hardcoded)
- [x] Cross-ADR references inside ADR bodies are descriptive ("see ADR-0006") — no bare relative links left
- [x] No regressions in audit handling (same Audit-* names produced)
- [ ] CI wiki-sync renders ADR pages on the live wiki after merge
- [ ] Sidebar shows new "Decisions (ADR)" group with all 6 entries