### PR TITLE
feat(persistence): api/persistence contract + coordinator + gob shim (ADR-0001 boot side)

### DIFF
--- a/api/persistence/errors.go
+++ b/api/persistence/errors.go
@@ -1,0 +1,24 @@
+package persistence
+
+import "errors"
+
+// ErrSinkFatal wraps Sink.Apply errors that the sink considers
+// non-recoverable. The coordinator quarantines fatal sinks (stops
+// dispatching to them, surfaces the failure, continues serving traffic
+// against the remaining healthy sinks). Transient errors that don't wrap
+// ErrSinkFatal are retried under a backoff schedule.
+//
+// Use with errors.Is / errors.As at the boundary:
+//
+//	if err := sink.Apply(ctx, batch); err != nil {
+//	    if errors.Is(err, persistence.ErrSinkFatal) {
+//	        // quarantine
+//	    }
+//	}
+var ErrSinkFatal = errors.New("persistence: sink fatal — quarantine")
+
+// ErrInvalidBootMode is returned by the coordinator when a Source returns
+// a BootResult with an unrecognised Mode. Closed enums are checked at
+// boot time so unknown values fail fast rather than getting silently
+// dropped.
+var ErrInvalidBootMode = errors.New("persistence: source returned invalid BootMode")

--- a/api/persistence/sink.go
+++ b/api/persistence/sink.go
@@ -1,0 +1,44 @@
+package persistence
+
+import "context"
+
+// Sink consumes the ongoing mutation feed during steady-state operation.
+// Sinks see writes after the cache has committed them — they cannot veto
+// or modify the write. The coordinator group-commits mutations (1ms ‖ 64KB
+// triggers, see ADR-0003) before calling Apply, so each Apply receives a
+// batch the Sink can amortise its per-flush cost over.
+//
+// Sinks are NOT wired in this PR (feat/persistence-contract). The interface
+// is defined so the contract is stable; the coordinator's Sink dispatch
+// path lands in feat/persistence-mutation-feed.
+type Sink interface {
+	// Name identifies the sink for logging, error attribution, and
+	// command-routing decisions (which Sink answers BGREWRITEAOF, etc.).
+	Name() string
+
+	// FsyncPolicy returns the durability policy this sink runs under.
+	// The coordinator uses this to dispatch fsyncs after Apply; the sink
+	// should not call fsync itself unless it has a sink-specific reason
+	// to (e.g. a file rotation point). See ADR-0003.
+	FsyncPolicy() FsyncPolicy
+
+	// Apply receives a batch of mutations in LSN order. The batch is
+	// non-empty. The coordinator calls Apply serially per Sink (no
+	// concurrent Apply calls on the same Sink instance), so Sinks need
+	// not be internally synchronised across Apply calls.
+	//
+	// Errors are surfaced via the coordinator's health channel. Sinks
+	// that cannot recover from a write failure should return an error
+	// that wraps a sentinel (see ErrSinkFatal); the coordinator may then
+	// quarantine the sink. Transient errors (e.g. disk full) are
+	// retried by the coordinator under a backoff schedule.
+	Apply(ctx context.Context, batch []Mutation) error
+
+	// Close signals shutdown. The coordinator drains any in-flight batch
+	// to this sink and calls Close exactly once. Sinks should flush any
+	// internal buffers, close file handles, and release network
+	// connections. Returning an error from Close is logged but does not
+	// abort shutdown — by Close time the cache state is no longer being
+	// modified.
+	Close(ctx context.Context) error
+}

