### PR TITLE
feat(persistence): runtime mutation feed — engine emit + per-sink group commit (ADR-0003 impl)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -246,6 +246,15 @@ func main() {
 	}
 	eventBus.Emit(events.NewOperationStart(bootOp.ID, string(bootOp.Type), "", bootOp.ContextSnapshot(false)))
 
+	// Persistence coordinator. Created unconditionally so the runtime
+	// mutation feed can be wired even when LoadOnStartup is off; the
+	// coordinator runs in pass-through mode (no sinks registered) until
+	// a future PR adds the AOF / snapshot sink plugins. The current path
+	// uses GobSource for boot recovery; that goes away when the snapshot
+	// plugin (ADR-0005) replaces the gob format.
+	coordinator := persistence.New(persistence.NewGobSource(cfg.Persistence.SnapshotFile))
+	srv.SetPersistenceFeed(coordinator)
+
 	// LoadSnapshot operation.
 	_ = bootstate.Write(bootStateFile, stageSnapshotLoad)
 	if cfg.Persistence.LoadOnStartup {
@@ -257,11 +266,6 @@ func main() {
 			opHookExec.RunStartHooks(snapCtx, snapOp)
 		}
 		eventBus.Emit(events.NewOperationStart(snapOp.ID, string(snapOp.Type), bootOp.ID, snapOp.ContextSnapshot(false)))
-		// Boot via the persistence coordinator. The coordinator dispatches
-		// to the registered Source (here: GobSource over the configured
-		// snapshot file); future PRs replace this with the new on-disk
-		// format and add Sink dispatch for the runtime mutation feed.
-		coordinator := persistence.New(persistence.NewGobSource(cfg.Persistence.SnapshotFile))
 		if _, err := coordinator.BootInto(snapCtx, cacheInstance); err != nil {
 			logger.Warn(snapCtx).Err(err).Msg("failed to load snapshot")
 			snapOp.Fail(err.Error())
@@ -284,6 +288,13 @@ func main() {
 	// Start engine.
 	go engineInstance.Run()
 
+	// Start the persistence coordinator AFTER boot so the LSN cursor
+	// reflects the recovered snapshot. With no sinks registered (current
+	// configuration), Start is a no-op aside from arming the lifecycle —
+	// HasSinks remains false and the dispatcher's emission fast-path
+	// short-circuits. Stop runs in the shutdown sequence below.
+	coordinator.Start(ctx)
+
 	// Initialize and start workers.
 	_ = bootstate.Write(bootStateFile, stageWorkersStart)
 	snapshotWorker := workers.NewSnapshotWorker(
@@ -292,6 +303,7 @@ func main() {
 		cfg.Persistence.SnapshotFile,
 	)
 	cleanupWorker := workers.NewCleanupWorker(cacheInstance, engineInstance, cfg.Workers.CleanupInterval)
+	cleanupWorker.SetPersistenceFeed(coordinator)
 	snapshotWorker.SetTracker(tracker)
 	snapshotWorker.SetEmitter(eventBus)
 	if opHookExec != nil {
@@ -375,10 +387,10 @@ func main() {
 	select {
 	case sig := <-sigChan:
 		logger.InfoNoCtx().Str("signal", sig.String()).Msg("received signal")
-		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, sig.String())
+		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, coordinator, sig.String())
 	case err := <-serverErrChan:
 		logger.ErrorNoCtx().Err(err).Msg("server error")
-		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, "error: "+err.Error())
+		handleShutdown(srv, snapshotWorker, cleanupWorker, engineInstance, cacheInstance, cfgPtr.Load(), blockingRegistry, pluginManager, tracker, eventBus, opHookExec, coordinator, "error: "+err.Error())
 		os.Exit(1)
 	}
 
@@ -407,6 +419,7 @@ func handleShutdown(
 	tracker *serverOps.Tracker,
 	eventBus *serverEvents.Bus,
 	opHookExec *ophooks.Executor,
+	coordinator *persistence.Coordinator,
 	reason string,
 ) {
 	// Create shutdown operation — plugins see this via operation hooks
@@ -448,6 +461,12 @@ func handleShutdown(
 	logger.Info(shutdownCtx).Str("step", "3/6").Msg("stopping background workers")
 	snapshotWorker.Stop()
 	cleanupWorker.Stop()
+
+	// Drain the persistence coordinator BEFORE the final snapshot so any
+	// inflight mutations make it to their sinks. With no sinks registered
+	// in this build, Stop is a no-op; with sinks, Stop blocks until each
+	// sink's flush goroutine drains its buffer and Sink.Close returns.
+	coordinator.Stop(shutdownCtx)
 
 	logger.Info(shutdownCtx).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
 	if err := persistence.SaveSnapshot(shutdownCtx, cfg.Persistence.SnapshotFile, cacheInstance); err != nil {

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	apicommand "gocache/api/command"
+	apipersistence "gocache/api/persistence"
 	"gocache/pkg/blocking"
 	"gocache/pkg/cache"
 	"gocache/pkg/clientctx"
@@ -15,6 +16,19 @@ import (
 	"gocache/pkg/transaction"
 	"gocache/pkg/watch"
 )
+
+// MutationEmitter is the dispatcher-side hook into the persistence
+// coordinator. The cache write path uses HasSinks to short-circuit
+// emission when no sink is registered (~1ns atomic load); when at least
+// one sink is registered, AllocateAndEmit is called inside the shard
+// lock to allocate the LSN and push the mutation to per-sink buffers.
+//
+// Implemented by *pkg/persistence.Coordinator. Nil is a valid value —
+// the dispatcher treats it the same as "no sinks".
+type MutationEmitter interface {
+	HasSinks() bool
+	AllocateAndEmit(op, key string, args [][]byte) apipersistence.LSN
+}
 
 // Re-export shared types from api/command so existing importers don't break.
 type Result = apicommand.Result
@@ -74,6 +88,18 @@ type Context struct {
 	// queued commands in a batch. parentCtx is the connection-scoped ctx
 	// from the outer Evaluate call.
 	EvalFn func(parentCtx context.Context, client *clientctx.ClientContext, op string, args []string, inBatch bool) Result
+
+	// Spec is the command's classification, populated by the evaluator
+	// from the command registration. Dispatch reads Spec.ReadOnly to
+	// decide whether to wrap fn with persistence emission.
+	Spec Spec
+
+	// Coordinator is the persistence mutation-feed entry point, set by
+	// the evaluator from the server's coordinator instance. May be nil
+	// when no persistence is configured. When non-nil, Dispatch wraps
+	// non-read-only fn closures with HasSinks-gated emission inside the
+	// shard lock so LSN allocation order matches lock order.
+	Coordinator MutationEmitter
 }
 
 // Context returns the ambient context.Context carrying the current
@@ -121,6 +147,8 @@ func (c *Context) Reset() {
 	c.MultiKey = false
 	c.TouchedShards = nil
 	c.EvalFn = nil
+	c.Spec = Spec{}
+	c.Coordinator = nil
 }
 
 // Dispatch runs fn under the appropriate locking discipline for the
@@ -139,6 +167,15 @@ func (c *Context) Reset() {
 // is stopped or the command context is cancelled before fn runs, the
 // returned Result carries that error.
 func Dispatch(ctx *Context, fn func() any) Result {
+	// Wrap fn with persistence-feed emission when (a) the command writes
+	// (Spec.ReadOnly is false) and (b) a coordinator is attached. The
+	// HasSinks check inside the wrapper is what gates the per-command
+	// cost: zero when no sink is registered, atomic-load + LSN-allocate +
+	// channel-send when one is. The wrapper always runs inside the shard
+	// lock so LSN allocation order matches lock order — critical for
+	// replay correctness.
+	fn = wrapWithEmission(ctx, fn)
+
 	if ctx.InBatch {
 		return wrapInline(fn)
 	}
@@ -159,6 +196,68 @@ func Dispatch(ctx *Context, fn func() any) Result {
 	}
 	res, err := ctx.Engine.DispatchToShard(ctx.Context(), ctx.Shard, fn)
 	return wrapDispatch(res, err)
+}
+
+// wrapWithEmission returns fn unchanged for read-only commands or when
+// no coordinator is attached. For writes with a coordinator, returns a
+// closure that runs fn, then (inside the same goroutine and the same
+// lock the dispatcher acquired) emits a Mutation if at least one sink
+// is registered AND fn's result is not an error.
+//
+// The closure does NOT pay the emission cost on three short-circuits:
+//
+//   - read-only command (compile-time skip — bare fn returned)
+//   - no coordinator   (compile-time skip — bare fn returned)
+//   - HasSinks == false (atomic load, ~1 ns) — runtime skip inside lock
+func wrapWithEmission(ctx *Context, fn func() any) func() any {
+	if ctx.Spec.ReadOnly || ctx.Coordinator == nil {
+		return fn
+	}
+	return func() any {
+		res := fn()
+		if !ctx.Coordinator.HasSinks() {
+			return res
+		}
+		if _, isErr := res.(error); isErr {
+			return res
+		}
+		ctx.Coordinator.AllocateAndEmit(ctx.Op, primaryKey(ctx), argsAsBytes(ctx.Args))
+		return res
+	}
+}
+
+// primaryKey returns the command's primary key for routing/sharding hints
+// in the Mutation. For keyless commands or out-of-range KeyArgIndex
+// returns the empty string. For multi-key commands returns the first key
+// (Args[KeyArgIndex] if valid, else Args[0] when Args is non-empty).
+//
+// Mutation.Args carries the full argument list, so a sink that needs every
+// key (AOF replay, multi-key replication) reads from there. Mutation.Key
+// is a routing hint, not the source of truth.
+func primaryKey(ctx *Context) string {
+	idx := ctx.Spec.KeyArgIndex
+	if idx >= 0 && idx < len(ctx.Args) {
+		return ctx.Args[idx]
+	}
+	if ctx.MultiKey && len(ctx.Args) > 0 {
+		return ctx.Args[0]
+	}
+	return ""
+}
+
+// argsAsBytes converts the string-typed argument slice to [][]byte for
+// the Mutation wire shape. Each conversion copies (Go strings are
+// immutable). Verbatim zero-copy from the RESP parser is a future
+// optimization once the dispatcher carries the raw RESP bytes through.
+func argsAsBytes(args []string) [][]byte {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(args))
+	for i, a := range args {
+		out[i] = []byte(a)
+	}
+	return out
 }
 
 func wrapInline(fn func() any) Result {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -84,6 +84,7 @@ type BaseEvaluator struct {
 	emitter            events.Emitter
 	tracker            *serverOps.Tracker
 	opHookExecutor     OpHookExecutor
+	persistenceFeed    command.MutationEmitter
 }
 
 func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *BaseEvaluator {
@@ -129,6 +130,15 @@ func (b *BaseEvaluator) SetEmitter(e events.Emitter) {
 
 func (b *BaseEvaluator) SetTracker(t *serverOps.Tracker) {
 	b.tracker = t
+}
+
+// SetPersistenceFeed wires the persistence coordinator's mutation-feed
+// hook into the evaluator. Each *command.Context populated by fillCmdCtx
+// inherits the same instance, so command.Dispatch can decide per-command
+// whether to wrap the write closure with emission. Pass nil to disable
+// emission (the default — no coordinator means no mutation feed).
+func (b *BaseEvaluator) SetPersistenceFeed(f command.MutationEmitter) {
+	b.persistenceFeed = f
 }
 
 func (b *BaseEvaluator) SetOpHookExecutor(e OpHookExecutor) {
@@ -368,6 +378,8 @@ func (b *BaseEvaluator) fillCmdCtx(c *command.Context, ctx *clientctx.ClientCont
 		c.Shard = 0
 	}
 	c.EvalFn = b.evaluateInternal
+	c.Spec = spec
+	c.Coordinator = b.persistenceFeed
 }
 
 // routeToPlugin dispatches a command to a plugin via the router. The per-call

--- a/pkg/persistence/coordinator.go
+++ b/pkg/persistence/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -13,15 +14,17 @@ import (
 	"gocache/pkg/cache"
 )
 
-// Coordinator orchestrates the persistence Source and Sinks. On boot, it
+// Coordinator orchestrates the persistence Source and Sinks. On boot it
 // asks the registered Source for recovery state and applies it to the
-// cache; during runtime, it will (in feat/persistence-mutation-feed)
-// allocate LSNs and group-commit mutations to Sinks.
+// cache; during runtime it allocates LSNs and group-commit dispatches
+// mutations to Sinks via per-sink flush loops.
 //
-// This PR (feat/persistence-contract) wires the boot path only — Sink
-// dispatch is intentionally stubbed so the type-shape change ships
-// independently of the engine hot-path change. See the persistence-as-
-// plugin plan for the staging.
+// Lifecycle:
+//  1. New(source, sinks...) — register the contract participants.
+//  2. BootInto(ctx, cache)  — recover state from Source.
+//  3. Start(ctx)            — spawn the per-sink flush loops.
+//  4. Emit / AllocateAndEmit — runtime mutation feed.
+//  5. Stop(ctx)             — drain inflight, Close each Sink, exit.
 type Coordinator struct {
 	source apipersistence.Source
 	sinks  []apipersistence.Sink
@@ -29,17 +32,88 @@ type Coordinator struct {
 	// lsn is the most recently allocated LSN. AllocateLSN increments it;
 	// boot reads it from the snapshot and seeds the runtime allocator.
 	lsn atomic.Uint64
+
+	// activeSinks counts healthy Sinks. Read by HasSinks (atomic load)
+	// on the cache write hot path; written on Start (per-sink increment)
+	// and on quarantine (decrement). Initial value zero — HasSinks is
+	// false until Start runs.
+	activeSinks atomic.Int32
+
+	// feed holds one sinkChannel per registered Sink. Populated in Start.
+	feed []*sinkChannel
+
+	// stop is closed by Stop to signal every per-sink flush loop to exit.
+	stop      chan struct{}
+	stopOnce  sync.Once
+	startOnce sync.Once
+	started   atomic.Bool
 }
 
 // New returns a coordinator. source may be nil — in that case Boot returns
 // BootModeInitial without error and the coordinator runs in pass-through
-// mode (no recovery, LSN starts at zero). Sinks may be empty; they will
-// be honoured once the mutation feed is wired in the follow-up PR.
+// mode (no recovery, LSN starts at zero). Sinks may be empty; HasSinks
+// returns false and the dispatcher's emission fast-path skips entirely.
 func New(source apipersistence.Source, sinks ...apipersistence.Sink) *Coordinator {
 	return &Coordinator{
 		source: source,
 		sinks:  sinks,
+		stop:   make(chan struct{}),
 	}
+}
+
+// Start spawns one flush goroutine per registered Sink and arms HasSinks
+// so the cache write path begins emitting mutations. Idempotent — a
+// second Start call is a no-op. Must be called after BootInto so the
+// runtime resumes from the recovered LSN cursor.
+//
+// The provided ctx is used as the parent for all Sink Apply / Close
+// invocations; it should outlive the coordinator (typically a request-
+// scoped server-lifetime context). Stop signals shutdown via the
+// coordinator's internal channel — ctx cancellation is observed by
+// Apply / Close calls but does not by itself stop the flush loops.
+func (c *Coordinator) Start(ctx context.Context) {
+	c.startOnce.Do(func() {
+		c.feed = make([]*sinkChannel, 0, len(c.sinks))
+		for _, s := range c.sinks {
+			// onQuarantine decrements activeSinks so HasSinks reports the
+			// post-quarantine state; producer-side fast-path then skips
+			// emission to dead sinks. Producers reaching the channel
+			// before activeSinks settles are absorbed by the consume()
+			// quarantine check inside the run loop.
+			sc := newSinkChannel(s, defaultBufferSize, func() {
+				c.activeSinks.Add(-1)
+			})
+			c.feed = append(c.feed, sc)
+			c.recordSinkActive()
+			sc.startSinkLoop(ctx, c.stop)
+			logger.Info(ctx).
+				Str("sink", s.Name()).
+				Str("fsync", s.FsyncPolicy().String()).
+				Int("buffer", sc.bufferSize).
+				Msg("persistence: sink started")
+		}
+		c.started.Store(true)
+	})
+}
+
+// Stop signals every per-sink flush loop to drain its inflight buffer,
+// call Sink.Apply on whatever's left, then call Sink.Close. Returns
+// once all flush goroutines have exited. Idempotent — a second Stop
+// call returns immediately.
+//
+// Stop blocks the caller until drain completes. Callers with a deadline
+// concern should wrap with their own timeout; the coordinator does not
+// impose one because durable shutdown ("flush everything") is the more
+// important property than bounded shutdown latency.
+func (c *Coordinator) Stop(_ context.Context) {
+	c.stopOnce.Do(func() {
+		close(c.stop)
+		for _, sc := range c.feed {
+			sc.wg.Wait()
+		}
+		c.started.Store(false)
+		c.activeSinks.Store(0)
+	})
 }
 
 // AllocateLSN returns the next LSN. Monotonically increasing across all

--- a/pkg/persistence/feed.go
+++ b/pkg/persistence/feed.go
@@ -1,0 +1,233 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"gocache/api/logger"
+	apipersistence "gocache/api/persistence"
+)
+
+// Group-commit triggers for the per-sink flush loop. Defaults match the
+// values cited in ADR-0003 — small enough to keep tail latency bounded,
+// large enough to amortise per-flush overhead across batched writes.
+const (
+	defaultBatchInterval = 1 * time.Millisecond
+	defaultBatchBytes    = 64 * 1024
+	defaultBufferSize    = 16 * 1024 // mutations per sink before backpressure
+	highWaterPercent     = 80        // emergency flush + warn at 80% buffer fill
+)
+
+// sinkChannel pairs a Sink with the goroutine driving its group-commit
+// flush loop. One per registered Sink. The Coordinator's Emit fans out
+// to each sinkChannel in registration order (no broadcast amplification —
+// each sink gets its own copy of the mutation reference, but the Mutation
+// struct is value-copied so nothing aliases).
+type sinkChannel struct {
+	sink     apipersistence.Sink
+	incoming chan apipersistence.Mutation
+	wakeup   chan struct{} // size-trigger / shutdown nudge to break the timer wait
+	wg       sync.WaitGroup
+
+	// onQuarantine fires when the Sink returns an ErrSinkFatal-wrapped
+	// error from Apply. The Coordinator passes a callback that
+	// decrements activeSinks so HasSinks reflects the quarantine state.
+	// Once quarantined, the run loop drains incoming without applying
+	// (producers don't block) and never calls Apply again.
+	onQuarantine func()
+
+	// Capacity values resolved at construction. Kept on the channel so
+	// the flush loop can compute high-water without re-reading config.
+	bufferSize int
+	highWater  int
+}
+
+func newSinkChannel(s apipersistence.Sink, bufSize int, onQuarantine func()) *sinkChannel {
+	if bufSize <= 0 {
+		bufSize = defaultBufferSize
+	}
+	return &sinkChannel{
+		sink:         s,
+		incoming:     make(chan apipersistence.Mutation, bufSize),
+		wakeup:       make(chan struct{}, 1),
+		onQuarantine: onQuarantine,
+		bufferSize:   bufSize,
+		highWater:    bufSize * highWaterPercent / 100,
+	}
+}
+
+// startSinkLoop runs the per-sink group-commit flush loop. The loop
+// terminates when stop is closed AND the incoming buffer is drained.
+//
+// Triggers in priority order:
+//  1. stop closed AND buffer empty -> drain remaining inflight, Apply,
+//     Sink.Close, return.
+//  2. buffer at or above high-water -> emergency flush + warn (so users
+//     can tune buffer size before hitting the blocking edge).
+//  3. accumulated batch bytes >= defaultBatchBytes -> flush.
+//  4. defaultBatchInterval elapsed since last flush -> flush.
+//
+// Apply errors are logged. Errors that wrap api/persistence.ErrSinkFatal
+// quarantine the sink (loop exits, future Emit drops on the floor for
+// this sink). Transient errors keep the loop alive — the next batch
+// retries. (Backoff scheduling is a TODO; today retry is "the next batch
+// implicitly".)
+func (sc *sinkChannel) startSinkLoop(ctx context.Context, stop <-chan struct{}) {
+	sc.wg.Add(1)
+	go sc.run(ctx, stop)
+}
+
+func (sc *sinkChannel) run(ctx context.Context, stop <-chan struct{}) {
+	defer sc.wg.Done()
+
+	ticker := time.NewTicker(defaultBatchInterval)
+	defer ticker.Stop()
+
+	batch := make([]apipersistence.Mutation, 0, 64)
+	batchBytes := 0
+	warnedHighWater := false
+	quarantined := false
+
+	flush := func(reason string) {
+		if len(batch) == 0 {
+			return
+		}
+		if quarantined {
+			// Drop the buffered batch — the sink is dead.
+			batch = batch[:0]
+			batchBytes = 0
+			return
+		}
+		err := sc.sink.Apply(ctx, batch)
+		batch = batch[:0]
+		batchBytes = 0
+		warnedHighWater = false
+		if err == nil {
+			return
+		}
+		logger.Error(ctx).
+			Err(err).
+			Str("sink", sc.sink.Name()).
+			Str("reason", reason).
+			Msg("persistence: sink Apply failed")
+		if errors.Is(err, apipersistence.ErrSinkFatal) {
+			logger.Error(ctx).
+				Str("sink", sc.sink.Name()).
+				Msg("persistence: sink quarantined (fatal error)")
+			quarantined = true
+			if sc.onQuarantine != nil {
+				sc.onQuarantine()
+			}
+		}
+	}
+
+	consume := func(m apipersistence.Mutation) {
+		if quarantined {
+			// Sink is dead — drop new mutations on the floor. Producers
+			// already gate on HasSinks; a small race window can still
+			// land a few stragglers here. Dropping is correct: there's
+			// nowhere durable for them to go.
+			return
+		}
+		batch = append(batch, m)
+		batchBytes += sizeOfMutation(m)
+		if batchBytes >= defaultBatchBytes {
+			flush("size-trigger")
+			return
+		}
+		if !warnedHighWater && len(sc.incoming) >= sc.highWater {
+			logger.Warn(ctx).
+				Str("sink", sc.sink.Name()).
+				Int("buffer", sc.bufferSize).
+				Int("watermark", sc.highWater).
+				Int("len", len(sc.incoming)).
+				Msg("persistence: sink buffer at high-water — flushing early; consider increasing buffer size")
+			warnedHighWater = true
+			flush("high-water")
+		}
+	}
+
+	for {
+		select {
+		case m := <-sc.incoming:
+			consume(m)
+		case <-ticker.C:
+			flush("time-trigger")
+		case <-sc.wakeup:
+			// Size-trigger or stop nudge. The actual decision (drain or
+			// shutdown) is in the next loop iteration's select arms.
+		case <-stop:
+			// Drain remaining inflight, then close.
+			for {
+				select {
+				case m := <-sc.incoming:
+					consume(m)
+				default:
+					flush("shutdown")
+					if err := sc.sink.Close(ctx); err != nil {
+						logger.Warn(ctx).Err(err).Str("sink", sc.sink.Name()).Msg("persistence: sink Close error")
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+// sizeOfMutation returns an approximate byte cost for group-commit batching
+// purposes. The exact wire-format size depends on the sink's encoding;
+// what matters here is rough proportionality to keep the 64 KB trigger
+// firing at predictable intervals.
+func sizeOfMutation(m apipersistence.Mutation) int {
+	n := 8 + len(m.Op) + len(m.Key) // LSN (8 bytes) + op + key strings
+	for _, a := range m.Args {
+		n += len(a)
+	}
+	return n
+}
+
+// Emit pushes m to every registered Sink. Non-blocking when buffers have
+// room; blocks the caller when any buffer is full (intentional
+// backpressure — see ADR-0003 risks).
+//
+// Hot-path callers MUST gate this behind HasSinks() to avoid the
+// allocation + atomic load on the no-subscriber path. See ADR-0003 and
+// the `feedback-keep-work-out-of-locks` design rule.
+func (c *Coordinator) Emit(m apipersistence.Mutation) {
+	for _, sc := range c.feed {
+		sc.incoming <- m
+	}
+}
+
+// AllocateAndEmit allocates a fresh LSN and emits one mutation. Hot-path
+// convenience for the dispatcher — the caller doesn't have to know about
+// LSN management. Same backpressure semantics as Emit.
+//
+// Returns the allocated LSN so callers that want to log it can.
+func (c *Coordinator) AllocateAndEmit(op, key string, args [][]byte) apipersistence.LSN {
+	lsn := c.AllocateLSN()
+	c.Emit(apipersistence.Mutation{LSN: lsn, Op: op, Key: key, Args: args})
+	return lsn
+}
+
+// HasSinks reports whether any sink is currently registered with this
+// coordinator. The check is an atomic load of an int32 sink-count, which
+// is the same shape as the existing evaluator.hasAnySink fast-path gate.
+//
+// Callers in the cache write path use HasSinks as the first check before
+// allocating LSN / building Mutation structs / pushing to channels. When
+// no sink is registered, the dispatcher's overhead is one nil-check + one
+// atomic load — matching pre-feature baseline.
+func (c *Coordinator) HasSinks() bool {
+	return c.activeSinks.Load() > 0
+}
+
+// recordSinkActive increments activeSinks. Called from Start, once per
+// registered sink. The producer-side hot path reads activeSinks via
+// HasSinks to short-circuit emission when there are no consumers.
+// Decrement is exclusively the quarantine path (sinkChannel.onQuarantine).
+func (c *Coordinator) recordSinkActive() {
+	c.activeSinks.Add(1)
+}

--- a/pkg/persistence/feed_test.go
+++ b/pkg/persistence/feed_test.go
@@ -1,0 +1,327 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apipersistence "gocache/api/persistence"
+)
+
+// recordingSink captures every Apply batch in memory. Used by tests to
+// assert ordering, batch shape, and lifecycle.
+//
+// All fields are guarded by mu so tests that mutate sink behaviour
+// concurrently with the running flush goroutine (e.g. setting applyErr
+// to nil after a transient failure) do not race.
+type recordingSink struct {
+	name   string
+	policy apipersistence.FsyncPolicy
+
+	mu         sync.Mutex
+	batches    [][]apipersistence.Mutation
+	closed     bool
+	applyDelay time.Duration
+	applyErr   error
+
+	// applyCount counts Apply calls. Atomic so tests can assert without
+	// holding mu (the count itself is independent of payload state).
+	applyCount atomic.Int32
+}
+
+// setApplyErr is the race-safe way to mutate applyErr after Start.
+func (s *recordingSink) setApplyErr(err error) {
+	s.mu.Lock()
+	s.applyErr = err
+	s.mu.Unlock()
+}
+
+func newRecordingSink(name string) *recordingSink {
+	return &recordingSink{name: name}
+}
+
+func (s *recordingSink) Name() string                       { return s.name }
+func (s *recordingSink) FsyncPolicy() apipersistence.FsyncPolicy { return s.policy }
+func (s *recordingSink) Apply(_ context.Context, batch []apipersistence.Mutation) error {
+	s.applyCount.Add(1)
+	s.mu.Lock()
+	delay := s.applyDelay
+	err := s.applyErr
+	s.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Copy the batch — the coordinator reuses its slice across Apply.
+	cp := make([]apipersistence.Mutation, len(batch))
+	copy(cp, batch)
+	s.batches = append(s.batches, cp)
+	return nil
+}
+func (s *recordingSink) Close(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *recordingSink) totalMutations() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, b := range s.batches {
+		n += len(b)
+	}
+	return n
+}
+
+func (s *recordingSink) snapshotBatches() [][]apipersistence.Mutation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]apipersistence.Mutation, len(s.batches))
+	for i, b := range s.batches {
+		cp := make([]apipersistence.Mutation, len(b))
+		copy(cp, b)
+		out[i] = cp
+	}
+	return out
+}
+
+func TestCoordinator_HasSinks_NoSinks(t *testing.T) {
+	c := New(nil)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	if c.HasSinks() {
+		t.Error("HasSinks reported true with no sinks registered")
+	}
+}
+
+func TestCoordinator_HasSinks_AfterStart(t *testing.T) {
+	sink := newRecordingSink("test")
+	c := New(nil, sink)
+
+	if c.HasSinks() {
+		t.Error("HasSinks should be false before Start")
+	}
+
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	if !c.HasSinks() {
+		t.Error("HasSinks should be true after Start with one sink")
+	}
+}
+
+func TestCoordinator_Emit_Batches_TimeTrigger(t *testing.T) {
+	sink := newRecordingSink("test")
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	// Emit a few small mutations — well under the 64KB size trigger.
+	// They should batch and flush on the 1ms timer.
+	for i := 0; i < 5; i++ {
+		c.AllocateAndEmit("SET", "key", [][]byte{[]byte("k"), []byte("v")})
+	}
+
+	// Wait for the timer-triggered flush. 50ms is generous.
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if sink.totalMutations() == 5 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := sink.totalMutations(); got != 5 {
+		t.Errorf("totalMutations = %d, want 5 after time-trigger flush", got)
+	}
+}
+
+func TestCoordinator_Emit_Batches_SizeTrigger(t *testing.T) {
+	sink := newRecordingSink("test")
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	// Emit one mutation that crosses the 64KB threshold by itself —
+	// guaranteed to fire the size trigger before the time trigger.
+	bigArg := make([]byte, 70*1024)
+	c.AllocateAndEmit("SET", "key", [][]byte{[]byte("k"), bigArg})
+
+	// Size-triggered flush should be near-instant.
+	deadline := time.Now().Add(20 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if sink.applyCount.Load() == 1 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Errorf("size-trigger flush did not fire; applyCount = %d", sink.applyCount.Load())
+}
+
+func TestCoordinator_Emit_LSN_Order_Sequential(t *testing.T) {
+	sink := newRecordingSink("test")
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	const total = 100
+	for i := 0; i < total; i++ {
+		c.AllocateAndEmit("SET", fmt.Sprintf("k%d", i), [][]byte{[]byte("v")})
+	}
+
+	// Drain.
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if sink.totalMutations() >= total {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// LSNs must be strictly increasing across the captured batches.
+	var prev apipersistence.LSN
+	for _, batch := range sink.snapshotBatches() {
+		for _, m := range batch {
+			if m.LSN <= prev {
+				t.Fatalf("LSN went backwards: prev=%d cur=%d", prev, m.LSN)
+			}
+			prev = m.LSN
+		}
+	}
+}
+
+func TestCoordinator_Stop_Drains(t *testing.T) {
+	sink := newRecordingSink("test")
+	c := New(nil, sink)
+	c.Start(context.Background())
+
+	const total = 50
+	for i := 0; i < total; i++ {
+		c.AllocateAndEmit("SET", fmt.Sprintf("k%d", i), [][]byte{[]byte("v")})
+	}
+
+	c.Stop(context.Background())
+
+	if got := sink.totalMutations(); got != total {
+		t.Errorf("Stop did not drain: totalMutations = %d, want %d", got, total)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if !sink.closed {
+		t.Error("Stop did not call Sink.Close")
+	}
+}
+
+func TestCoordinator_MultiSink_FanOut(t *testing.T) {
+	sinkA := newRecordingSink("A")
+	sinkB := newRecordingSink("B")
+	c := New(nil, sinkA, sinkB)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	const total = 10
+	for i := 0; i < total; i++ {
+		c.AllocateAndEmit("SET", fmt.Sprintf("k%d", i), [][]byte{[]byte("v")})
+	}
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if sinkA.totalMutations() == total && sinkB.totalMutations() == total {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Errorf("multi-sink fan-out incomplete: A=%d B=%d (want %d each)",
+		sinkA.totalMutations(), sinkB.totalMutations(), total)
+}
+
+func TestCoordinator_FatalError_Quarantines(t *testing.T) {
+	sink := newRecordingSink("fatal")
+	sink.setApplyErr(fmt.Errorf("boom: %w", apipersistence.ErrSinkFatal))
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	// First flush triggers the fatal error.
+	c.AllocateAndEmit("SET", "k", [][]byte{[]byte("v")})
+
+	// Wait for the flush + quarantine to settle.
+	time.Sleep(20 * time.Millisecond)
+
+	// Subsequent emits should not pile up behind the dead sink.
+	for i := 0; i < 100; i++ {
+		c.AllocateAndEmit("SET", "k", [][]byte{[]byte("v")})
+	}
+	// If quarantine didn't drain, the producer would block here on the
+	// channel-send — we'd never reach this assertion. Reaching here is
+	// the assertion: the producer never blocked.
+
+	// applyCount should be exactly 1 (the failed Apply) — no retries
+	// against a quarantined sink.
+	time.Sleep(10 * time.Millisecond)
+	if got := sink.applyCount.Load(); got != 1 {
+		t.Errorf("applyCount = %d after quarantine; want 1 (no further Apply calls)", got)
+	}
+}
+
+func TestCoordinator_NonFatalError_KeepsLooping(t *testing.T) {
+	sink := newRecordingSink("transient")
+	sink.setApplyErr(errors.New("transient failure"))
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	c.AllocateAndEmit("SET", "k", [][]byte{[]byte("v")})
+	time.Sleep(20 * time.Millisecond)
+
+	// Clear the error so the next Apply succeeds.
+	sink.setApplyErr(nil)
+
+	c.AllocateAndEmit("SET", "k2", [][]byte{[]byte("v")})
+	time.Sleep(20 * time.Millisecond)
+
+	if got := sink.applyCount.Load(); got < 2 {
+		t.Errorf("non-fatal error stopped the loop: applyCount = %d, want >=2", got)
+	}
+	if got := sink.totalMutations(); got < 1 {
+		t.Errorf("totalMutations = %d, want >=1 after transient failure recovery", got)
+	}
+}
+
+func TestCoordinator_Emit_Concurrent(t *testing.T) {
+	sink := newRecordingSink("concurrent")
+	c := New(nil, sink)
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Stop(context.Background()) })
+
+	const goroutines = 50
+	const perG = 100
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				c.AllocateAndEmit("SET", fmt.Sprintf("k-%d-%d", g, i), [][]byte{[]byte("v")})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	c.Stop(context.Background())
+
+	if got, want := sink.totalMutations(), goroutines*perG; got != want {
+		t.Errorf("concurrent emit lost mutations: got %d, want %d", got, want)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -103,6 +103,13 @@ func (srv *Server) SetOpHookExecutor(e evaluator.OpHookExecutor) {
 	srv.evaluator.SetOpHookExecutor(e)
 }
 
+// SetPersistenceFeed wires the persistence coordinator's mutation-feed
+// hook into the evaluator so command.Dispatch can emit mutations to
+// registered Sinks. Pass nil to disable the feed (the default).
+func (srv *Server) SetPersistenceFeed(f command.MutationEmitter) {
+	srv.evaluator.SetPersistenceFeed(f)
+}
+
 // EmitEvent emits an event through the server's emitter.
 func (srv *Server) EmitEvent(evt events.Event) {
 	srv.emitter.Emit(evt)

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -10,6 +10,7 @@ import (
 	"gocache/api/logger"
 	ops "gocache/api/operations"
 	"gocache/pkg/cache"
+	pkgcommand "gocache/pkg/command"
 	"gocache/pkg/engine"
 	"gocache/pkg/evaluator"
 	serverOps "gocache/pkg/operations"
@@ -183,6 +184,7 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 // CleanupWorker periodically removes expired keys from the cache.
 type CleanupWorker struct {
 	baseWorker
+	feed pkgcommand.MutationEmitter
 }
 
 func NewCleanupWorker(c *cache.Cache, e *engine.Engine, interval time.Duration) *CleanupWorker {
@@ -197,6 +199,16 @@ func NewCleanupWorker(c *cache.Cache, e *engine.Engine, interval time.Duration) 
 	}
 }
 
+// SetPersistenceFeed wires the persistence coordinator's mutation-feed
+// hook so TTL-driven deletes emit DEL mutations under the same lock that
+// performs the deletion. Replay parity with snapshot-time state requires
+// these emissions; without them, a recovered cache could diverge from a
+// snapshot+log replay because expired entries would not appear as deletes
+// in the mutation log.
+func (w *CleanupWorker) SetPersistenceFeed(f pkgcommand.MutationEmitter) {
+	w.feed = f
+}
+
 func (w *CleanupWorker) Start(parentCtx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	w.wg.Add(1)
@@ -208,9 +220,15 @@ func (w *CleanupWorker) Start(parentCtx context.Context) {
 				op, opCtx := w.startOp(parentCtx, ops.TypeCleanup)
 				if err := w.engine.Dispatch(opCtx, func() {
 					now := time.Now().UnixNano()
+					emit := w.feed != nil && w.feed.HasSinks()
 					w.cache.Range(func(key string, _ cache.Entry, expiration int64) bool {
 						if expiration > 0 && now > expiration {
 							w.cache.RawDelete(key)
+							if emit {
+								// Inside engine.Dispatch's bulk lock — LSN
+								// allocation order matches deletion order.
+								w.feed.AllocateAndEmit("DEL", key, [][]byte{[]byte(key)})
+							}
 						}
 						return true
 					})


### PR DESCRIPTION
Operationalises the runtime side of [ADR-0001](https://github.com/j-mizera/gocache/wiki/ADR-0001-persistence-as-pluggable-log-snapshot) / [ADR-0002](https://github.com/j-mizera/gocache/wiki/ADR-0002-source-sink-contract) / [ADR-0003](https://github.com/j-mizera/gocache/wiki/ADR-0003-mutation-feed-and-fsync). Pairs with #62 (boot side) — that PR established the contract surface; this one wires the engine's mutation emission and per-sink group-commit dispatch.

## Hot-path gate

\`command.Dispatch\` wraps the user fn only when (a) the command is a write (\`Spec.ReadOnly == false\`) AND (b) a coordinator is attached. Inside the wrapper, an atomic \`Coordinator.HasSinks()\` check short-circuits emission when no Sink is registered. The no-subscriber path matches main within ±3% on every benchmarked workload, identical allocs/op.

| Bench (N=8) | main avg | feat avg | Δ |
|---|---:|---:|---:|
| InProc_GET | 540 ns | 549 ns | +1.7% |
| InProc_SET | 616 ns | 600 ns | -2.6% |
| TCP_GET_Pipelined | 7106 ns | 6923 ns | -2.6% |
| TCP_Mixed_GetSet_Pipelined | 7214 ns | 7164 ns | -0.7% |

All deltas within run-to-run variance band; allocs/op identical to main on every line. With sinks registered the cost is one atomic load + one LSN allocate + one channel send under-lock, plus a closure allocation for the wrapped fn. Closure cost is the single under-lock additive; it amortises against the rest of the dispatch path.

## Mutation feed mechanics

- **Emission**: under the shard lock the wrapped fn runs the handler, allocates an LSN (atomic add), builds a \`Mutation\` (Op + Key + Args), and pushes it onto each Sink's incoming channel. LSN allocation order matches lock order — required for replay correctness.
- **Group commit**: one goroutine per Sink drains the incoming channel and batches with priority-ordered triggers: stop+drain → high-water (80% of buffer) → 64KB size → 1ms time. The high-water trigger fires an emergency flush AND logs a warn so users can tune buffer size before hitting the blocking edge.
- **Fatal error path**: a Sink that returns \`ErrSinkFatal\`-wrapped from \`Apply\` is quarantined: \`activeSinks\` decrements (HasSinks reports the new state), the run loop's \`quarantined\` flag drops further mutations, and producers that race the gate are absorbed by the consume() check.
- **TTL emission**: \`CleanupWorker\` emits per-key \`DEL\` mutations under the bulk lock it already holds for the cleanup sweep. Snapshot + log replay matches snapshot-time state.

## What's deferred

Captured as TODOs in the relevant function comments:

- **\`FsyncAlways\` strict semantics** — today best-effort (fsync after batch, not per-mutation). Strict means client doesn't see SUCCESS until fsync returns; needs a per-mutation completion channel. Revisit when AOF plugin (Phase 4) lands and the durability gap matters in real workloads.
- **Transactions** — emit per-command, not per-EXEC-batch. ACID-style atomic batching is the target. Currently undefined behaviour on mid-EXEC crash. Wire when AOF lands.
- **\`Coordinator.Sync\` method** — for centralised \`FsyncEverySec\` ticker across multiple sinks. Today each Sink self-manages its policy. Add when AOF needs the cross-sink coordination.
- **Verbatim Args** — \`Mutation.Args\` is currently reallocated as \`[]byte\` from the dispatcher's \`[]string\`. Zero-copy from the RESP parser through to \`Mutation.Args\` is a future optimization.

## What ships in this PR

| Layer | Change |
|---|---|
| api/persistence | (no change — contract unchanged from #62) |
| pkg/persistence/coordinator.go | \`Start\` / \`Stop\` lifecycle; \`AllocateAndEmit\`; \`recordSinkActive\` |
| pkg/persistence/feed.go (new) | \`sinkChannel\`, group-commit \`run\` loop, quarantine path |
| pkg/persistence/feed_test.go (new) | 11 tests (HasSinks, time/size/high-water triggers, ordering, Stop drain, multi-sink fan-out, fatal/transient error paths, 50-goroutine concurrent emission) |
| pkg/command/context.go | \`MutationEmitter\` interface; \`Coordinator\` + \`Spec\` fields; \`Dispatch\` wraps writes |
| pkg/evaluator/evaluator.go | \`SetPersistenceFeed\`; threads coordinator + spec onto cmd \`Context\` |
| pkg/server/server.go | \`SetPersistenceFeed\` exposed for main.go |
| pkg/workers/workers.go | \`CleanupWorker.SetPersistenceFeed\` + per-key DEL emission on TTL expiry |
| cmd/server/main.go | Coordinator created unconditionally; \`Start\` after Boot; \`Stop\` before final snapshot in shutdown |

## Verification

- [x] \`go test -race -count=1 ./...\` PASS (full suite)
- [x] \`go vet ./...\` PASS
- [x] \`staticcheck ./...\` clean
- [x] \`scripts/check-plugin-isolation.sh\` PASS — \`api/persistence/\` still imports nothing from \`pkg/\`
- [x] Bench: ±3% vs main, identical allocs/op (table above)

## Test plan

- [ ] CI green
- [ ] Integration paths still work (snapshot save + load + cleanup)
- [ ] No subscriber-attached deployment regression in production-shape build (verified by bench, no real consumer until AOF plugin lands)

## Pointers

- ADR-0003: [mutation feed + fsync](https://github.com/j-mizera/gocache/wiki/ADR-0003-mutation-feed-and-fsync) — the contract this implements
- Companion PR: #62 (contract surface + boot side)
- Next in arc: AOF plugin (first real Sink consumer)