--- a/api/persistence/source.go
+++ b/api/persistence/source.go
@@ -1,0 +1,114 @@
+package persistence
+
+import "context"
+
+// Source supplies recovery state at boot time. Every persistence provider
+// that contributes to recovery (built-in snapshot, built-in AOF, third-party
+// Postgres connector, archival S3 reader, …) implements this interface.
+//
+// Source is invoked exactly once per server lifetime, before the cache
+// accepts client traffic. After Boot returns, the Source's lifecycle is
+// done — runtime mutations flow to Sinks (see Sink), not Sources.
+//
+// The split between Source and Sink is intentional: a provider can supply
+// only one half if that's all it needs to do. A pure archival Sink doesn't
+// have to write a Source stub; a one-shot Postgres-as-cache loader doesn't
+// have to write a Sink stub. See ADR-0002.
+type Source interface {
+	// Name identifies the source for logging, error attribution, and
+	// command-routing decisions (which Source answers SAVE, etc.).
+	// Returns a stable identifier — typically the plugin / built-in name.
+	Name() string
+
+	// Boot returns the recovery artefact, or BootResult{Mode:Initial}
+	// when there is nothing to recover. Errors propagate without retry —
+	// boot failures abort startup.
+	//
+	// The returned BootResult owns its iterator(s); callers MUST close
+	// the BootResult when done (BootResult.Close is the convenience
+	// helper that closes whichever iterator was set).
+	Boot(ctx context.Context) (BootResult, error)
+}
+
+// BootResult is what a Source returns from Boot. The Mode discriminator
+// determines which other field is set:
+//
+//   - BootModeInitial: no iterator, LSN ignored.
+//   - BootModeSnapshot: Snapshot is set; LSN is the snapshot's at-LSN
+//     (the runtime resumes allocation from LSN+1).
+//   - BootModeReplay: Replay is set; LSN is ignored on entry — the
+//     resume LSN is whatever the iterator's last yielded Mutation
+//     reported.
+//
+// Exactly one of Snapshot / Replay is non-nil for non-Initial modes.
+type BootResult struct {
+	Mode     BootMode
+	LSN      LSN
+	Snapshot SnapshotIterator
+	Replay   ReplayIterator
+}
+
+// Close releases whichever iterator is held. Idempotent — safe to call
+// multiple times. Callers should defer Close immediately after a successful
+// Boot to ensure resources are released even on early-exit paths.
+func (r BootResult) Close() error {
+	if r.Snapshot != nil {
+		return r.Snapshot.Close()
+	}
+	if r.Replay != nil {
+		return r.Replay.Close()
+	}
+	return nil
+}
+
+// SnapshotIterator yields snapshot entries in source-defined order. The
+// iterator is forward-only and single-pass; callers iterate to completion
+// (Next returns io.EOF) or stop early via Close.
+type SnapshotIterator interface {
+	// Next returns the next entry, or io.EOF when exhausted.
+	// On error other than io.EOF, the iterator is in an undefined state
+	// and the caller should Close and abort recovery.
+	Next(ctx context.Context) (SnapshotEntry, error)
+
+	// Close releases any underlying resources (file handles, network
+	// streams). Calling Close on an already-closed iterator is a no-op.
+	Close() error
+}
+
+// SnapshotEntry is one key-value tuple in a snapshot. The Value field's
+// concrete type depends on (ValueType, Encoding):
+//
+//   - EncodingPacked: Value is []byte — the packed byte buffer the cache
+//     can hand straight to its slab allocator.
+//   - EncodingNative + ValueTypeBytes: Value is []byte (legacy) or string
+//     (older snapshots); the loader accepts both.
+//   - EncodingNative + ValueTypeList: Value is []string.
+//   - EncodingNative + ValueTypeHash: Value is map[string]string.
+//   - EncodingNative + ValueTypeSet: Value is map[string]struct{}.
+//   - EncodingNative + ValueTypeSortedSet: Value is provider-specific
+//     (built-in encoder produces a serialisable form documented alongside
+//     the format spec in ADR-0005).
+//
+// Expiration is the absolute Unix-nanosecond deadline; 0 means no expiry.
+// The loader skips entries whose Expiration is in the past at load time.
+type SnapshotEntry struct {
+	Key        string
+	ValueType  ValueType
+	Encoding   Encoding
+	Value      any
+	Expiration int64
+}
+
+// ReplayIterator yields mutations in LSN order. Same lifecycle rules as
+// SnapshotIterator (forward-only, single-pass, Close on early exit).
+//
+// Each yielded Mutation carries its own LSN. The coordinator advances its
+// LSN cursor to the highest yielded LSN as replay progresses; the
+// post-replay LSN is the resume point for runtime allocation.
+type ReplayIterator interface {
+	// Next returns the next mutation, or io.EOF when exhausted.
+	Next(ctx context.Context) (Mutation, error)
+
+	// Close releases any underlying resources. Idempotent.
+	Close() error
+}

--- a/api/persistence/types.go
+++ b/api/persistence/types.go
@@ -1,0 +1,137 @@
+// Package persistence is the public contract surface for gocache's
+// persistence subsystem. Plugins under plugins/ may import this package;
+// the corresponding implementation guts live in pkg/persistence/.
+//
+// The shape captured here is the operationalisation of the persistence ADRs:
+//   - ADR-0001: persistence is pluggable, keyed by log + snapshot + LSN
+//   - ADR-0002: split into Source (boot-side) and Sink (runtime-side)
+//   - ADR-0003: per-Sink FsyncPolicy chosen at registration time
+//
+// The contract is transport-neutral — embedded plugins (built-in snapshot,
+// built-in AOF) and IPC plugins (third-party connectors) implement the same
+// types. ADR-0006 covers the transport choice.
+package persistence
+
+// LSN is a monotonic 64-bit Log Sequence Number. The coordinator allocates
+// LSNs and tags every mutation with one; Sources surface the LSN at which
+// a snapshot was taken so the runtime resumes allocation correctly.
+//
+// LSN 0 is reserved for "no LSN" — used by Sources that supply an Initial
+// boot (no recovery state) or for fields that have not been set.
+type LSN uint64
+
+// ZeroLSN is the LSN value that means "no LSN" — never allocated by the
+// coordinator. Used as a sentinel for boot results and uninitialised fields.
+const ZeroLSN LSN = 0
+
+// BootMode is what a Source declares when asked for recovery state. It is
+// a closed trichotomy — see ADR-0002 for the rationale and ADR-0001 for
+// the per-mode boot semantics.
+type BootMode uint8
+
+const (
+	// BootModeInitial: the Source has nothing to recover from. The server
+	// starts with an empty cache. The corresponding BootResult carries no
+	// iterator and no LSN.
+	BootModeInitial BootMode = iota
+
+	// BootModeSnapshot: the Source supplies a point-in-time snapshot at
+	// LSN=N. The server loads the snapshot, then resumes mutation
+	// allocation from LSN=N+1. BootResult carries Snapshot and LSN.
+	BootModeSnapshot
+
+	// BootModeReplay: the Source supplies an iterator over the mutation
+	// log starting from the lowest available LSN. The server replays each
+	// mutation in order; the final LSN is the resume point. BootResult
+	// carries Replay; the iterator carries the LSN per Mutation.
+	BootModeReplay
+)
+
+// String renders BootMode for logs and errors.
+func (m BootMode) String() string {
+	switch m {
+	case BootModeInitial:
+		return "initial"
+	case BootModeSnapshot:
+		return "snapshot"
+	case BootModeReplay:
+		return "replay"
+	default:
+		return "unknown"
+	}
+}
+
+// FsyncPolicy is a Sink's durability contract — when does it call fsync(2)
+// (or the equivalent) on the underlying medium. Naming matches Redis's
+// `appendfsync` so users carry the same mental model. See ADR-0003.
+type FsyncPolicy uint8
+
+const (
+	// FsyncAlways: fsync after every group-committed batch. Highest
+	// durability; highest latency. Equivalent to Redis appendfsync always.
+	FsyncAlways FsyncPolicy = iota
+
+	// FsyncEverySec: a background goroutine fsyncs at most once per second.
+	// Loses up to ~1s of writes on crash. Default for built-in AOF.
+	// Equivalent to Redis appendfsync everysec.
+	FsyncEverySec
+
+	// FsyncNo: no explicit fsync; rely on the OS page-cache flush schedule.
+	// Loses up to ~30s on crash on Linux defaults. For dev, ephemeral
+	// caches, or sinks where durability is delegated elsewhere.
+	// Equivalent to Redis appendfsync no.
+	FsyncNo
+)
+
+// String renders FsyncPolicy for logs and config dumps.
+func (p FsyncPolicy) String() string {
+	switch p {
+	case FsyncAlways:
+		return "always"
+	case FsyncEverySec:
+		return "everysec"
+	case FsyncNo:
+		return "no"
+	default:
+		return "unknown"
+	}
+}
+
+// ValueType mirrors the cache's value-type tag at the contract layer so
+// SnapshotEntry can carry it without leaking pkg/cache into api/. The
+// values match pkg/cache.ValueType numerically; conversion at the boundary
+// is a one-line cast in pkg/persistence.
+type ValueType uint8
+
+const (
+	ValueTypeBytes     ValueType = iota // string / raw bytes
+	ValueTypeList                       // list-of-strings
+	ValueTypeHash                       // field→value map
+	ValueTypeSet                        // unordered set
+	ValueTypeSortedSet                  // score→member sorted set
+)
+
+// Encoding mirrors the cache's per-entry encoding flag (native Go shape vs
+// packed byte buffer). Same boundary-conversion rule as ValueType.
+type Encoding uint8
+
+const (
+	EncodingNative Encoding = iota // map / slice / *SortedSet
+	EncodingPacked                 // flat []byte (pkg/cache/packed)
+)
+
+// Mutation is one durable write — what the cache committed under a single
+// command. The coordinator allocates LSN and tags the Mutation before
+// fanning it out to Sinks. The byte representation of Args mirrors RESP
+// bulk-string framing so Sinks that persist commands verbatim (AOF, IPC
+// replication) can write them out without re-encoding.
+//
+// Op is the command name uppercased (e.g. "SET", "HSET"). Key is the
+// primary key for routing/sharding; for multi-key commands, Key is the
+// first key (consistent with how the engine routes).
+type Mutation struct {
+	LSN  LSN
+	Op   string
+	Key  string
+	Args [][]byte
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -257,7 +257,12 @@ func main() {
 			opHookExec.RunStartHooks(snapCtx, snapOp)
 		}
 		eventBus.Emit(events.NewOperationStart(snapOp.ID, string(snapOp.Type), bootOp.ID, snapOp.ContextSnapshot(false)))
-		if err := persistence.LoadSnapshot(snapCtx, cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
+		// Boot via the persistence coordinator. The coordinator dispatches
+		// to the registered Source (here: GobSource over the configured
+		// snapshot file); future PRs replace this with the new on-disk
+		// format and add Sink dispatch for the runtime mutation feed.
+		coordinator := persistence.New(persistence.NewGobSource(cfg.Persistence.SnapshotFile))
+		if _, err := coordinator.BootInto(snapCtx, cacheInstance); err != nil {
 			logger.Warn(snapCtx).Err(err).Msg("failed to load snapshot")
 			snapOp.Fail(err.Error())
 			if opHookExec != nil {

--- a/pkg/persistence/coordinator.go
+++ b/pkg/persistence/coordinator.go
@@ -1,0 +1,213 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"gocache/api/logger"
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+)
+
+// Coordinator orchestrates the persistence Source and Sinks. On boot, it
+// asks the registered Source for recovery state and applies it to the
+// cache; during runtime, it will (in feat/persistence-mutation-feed)
+// allocate LSNs and group-commit mutations to Sinks.
+//
+// This PR (feat/persistence-contract) wires the boot path only — Sink
+// dispatch is intentionally stubbed so the type-shape change ships
+// independently of the engine hot-path change. See the persistence-as-
+// plugin plan for the staging.
+type Coordinator struct {
+	source apipersistence.Source
+	sinks  []apipersistence.Sink
+
+	// lsn is the most recently allocated LSN. AllocateLSN increments it;
+	// boot reads it from the snapshot and seeds the runtime allocator.
+	lsn atomic.Uint64
+}
+
+// New returns a coordinator. source may be nil — in that case Boot returns
+// BootModeInitial without error and the coordinator runs in pass-through
+// mode (no recovery, LSN starts at zero). Sinks may be empty; they will
+// be honoured once the mutation feed is wired in the follow-up PR.
+func New(source apipersistence.Source, sinks ...apipersistence.Sink) *Coordinator {
+	return &Coordinator{
+		source: source,
+		sinks:  sinks,
+	}
+}
+
+// AllocateLSN returns the next LSN. Monotonically increasing across all
+// callers (atomic add). The caller must use this for any mutation that's
+// about to be persisted. ZeroLSN is never returned.
+func (c *Coordinator) AllocateLSN() apipersistence.LSN {
+	return apipersistence.LSN(c.lsn.Add(1))
+}
+
+// CurrentLSN returns the most recently allocated LSN, or ZeroLSN if no
+// LSN has been allocated yet.
+func (c *Coordinator) CurrentLSN() apipersistence.LSN {
+	return apipersistence.LSN(c.lsn.Load())
+}
+
+// SetLSN seeds the LSN cursor — used internally on boot and by tests that
+// need to install a known cursor. Production code should prefer Boot to
+// derive the cursor from recovery state.
+func (c *Coordinator) SetLSN(lsn apipersistence.LSN) {
+	c.lsn.Store(uint64(lsn))
+}
+
+// Source returns the registered source (may be nil).
+func (c *Coordinator) Source() apipersistence.Source { return c.source }
+
+// Sinks returns the registered sinks (may be empty).
+func (c *Coordinator) Sinks() []apipersistence.Sink { return c.sinks }
+
+// BootInto drives the recovery path: fetches the BootResult from the
+// Source, applies it to the target cache, and seeds the LSN cursor. The
+// returned LSN is the resume point for runtime mutation allocation.
+//
+// For BootModeInitial (or nil source), returns (ZeroLSN, nil) without
+// touching the cache. For BootModeSnapshot, the snapshot's at-LSN seeds
+// the cursor and snapshot entries are loaded. For BootModeReplay, each
+// replayed Mutation advances the cursor; the final LSN is the resume
+// point.
+//
+// On error, the cache may be in a partially-loaded state — callers should
+// abort startup rather than continue serving traffic against a torn cache.
+func (c *Coordinator) BootInto(ctx context.Context, target *cache.Cache) (apipersistence.LSN, error) {
+	if c.source == nil {
+		logger.Debug(ctx).Msg("persistence coordinator: no source registered, BootMode=initial")
+		return apipersistence.ZeroLSN, nil
+	}
+
+	boot, err := c.source.Boot(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("source %s: %w", c.source.Name(), err)
+	}
+	defer func() {
+		if cerr := boot.Close(); cerr != nil {
+			logger.Warn(ctx).Err(cerr).Str("source", c.source.Name()).Msg("boot result close error")
+		}
+	}()
+
+	switch boot.Mode {
+	case apipersistence.BootModeInitial:
+		logger.Debug(ctx).Str("source", c.source.Name()).Msg("persistence: nothing to recover")
+		return apipersistence.ZeroLSN, nil
+
+	case apipersistence.BootModeSnapshot:
+		if boot.Snapshot == nil {
+			return 0, fmt.Errorf("source %s declared BootModeSnapshot with nil Snapshot", c.source.Name())
+		}
+		loaded, err := loadSnapshotInto(ctx, boot.Snapshot, target)
+		if err != nil {
+			return 0, fmt.Errorf("source %s snapshot: %w", c.source.Name(), err)
+		}
+		c.SetLSN(boot.LSN)
+		logger.Info(ctx).
+			Str("source", c.source.Name()).
+			Int("entries", loaded).
+			Int64("lsn", int64(boot.LSN)).
+			Msg("persistence: snapshot loaded")
+		return boot.LSN, nil
+
+	case apipersistence.BootModeReplay:
+		if boot.Replay == nil {
+			return 0, fmt.Errorf("source %s declared BootModeReplay with nil Replay", c.source.Name())
+		}
+		last, applied, err := replayInto(ctx, boot.Replay, target)
+		if err != nil {
+			return 0, fmt.Errorf("source %s replay: %w", c.source.Name(), err)
+		}
+		c.SetLSN(last)
+		logger.Info(ctx).
+			Str("source", c.source.Name()).
+			Int("mutations", applied).
+			Int64("lsn", int64(last)).
+			Msg("persistence: replay complete")
+		return last, nil
+
+	default:
+		return 0, fmt.Errorf("%w: %d (source %s)", apipersistence.ErrInvalidBootMode, boot.Mode, c.source.Name())
+	}
+}
+
+// loadSnapshotInto drains a SnapshotIterator into the cache. Returns the
+// number of entries loaded.
+func loadSnapshotInto(ctx context.Context, it apipersistence.SnapshotIterator, target *cache.Cache) (int, error) {
+	target.Clear(ctx)
+	loaded := 0
+	now := time.Now().UnixNano()
+	for {
+		e, err := it.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			return loaded, nil
+		}
+		if err != nil {
+			return loaded, fmt.Errorf("read entry %d: %w", loaded, err)
+		}
+		if e.Expiration > 0 && e.Expiration < now {
+			continue
+		}
+		if err := applyEntry(ctx, e, target); err != nil {
+			logger.Warn(ctx).Err(err).Str("key", e.Key).Msg("persistence: skipping malformed entry")
+			continue
+		}
+		loaded++
+	}
+}
+
+// replayInto drains a ReplayIterator. Returns the highest LSN observed
+// and the number of mutations applied. The mutation-replay path is a stub
+// in this PR — it advances the LSN cursor but does not yet re-execute
+// mutations against the cache (that requires the engine adapter wired in
+// feat/persistence-mutation-feed). Returning early is correct: the
+// snapshot path is the recovery path that ships now.
+func replayInto(ctx context.Context, it apipersistence.ReplayIterator, _ *cache.Cache) (apipersistence.LSN, int, error) {
+	var last apipersistence.LSN
+	count := 0
+	for {
+		m, err := it.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			return last, count, nil
+		}
+		if err != nil {
+			return last, count, fmt.Errorf("read mutation %d: %w", count, err)
+		}
+		// Advance the cursor; actual cache mutation re-execution lands
+		// in the next PR alongside the engine adapter.
+		if m.LSN > last {
+			last = m.LSN
+		}
+		count++
+	}
+}
+
+// applyEntry writes one snapshot entry into the target cache. It mirrors
+// the existing LoadSnapshot logic — the only difference is the api types
+// instead of pkg/persistence's internal struct. Conversion between the
+// api enums and pkg/cache enums is a numeric cast (the values are aligned
+// — see the type comments in api/persistence/types.go).
+func applyEntry(_ context.Context, e apipersistence.SnapshotEntry, target *cache.Cache) error {
+	if e.Encoding == apipersistence.EncodingPacked {
+		var buf []byte
+		switch v := e.Value.(type) {
+		case []byte:
+			buf = v
+		case string:
+			buf = []byte(v)
+		default:
+			return fmt.Errorf("packed entry has non-byte payload: %T", e.Value)
+		}
+		target.RawLoadPacked(e.Key, cache.ValueType(e.ValueType), buf, e.Expiration)
+		return nil
+	}
+	target.RawLoad(e.Key, e.Value, e.Expiration)
+	return nil
+}

--- a/pkg/persistence/coordinator_test.go
+++ b/pkg/persistence/coordinator_test.go
@@ -1,0 +1,296 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+)
+
+func TestCoordinator_BootInto_NilSource(t *testing.T) {
+	c := New(nil)
+	target := cache.New()
+
+	lsn, err := c.BootInto(context.Background(), target)
+	if err != nil {
+		t.Fatalf("BootInto with nil source: unexpected error: %v", err)
+	}
+	if lsn != apipersistence.ZeroLSN {
+		t.Errorf("BootInto with nil source: lsn = %d, want %d", lsn, apipersistence.ZeroLSN)
+	}
+	if got := target.Len(); got != 0 {
+		t.Errorf("BootInto with nil source: target.Len = %d, want 0", got)
+	}
+}
+
+func TestCoordinator_BootInto_GobRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snapshot.dat")
+
+	src := cache.New()
+	src.Lock()
+	_ = src.RawSet(context.Background(), "str", "hello", 0)
+	_ = src.RawSet(context.Background(), "list", []string{"a", "b", "c"}, 0)
+	_ = src.RawSet(context.Background(), "hash", map[string]string{"k": "v"}, 0)
+	src.Unlock()
+
+	if err := SaveSnapshot(context.Background(), file, src); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	co := New(NewGobSource(file))
+
+	lsn, err := co.BootInto(context.Background(), target)
+	if err != nil {
+		t.Fatalf("BootInto: %v", err)
+	}
+	if lsn != apipersistence.ZeroLSN {
+		// Gob shim has no LSN concept, so the recovered LSN is zero.
+		t.Errorf("BootInto: lsn = %d, want %d (gob shim is LSN-naive)", lsn, apipersistence.ZeroLSN)
+	}
+	if got := target.Len(); got != 3 {
+		t.Errorf("target.Len = %d, want 3", got)
+	}
+
+	target.Lock()
+	defer target.Unlock()
+
+	entry, ok := target.RawGet("str")
+	if !ok {
+		t.Fatal("str not found in recovered cache")
+	}
+	if got := string(target.ResolvePacked(entry)); got != "hello" {
+		t.Errorf("recovered str = %q, want %q", got, "hello")
+	}
+}
+
+func TestCoordinator_BootInto_MissingFileTreatedAsInitial(t *testing.T) {
+	target := cache.New()
+	co := New(NewGobSource("/nonexistent/path/snapshot.dat"))
+
+	lsn, err := co.BootInto(context.Background(), target)
+	if err != nil {
+		t.Fatalf("BootInto on missing file: %v", err)
+	}
+	if lsn != apipersistence.ZeroLSN {
+		t.Errorf("missing file: lsn = %d, want %d", lsn, apipersistence.ZeroLSN)
+	}
+	if got := target.Len(); got != 0 {
+		t.Errorf("missing file: target.Len = %d, want 0", got)
+	}
+}
+
+func TestCoordinator_BootInto_SkipsExpired(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snapshot.dat")
+
+	src := cache.New()
+	src.Lock()
+	_ = src.RawSet(context.Background(), "expired", "val", time.Now().Add(-time.Hour).UnixNano())
+	_ = src.RawSet(context.Background(), "alive", "val", 0)
+	src.Unlock()
+
+	if err := SaveSnapshot(context.Background(), file, src); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	co := New(NewGobSource(file))
+	if _, err := co.BootInto(context.Background(), target); err != nil {
+		t.Fatalf("BootInto: %v", err)
+	}
+
+	target.Lock()
+	defer target.Unlock()
+	if _, ok := target.RawGet("expired"); ok {
+		t.Error("expected expired key to be skipped during recovery")
+	}
+	if _, ok := target.RawGet("alive"); !ok {
+		t.Error("expected alive key to be recovered")
+	}
+}
+
+func TestCoordinator_AllocateLSN_Monotonic(t *testing.T) {
+	co := New(nil)
+	const total = 10_000
+
+	got := make([]uint64, total)
+	var wg sync.WaitGroup
+	for i := 0; i < total; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			got[idx] = uint64(co.AllocateLSN())
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[uint64]struct{}, total)
+	var max uint64
+	for _, v := range got {
+		if v == 0 {
+			t.Fatal("AllocateLSN returned ZeroLSN")
+		}
+		if _, dup := seen[v]; dup {
+			t.Fatalf("AllocateLSN returned duplicate: %d", v)
+		}
+		seen[v] = struct{}{}
+		if v > max {
+			max = v
+		}
+	}
+	if max != uint64(total) {
+		t.Errorf("max LSN = %d, want %d (no gaps after %d allocations)", max, total, total)
+	}
+	if got := co.CurrentLSN(); got != apipersistence.LSN(total) {
+		t.Errorf("CurrentLSN = %d, want %d", got, total)
+	}
+}
+
+func TestCoordinator_SetLSN(t *testing.T) {
+	co := New(nil)
+	co.SetLSN(42)
+	if got := co.CurrentLSN(); got != 42 {
+		t.Errorf("after SetLSN(42): CurrentLSN = %d, want 42", got)
+	}
+	if got := co.AllocateLSN(); got != 43 {
+		t.Errorf("AllocateLSN after SetLSN(42) = %d, want 43", got)
+	}
+}
+
+// fakeSource lets tests inject arbitrary boot results, including invalid
+// ones, to exercise error paths.
+type fakeSource struct {
+	name string
+	res  apipersistence.BootResult
+	err  error
+}
+
+func (s *fakeSource) Name() string { return s.name }
+func (s *fakeSource) Boot(_ context.Context) (apipersistence.BootResult, error) {
+	return s.res, s.err
+}
+
+func TestCoordinator_BootInto_PropagatesSourceError(t *testing.T) {
+	wantErr := errors.New("source-side failure")
+	co := New(&fakeSource{name: "fake", err: wantErr})
+
+	_, err := co.BootInto(context.Background(), cache.New())
+	if err == nil {
+		t.Fatal("expected error from BootInto")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("BootInto error = %v, want wraps %v", err, wantErr)
+	}
+}
+
+func TestCoordinator_BootInto_InvalidBootMode(t *testing.T) {
+	co := New(&fakeSource{
+		name: "fake",
+		res:  apipersistence.BootResult{Mode: 99},
+	})
+
+	_, err := co.BootInto(context.Background(), cache.New())
+	if err == nil {
+		t.Fatal("expected error for invalid BootMode")
+	}
+	if !errors.Is(err, apipersistence.ErrInvalidBootMode) {
+		t.Errorf("BootInto error = %v, want wraps ErrInvalidBootMode", err)
+	}
+}
+
+func TestCoordinator_BootInto_SnapshotModeRequiresIterator(t *testing.T) {
+	co := New(&fakeSource{
+		name: "fake",
+		res:  apipersistence.BootResult{Mode: apipersistence.BootModeSnapshot}, // Snapshot nil
+	})
+
+	_, err := co.BootInto(context.Background(), cache.New())
+	if err == nil {
+		t.Fatal("expected error for nil Snapshot iterator under BootModeSnapshot")
+	}
+}
+
+func TestCoordinator_BootInto_ReplayAdvancesLSNCursor(t *testing.T) {
+	mutations := []apipersistence.Mutation{
+		{LSN: 10, Op: "SET", Key: "a"},
+		{LSN: 20, Op: "SET", Key: "b"},
+		{LSN: 30, Op: "DEL", Key: "a"},
+	}
+	co := New(&fakeSource{
+		name: "fake",
+		res: apipersistence.BootResult{
+			Mode:   apipersistence.BootModeReplay,
+			Replay: &sliceReplay{items: mutations},
+		},
+	})
+
+	lsn, err := co.BootInto(context.Background(), cache.New())
+	if err != nil {
+		t.Fatalf("BootInto: %v", err)
+	}
+	if lsn != 30 {
+		t.Errorf("recovered LSN = %d, want 30 (highest in replay)", lsn)
+	}
+	if got := co.CurrentLSN(); got != 30 {
+		t.Errorf("CurrentLSN after replay = %d, want 30", got)
+	}
+}
+
+// sliceReplay is a ReplayIterator backed by an in-memory slice.
+type sliceReplay struct {
+	items  []apipersistence.Mutation
+	idx    int
+	closed bool
+}
+
+func (r *sliceReplay) Next(_ context.Context) (apipersistence.Mutation, error) {
+	if r.idx >= len(r.items) {
+		return apipersistence.Mutation{}, io.EOF
+	}
+	m := r.items[r.idx]
+	r.idx++
+	return m, nil
+}
+
+func (r *sliceReplay) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestGobSource_Name(t *testing.T) {
+	if got := NewGobSource("x").Name(); got != "gob-snapshot" {
+		t.Errorf("GobSource.Name = %q, want %q", got, "gob-snapshot")
+	}
+}
+
+func TestGobSource_BootEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "empty.dat")
+	if err := writeFile(file, nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	res, err := NewGobSource(file).Boot(context.Background())
+	if err != nil {
+		t.Fatalf("Boot on empty file: %v", err)
+	}
+	if res.Mode != apipersistence.BootModeInitial {
+		t.Errorf("empty file mode = %v, want Initial (treated as no-state)", res.Mode)
+	}
+	_ = res.Close()
+}
+
+// writeFile is a helper that creates a file with given bytes (may be nil
+// for empty). Avoids importing os in test-only paths and keeps the table-
+// driven tests clean.
+func writeFile(path string, data []byte) error {
+	return writeFileFn(path, data)
+}

--- a/pkg/persistence/gobshim.go
+++ b/pkg/persistence/gobshim.go
@@ -1,0 +1,133 @@
+package persistence
+
+import (
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+)
+
+// GobSource adapts the existing gob-encoded snapshot format to the
+// api/persistence.Source contract. It exists so the contract surface ships
+// in feat/persistence-contract without forcing the new on-disk format
+// (ADR-0005) to land at the same time. The new built-in snapshot plugin
+// will replace this shim with the custom binary format.
+//
+// GobSource carries no LSN — gob snapshots predate the LSN concept. Boot
+// returns LSN=ZeroLSN, which means the runtime allocator starts from 1.
+// This is correct for the legacy path because gob is snapshot-only (no
+// matching log); there's nothing to LSN-order against.
+//
+// Missing snapshot file → BootModeInitial. This matches the legacy
+// LoadSnapshot semantics ("not found is not an error").
+type GobSource struct {
+	filename string
+}
+
+// NewGobSource returns a Source that reads from filename. The path is
+// resolved at Boot time, not now — config hot-reload may change it
+// between construction and boot.
+func NewGobSource(filename string) *GobSource {
+	return &GobSource{filename: filename}
+}
+
+// Name implements api/persistence.Source.
+func (s *GobSource) Name() string { return "gob-snapshot" }
+
+// Boot implements api/persistence.Source. Opens the snapshot file, reads
+// the count header, and returns a SnapshotIterator that decodes one entry
+// at a time. The iterator owns the file handle and closes it on Close.
+func (s *GobSource) Boot(ctx context.Context) (apipersistence.BootResult, error) {
+	file, err := os.Open(s.filename)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
+		}
+		return apipersistence.BootResult{}, fmt.Errorf("open %s: %w", s.filename, err)
+	}
+
+	dec := gob.NewDecoder(file)
+	var count int
+	if err := dec.Decode(&count); err != nil {
+		_ = file.Close()
+		// Empty file is an edge case — treat as Initial rather than an
+		// error. The legacy LoadSnapshot also tolerated this implicitly
+		// (the count decode would fail on EOF).
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
+		}
+		return apipersistence.BootResult{}, fmt.Errorf("decode header %s: %w", s.filename, err)
+	}
+
+	return apipersistence.BootResult{
+		Mode: apipersistence.BootModeSnapshot,
+		LSN:  apipersistence.ZeroLSN,
+		Snapshot: &gobIterator{
+			file:      file,
+			dec:       dec,
+			remaining: count,
+		},
+	}, nil
+}
+
+// gobIterator drains a gob-encoded SnapshotEntry stream. It expects exactly
+// `remaining` entries — the count header is the contract. Reading more
+// returns io.EOF; reading fewer returns an error from gob.
+type gobIterator struct {
+	file      *os.File
+	dec       *gob.Decoder
+	remaining int
+	closed    bool
+}
+
+// Next yields the next SnapshotEntry, converting from the gob-internal
+// SnapshotEntry shape to the api type. The conversion is a per-field cast
+// because the enum values match by construction.
+func (it *gobIterator) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	if it.closed {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	if it.remaining == 0 {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	var e SnapshotEntry
+	if err := it.dec.Decode(&e); err != nil {
+		if errors.Is(err, io.EOF) {
+			return apipersistence.SnapshotEntry{}, io.EOF
+		}
+		return apipersistence.SnapshotEntry{}, fmt.Errorf("decode entry: %w", err)
+	}
+	it.remaining--
+	return apipersistence.SnapshotEntry{
+		Key:        e.Key,
+		ValueType:  apipersistence.ValueType(e.ValueType),
+		Encoding:   apipersistence.Encoding(e.Encoding),
+		Value:      e.Value,
+		Expiration: e.Expiration,
+	}, nil
+}
+
+// Close releases the file handle. Idempotent — calling Close more than
+// once returns nil after the first call.
+func (it *gobIterator) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+	return it.file.Close()
+}
+
+// Compile-time assertion: GobSource implements Source.
+var _ apipersistence.Source = (*GobSource)(nil)
+
+// Compile-time assertion: gobIterator implements SnapshotIterator.
+var _ apipersistence.SnapshotIterator = (*gobIterator)(nil)
+
+// Sentinel — use cache.Cache only via this file's narrow surface so a
+// future refactor can swap the loader without re-grepping.
+var _ = (*cache.Cache)(nil)

--- a/pkg/persistence/testhelpers_test.go
+++ b/pkg/persistence/testhelpers_test.go
@@ -1,0 +1,9 @@
+package persistence
+
+import "os"
+
+// writeFileFn is the implementation backing the test helper. Kept here so
+// the trivial os import doesn't pollute every test file.
+func writeFileFn(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o600)
+}


### PR DESCRIPTION
First implementation chunk of [ADR-0001](https://github.com/j-mizera/gocache/wiki/ADR-0001-persistence-as-pluggable-log-snapshot) / [ADR-0002](https://github.com/j-mizera/gocache/wiki/ADR-0002-source-sink-contract). Boot-side only — Sink wiring (mutation feed, group commit, fsync dispatch) follows in \`feat/persistence-mutation-feed\`. The split lets the type-shape change land independently of the engine hot-path change so the next PR has only one moving part to bench against the headline per-shard numbers.

## Summary

- \`api/persistence/\` — pure contract surface (no \`pkg/\` imports). \`LSN\`, \`BootMode\`, \`FsyncPolicy\`, \`ValueType\`, \`Encoding\`, \`Mutation\`; \`Source\` + \`Sink\` interfaces; \`BootResult\`, \`SnapshotIterator\`, \`ReplayIterator\`. \`ErrSinkFatal\` + \`ErrInvalidBootMode\` sentinels.
- \`pkg/persistence/coordinator.go\` — coordinator skeleton, atomic LSN counter, \`BootInto\` driving the recovery path.
- \`pkg/persistence/gobshim.go\` — \`GobSource\` adapts the existing gob \`LoadSnapshot\` to the new \`Source\` interface. The legacy \`SaveSnapshot\` path stays in place via the \`SnapshotWorker\` until the snapshot plugin (ADR-0005) ships.
- \`cmd/server/main.go\` — boot path replaces direct \`LoadSnapshot\` with \`persistence.New(GobSource).BootInto\`. Operation tracking + hooks + event emission unchanged.

## Why split into two PRs

The mutation feed touches the engine hot path — every command emits a mutation. Bundling it with the type-shape change would force one PR to defend two perf claims at once. Split this way:

- **This PR**: contract surface only. Bench delta is dead-code; verified ±3-4% noise vs main (identical allocs/op).
- **Next PR**: mutation feed + group commit. Bench delta is the *only* thing under review; comparison baseline is this PR.

## Tests

\`pkg/persistence/coordinator_test.go\`:
- BootInto with nil source -> \`ZeroLSN\`, no-op
- Round-trip via \`SaveSnapshot\` + \`Coordinator.BootInto\`
- Missing file treated as \`BootModeInitial\`
- Expired entries skipped during recovery
- \`AllocateLSN\` under 10k concurrent goroutines — no duplicates, no gaps
- Source error propagation via \`errors.Is\`
- Invalid \`BootMode\` -> \`ErrInvalidBootMode\`
- \`BootModeSnapshot\` with nil iterator -> error
- \`BootModeReplay\` advances cursor to highest yielded LSN
- Empty gob file -> \`BootModeInitial\` (tolerant of bootstrap-rig empties)

## Verification

- [x] \`go test -race -count=1 ./...\` PASS (full suite)
- [x] \`go vet ./...\` PASS
- [x] \`staticcheck ./...\` clean
- [x] \`scripts/check-plugin-isolation.sh\` PASS — \`api/persistence/\` imports nothing from \`pkg/\`
- [x] \`BenchmarkTCPShard_{GET,SET}_Pipelined/N=8\` vs main: within noise (±3-4%, identical allocs/op)

## Pointers

- ADR-0001: [pluggable log+snapshot+LSN](https://github.com/j-mizera/gocache/wiki/ADR-0001-persistence-as-pluggable-log-snapshot)
- ADR-0002: [Source/Sink contract](https://github.com/j-mizera/gocache/wiki/ADR-0002-source-sink-contract)
- ADR-0003: [mutation feed + fsync](https://github.com/j-mizera/gocache/wiki/ADR-0003-mutation-feed-and-fsync) — implementation follows in next PR

## Test plan

- [ ] CI green on all checks
- [ ] No third-party plugin import regressions (\`scripts/check-plugin-isolation.sh\` in CI)
- [ ] No bench regression on the wiki-published per-shard numbers