### PR TITLE
feat(persistence): Snapshotter contract — Coordinator.Snapshot + GobSource dual role

### DIFF
--- a/api/persistence/errors.go
+++ b/api/persistence/errors.go
@@ -22,3 +22,10 @@ var ErrSinkFatal = errors.New("persistence: sink fatal — quarantine")
 // boot time so unknown values fail fast rather than getting silently
 // dropped.
 var ErrInvalidBootMode = errors.New("persistence: source returned invalid BootMode")
+
+// ErrNoSnapshotter is returned by Coordinator.Snapshot when no Snapshotter
+// has been registered. Distinct from "snapshot succeeded with zero entries"
+// — calling code (SAVE handler, scheduled worker, shutdown path) needs to
+// distinguish "configured but nothing to save" from "not configured at all"
+// because the second is a config bug, not a steady-state outcome.
+var ErrNoSnapshotter = errors.New("persistence: no snapshotter registered")

--- a/api/persistence/snapshotter.go
+++ b/api/persistence/snapshotter.go
@@ -1,0 +1,53 @@
+package persistence
+
+import "context"
+
+// Snapshotter persists a point-in-time dump of cache state on demand.
+// Distinct from Sink (which consumes the ongoing mutation feed) and from
+// Source (which supplies recovery state at boot): a snapshot is "stop
+// the world for a moment, hand me every live entry, write it somewhere
+// durable." That shape doesn't fit Sink (no LSN-ordered batching) and
+// doesn't fit Source (Source is read-side, snapshot is write-side).
+//
+// Per ADR-0002, separate shapes get separate interfaces — a plugin that
+// only consumes mutations (AOF, Kafka) doesn't have to stub-implement
+// snapshot save, and a plugin that only saves snapshots doesn't have to
+// stub-implement Apply.
+//
+// A single plugin implementation may register as both Source (to handle
+// boot-time recovery from its on-disk format) and Snapshotter (to write
+// new snapshots in that same format). The built-in gob shim does this
+// today; the upcoming v1 binary plugin (ADR-0005) will too.
+type Snapshotter interface {
+	// Name identifies the snapshotter for logging and command routing
+	// (which Snapshotter answers SAVE / BGSAVE). Returns a stable
+	// identifier — typically the plugin / built-in name.
+	Name() string
+
+	// SaveSnapshot persists every entry yielded by src. The coordinator
+	// builds src by iterating the live cache; the snapshotter sees only
+	// SnapshotEntry values via Next, never the cache itself. The snapshotter
+	// is responsible for atomicity: either the new snapshot fully replaces
+	// the old, or the old remains intact (typical implementation: write
+	// to a temp file, fsync, rename).
+	//
+	// Returns when src is exhausted (Next returns io.EOF) and durable
+	// storage has been updated. Errors are surfaced to the caller without
+	// retry — the caller (worker, SAVE handler, shutdown path) decides
+	// the next move.
+	SaveSnapshot(ctx context.Context, src SnapshotSource) error
+}
+
+// SnapshotSource yields snapshot entries on demand. Same lifecycle shape
+// as SnapshotIterator (forward-only, single-pass, terminates on io.EOF)
+// but consumed by Snapshotter.SaveSnapshot rather than by a boot-side
+// loader. The two interfaces are kept distinct so each side's contract
+// stays narrow — boot-side iteration is owned by the Source, save-side
+// iteration is owned by the coordinator.
+type SnapshotSource interface {
+	// Next returns the next entry, or io.EOF when exhausted.
+	// On error other than io.EOF, the source is in an undefined state
+	// and the snapshotter should abort the save (typically by deleting
+	// the temp file before returning).
+	Next(ctx context.Context) (SnapshotEntry, error)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -250,10 +250,16 @@ func main() {
 	// mutation feed can be wired even when LoadOnStartup is off; the
 	// coordinator runs in pass-through mode (no sinks registered) until
 	// a future PR adds the AOF / snapshot sink plugins. The current path
-	// uses GobSource for boot recovery; that goes away when the snapshot
-	// plugin (ADR-0005) replaces the gob format.
-	coordinator := persistence.New(persistence.NewGobSource(cfg.Persistence.SnapshotFile))
+	// uses GobSource for boot recovery AND for runtime snapshot writes —
+	// the gob shim implements both Source and Snapshotter so SAVE,
+	// scheduled snapshots, and shutdown final-snapshot all run through
+	// the coordinator. The shim goes away when the v1 snapshot plugin
+	// (ADR-0005) lands.
+	gobShim := persistence.NewGobSource(cfg.Persistence.SnapshotFile)
+	coordinator := persistence.New(gobShim)
+	coordinator.RegisterSnapshotter(gobShim)
 	srv.SetPersistenceFeed(coordinator)
+	srv.SetSnapshotInvoker(coordinator)
 
 	// LoadSnapshot operation.
 	_ = bootstate.Write(bootStateFile, stageSnapshotLoad)
@@ -304,6 +310,7 @@ func main() {
 	)
 	cleanupWorker := workers.NewCleanupWorker(cacheInstance, engineInstance, cfg.Workers.CleanupInterval)
 	cleanupWorker.SetPersistenceFeed(coordinator)
+	snapshotWorker.SetSnapshotInvoker(coordinator)
 	snapshotWorker.SetTracker(tracker)
 	snapshotWorker.SetEmitter(eventBus)
 	if opHookExec != nil {
@@ -345,6 +352,7 @@ func main() {
 
 		snapshotWorker.UpdateInterval(newCfg.Persistence.SnapshotInterval)
 		snapshotWorker.UpdateFile(newCfg.Persistence.SnapshotFile)
+		gobShim.SetFilename(newCfg.Persistence.SnapshotFile)
 		cleanupWorker.UpdateInterval(newCfg.Workers.CleanupInterval)
 		cacheInstance.SetMemoryLimit(
 			reloadCtx,
@@ -469,7 +477,7 @@ func handleShutdown(
 	coordinator.Stop(shutdownCtx)
 
 	logger.Info(shutdownCtx).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
-	if err := persistence.SaveSnapshot(shutdownCtx, cfg.Persistence.SnapshotFile, cacheInstance); err != nil {
+	if err := coordinator.Snapshot(shutdownCtx, cacheInstance); err != nil {
 		logger.Warn(shutdownCtx).Err(err).Msg("failed to save final snapshot")
 	} else {
 		logger.Info(shutdownCtx).Msg("final snapshot saved successfully")

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -30,6 +30,18 @@ type MutationEmitter interface {
 	AllocateAndEmit(op, key string, args [][]byte) apipersistence.LSN
 }
 
+// SnapshotInvoker is the SAVE/BGSAVE handler-side hook into the
+// persistence coordinator. Distinct from MutationEmitter so the snapshot
+// command path doesn't drag mutation-feed concerns and vice versa: both
+// are implemented by *pkg/persistence.Coordinator, but consumers see only
+// the surface they need.
+//
+// Nil means "no snapshotter wired" — handler returns an error to the
+// client rather than silently no-oping a SAVE command.
+type SnapshotInvoker interface {
+	Snapshot(ctx context.Context, target *cache.Cache) error
+}
+
 // Re-export shared types from api/command so existing importers don't break.
 type Result = apicommand.Result
 type Spec = apicommand.Spec
@@ -100,6 +112,12 @@ type Context struct {
 	// non-read-only fn closures with HasSinks-gated emission inside the
 	// shard lock so LSN allocation order matches lock order.
 	Coordinator MutationEmitter
+
+	// Snapshotter is the SAVE/BGSAVE entry point. Set by the evaluator
+	// from the same coordinator instance. May be nil when persistence
+	// has no snapshot writer registered — the SAVE handler treats nil
+	// as a configuration error and surfaces it to the client.
+	Snapshotter SnapshotInvoker
 }
 
 // Context returns the ambient context.Context carrying the current
@@ -149,6 +167,7 @@ func (c *Context) Reset() {
 	c.EvalFn = nil
 	c.Spec = Spec{}
 	c.Coordinator = nil
+	c.Snapshotter = nil
 }
 
 // Dispatch runs fn under the appropriate locking discipline for the

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -85,6 +85,7 @@ type BaseEvaluator struct {
 	tracker            *serverOps.Tracker
 	opHookExecutor     OpHookExecutor
 	persistenceFeed    command.MutationEmitter
+	snapshotInvoker    command.SnapshotInvoker
 }
 
 func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *BaseEvaluator {
@@ -139,6 +140,16 @@ func (b *BaseEvaluator) SetTracker(t *serverOps.Tracker) {
 // emission (the default — no coordinator means no mutation feed).
 func (b *BaseEvaluator) SetPersistenceFeed(f command.MutationEmitter) {
 	b.persistenceFeed = f
+}
+
+// SetSnapshotInvoker wires the persistence coordinator's SAVE/BGSAVE
+// entry point into the evaluator. fillCmdCtx threads it onto each
+// *command.Context so the snapshot handler doesn't have to import
+// pkg/persistence directly. Pass nil to disable snapshot commands —
+// the handler returns an error to the client when invoked without a
+// registered snapshotter.
+func (b *BaseEvaluator) SetSnapshotInvoker(s command.SnapshotInvoker) {
+	b.snapshotInvoker = s
 }
 
 func (b *BaseEvaluator) SetOpHookExecutor(e OpHookExecutor) {
@@ -380,6 +391,7 @@ func (b *BaseEvaluator) fillCmdCtx(c *command.Context, ctx *clientctx.ClientCont
 	c.EvalFn = b.evaluateInternal
 	c.Spec = spec
 	c.Coordinator = b.persistenceFeed
+	c.Snapshotter = b.snapshotInvoker
 }
 
 // routeToPlugin dispatches a command to a plugin via the router. The per-call

--- a/pkg/persistence/coordinator.go
+++ b/pkg/persistence/coordinator.go
@@ -29,6 +29,13 @@ type Coordinator struct {
 	source apipersistence.Source
 	sinks  []apipersistence.Sink
 
+	// snapshotter is the registered point-in-time snapshot writer.
+	// Optional — Coordinator.Snapshot returns ErrNoSnapshotter when nil.
+	// Guarded by snapshotterMu so RegisterSnapshotter can race with
+	// in-flight Snapshot calls during config reload without tearing.
+	snapshotterMu sync.RWMutex
+	snapshotter   apipersistence.Snapshotter
+
 	// lsn is the most recently allocated LSN. AllocateLSN increments it;
 	// boot reads it from the snapshot and seeds the runtime allocator.
 	lsn atomic.Uint64
@@ -141,6 +148,95 @@ func (c *Coordinator) Source() apipersistence.Source { return c.source }
 
 // Sinks returns the registered sinks (may be empty).
 func (c *Coordinator) Sinks() []apipersistence.Sink { return c.sinks }
+
+// RegisterSnapshotter installs the point-in-time snapshot writer. Safe to
+// call before or after Start. A nil argument clears the registration.
+// Replacing an existing snapshotter is allowed — useful when config
+// reload swaps the on-disk format (e.g. gob → v1 binary).
+func (c *Coordinator) RegisterSnapshotter(s apipersistence.Snapshotter) {
+	c.snapshotterMu.Lock()
+	c.snapshotter = s
+	c.snapshotterMu.Unlock()
+}
+
+// Snapshotter returns the registered snapshotter (may be nil).
+func (c *Coordinator) Snapshotter() apipersistence.Snapshotter {
+	c.snapshotterMu.RLock()
+	defer c.snapshotterMu.RUnlock()
+	return c.snapshotter
+}
+
+// Snapshot writes a point-in-time dump of target to the registered
+// snapshotter. Iterates the cache, materialises a SnapshotSource backed
+// by the captured slice, then delegates to snapshotter.SaveSnapshot.
+//
+// Returns ErrNoSnapshotter when none is registered — callers can choose
+// to treat that as fatal (SAVE command) or as a no-op (scheduled worker
+// when persistence is disabled).
+//
+// The cache snapshot is captured eagerly into a slice before the
+// snapshotter sees it. That keeps the snapshotter simple (it just walks
+// Next/io.EOF) at the cost of buffering all entries in memory once. The
+// upcoming v1 streaming format (ADR-0005) can reduce buffering by
+// writing each record as it's yielded; the gob shim already buffers
+// internally so this PR is no worse than the legacy SaveSnapshot.
+func (c *Coordinator) Snapshot(ctx context.Context, target *cache.Cache) error {
+	s := c.Snapshotter()
+	if s == nil {
+		return apipersistence.ErrNoSnapshotter
+	}
+	entries := captureSnapshotEntries(target)
+	src := &sliceSnapshotSource{entries: entries}
+	return s.SaveSnapshot(ctx, src)
+}
+
+// captureSnapshotEntries walks the cache and returns every live entry as
+// an api/persistence.SnapshotEntry. Packed values are copied out of the
+// slab allocator so the snapshotter sees a stable []byte independent of
+// slab lifecycle. ValueType and Encoding cast directly from the cache
+// enums to the api enums — the values are aligned by construction (see
+// type comments in api/persistence/types.go).
+func captureSnapshotEntries(target *cache.Cache) []apipersistence.SnapshotEntry {
+	var entries []apipersistence.SnapshotEntry
+	target.Range(func(key string, entry cache.Entry, expiration int64) bool {
+		var v any
+		if entry.Encoding == cache.EncPacked {
+			src := target.ResolvePacked(entry)
+			buf := make([]byte, len(src))
+			copy(buf, src)
+			v = buf
+		} else {
+			v = entry.Value
+		}
+		entries = append(entries, apipersistence.SnapshotEntry{
+			Key:        key,
+			ValueType:  apipersistence.ValueType(entry.ValueType),
+			Encoding:   apipersistence.Encoding(entry.Encoding),
+			Value:      v,
+			Expiration: expiration,
+		})
+		return true
+	})
+	return entries
+}
+
+// sliceSnapshotSource is a SnapshotSource backed by a pre-captured slice.
+// Forward-only single-pass — Next walks the slice and returns io.EOF once
+// exhausted. Internal to the coordinator; snapshotters never type-assert
+// against it.
+type sliceSnapshotSource struct {
+	entries []apipersistence.SnapshotEntry
+	cursor  int
+}
+
+func (s *sliceSnapshotSource) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	if s.cursor >= len(s.entries) {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	e := s.entries[s.cursor]
+	s.cursor++
+	return e, nil
+}
 
 // BootInto drives the recovery path: fetches the BootResult from the
 // Source, applies it to the target cache, and seeds the LSN cursor. The

--- a/pkg/persistence/gobshim.go
+++ b/pkg/persistence/gobshim.go
@@ -7,16 +7,20 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sync"
 
+	"gocache/api/logger"
 	apipersistence "gocache/api/persistence"
 	"gocache/pkg/cache"
 )
 
 // GobSource adapts the existing gob-encoded snapshot format to the
-// api/persistence.Source contract. It exists so the contract surface ships
-// in feat/persistence-contract without forcing the new on-disk format
-// (ADR-0005) to land at the same time. The new built-in snapshot plugin
-// will replace this shim with the custom binary format.
+// api/persistence.Source and api/persistence.Snapshotter contracts. It
+// exists so the contract surface ships in feat/persistence-contract
+// without forcing the new on-disk format (ADR-0005) to land at the same
+// time. The new built-in snapshot plugin will replace this shim with the
+// custom binary format.
 //
 // GobSource carries no LSN — gob snapshots predate the LSN concept. Boot
 // returns LSN=ZeroLSN, which means the runtime allocator starts from 1.
@@ -25,30 +29,53 @@ import (
 //
 // Missing snapshot file → BootModeInitial. This matches the legacy
 // LoadSnapshot semantics ("not found is not an error").
+//
+// Filename is hot-reloadable via SetFilename: config reload can swap
+// the snapshot path without recreating the shim or restarting the
+// coordinator.
 type GobSource struct {
+	mu       sync.RWMutex
 	filename string
 }
 
-// NewGobSource returns a Source that reads from filename. The path is
-// resolved at Boot time, not now — config hot-reload may change it
-// between construction and boot.
+// NewGobSource returns a shim that reads from and writes to filename.
+// The path is resolved at Boot / SaveSnapshot time, not now — config
+// hot-reload may change it between construction and use via SetFilename.
 func NewGobSource(filename string) *GobSource {
 	return &GobSource{filename: filename}
 }
 
-// Name implements api/persistence.Source.
+// SetFilename updates the on-disk path. Concurrent with in-flight Boot or
+// SaveSnapshot calls — the path-read in those methods grabs an RLock so
+// the change is observed atomically.
+func (s *GobSource) SetFilename(f string) {
+	s.mu.Lock()
+	s.filename = f
+	s.mu.Unlock()
+}
+
+// currentFilename returns the active path. Held under RLock so config
+// reload sees a consistent snapshot of the field.
+func (s *GobSource) currentFilename() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.filename
+}
+
+// Name implements api/persistence.Source and api/persistence.Snapshotter.
 func (s *GobSource) Name() string { return "gob-snapshot" }
 
 // Boot implements api/persistence.Source. Opens the snapshot file, reads
 // the count header, and returns a SnapshotIterator that decodes one entry
 // at a time. The iterator owns the file handle and closes it on Close.
 func (s *GobSource) Boot(ctx context.Context) (apipersistence.BootResult, error) {
-	file, err := os.Open(s.filename)
+	filename := s.currentFilename()
+	file, err := os.Open(filename)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
 		}
-		return apipersistence.BootResult{}, fmt.Errorf("open %s: %w", s.filename, err)
+		return apipersistence.BootResult{}, fmt.Errorf("open %s: %w", filename, err)
 	}
 
 	dec := gob.NewDecoder(file)
@@ -61,7 +88,7 @@ func (s *GobSource) Boot(ctx context.Context) (apipersistence.BootResult, error)
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
 		}
-		return apipersistence.BootResult{}, fmt.Errorf("decode header %s: %w", s.filename, err)
+		return apipersistence.BootResult{}, fmt.Errorf("decode header %s: %w", filename, err)
 	}
 
 	return apipersistence.BootResult{
@@ -73,6 +100,87 @@ func (s *GobSource) Boot(ctx context.Context) (apipersistence.BootResult, error)
 			remaining: count,
 		},
 	}, nil
+}
+
+// SaveSnapshot implements api/persistence.Snapshotter. It drains src into
+// memory (the gob format requires a count header up-front so streaming
+// would need a separate pass anyway), writes to a sibling temp file,
+// fsyncs, and renames over the destination atomically. Crash mid-write
+// leaves the previous snapshot intact instead of corrupting it.
+//
+// Mirrors the legacy persistence.SaveSnapshot logic — the only behavioural
+// difference is the input shape (SnapshotSource pulls vs cache.Cache.Range
+// callback). Conversion from api/persistence.SnapshotEntry to the
+// gob-internal SnapshotEntry is per-field, matching the Boot-side
+// conversion in reverse.
+func (s *GobSource) SaveSnapshot(ctx context.Context, src apipersistence.SnapshotSource) error {
+	filename := s.currentFilename()
+	if filename == "" {
+		return fmt.Errorf("gob-snapshot: empty filename")
+	}
+
+	// Drain the source first. The gob count header forces this — we can't
+	// stream until we know the total. The new v1 format (ADR-0005) uses
+	// per-record framing so it can stream end-to-end.
+	var entries []SnapshotEntry
+	for {
+		e, err := src.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read snapshot entry: %w", err)
+		}
+		entries = append(entries, SnapshotEntry{
+			Key:        e.Key,
+			ValueType:  cache.ValueType(e.ValueType),
+			Encoding:   cache.Encoding(e.Encoding),
+			Value:      e.Value,
+			Expiration: e.Expiration,
+		})
+	}
+
+	dir := filepath.Dir(filename)
+	tmp, err := os.CreateTemp(dir, ".snapshot-*.tmp")
+	if err != nil {
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("failed to create snapshot temp file")
+		return fmt.Errorf("create snapshot temp %s: %w", filename, err)
+	}
+	tmpName := tmp.Name()
+	// Clean up the temp file on any failure path; a successful rename
+	// makes the cleanup a no-op because the name no longer exists.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	encoder := gob.NewEncoder(tmp)
+	if err := encoder.Encode(len(entries)); err != nil {
+		_ = tmp.Close()
+		logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot encode error")
+		return fmt.Errorf("encode snapshot %s: %w", filename, err)
+	}
+	for _, e := range entries {
+		if err := encoder.Encode(e); err != nil {
+			_ = tmp.Close()
+			logger.Error(ctx).Err(err).Str("file", filename).Msg("snapshot encode error")
+			return fmt.Errorf("encode snapshot %s: %w", filename, err)
+		}
+	}
+
+	// Flush to stable storage before rename. Without Sync, a crash between
+	// rename and kernel writeback could still leave a zero-length file at
+	// the destination path.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync snapshot %s: %w", filename, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close snapshot %s: %w", filename, err)
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		return fmt.Errorf("rename snapshot %s: %w", filename, err)
+	}
+
+	logger.Info(ctx).Str("file", filename).Int("entries", len(entries)).Msg("snapshot saved")
+	return nil
 }
 
 // gobIterator drains a gob-encoded SnapshotEntry stream. It expects exactly
@@ -122,8 +230,10 @@ func (it *gobIterator) Close() error {
 	return it.file.Close()
 }
 
-// Compile-time assertion: GobSource implements Source.
+// Compile-time assertions: GobSource implements both Source (boot side)
+// and Snapshotter (runtime save side).
 var _ apipersistence.Source = (*GobSource)(nil)
+var _ apipersistence.Snapshotter = (*GobSource)(nil)
 
 // Compile-time assertion: gobIterator implements SnapshotIterator.
 var _ apipersistence.SnapshotIterator = (*gobIterator)(nil)

--- a/pkg/persistence/snapshotter_test.go
+++ b/pkg/persistence/snapshotter_test.go
@@ -1,0 +1,244 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+)
+
+// recordingSnapshotter drains the SnapshotSource into memory so tests can
+// assert which entries the coordinator passed in. Threadsafe so concurrent
+// SaveSnapshot calls (none today, but cheap insurance) don't race.
+type recordingSnapshotter struct {
+	name string
+
+	mu      sync.Mutex
+	calls   int
+	entries []apipersistence.SnapshotEntry
+	saveErr error
+}
+
+func (r *recordingSnapshotter) Name() string { return r.name }
+
+func (r *recordingSnapshotter) SaveSnapshot(ctx context.Context, src apipersistence.SnapshotSource) error {
+	r.mu.Lock()
+	r.calls++
+	if r.saveErr != nil {
+		err := r.saveErr
+		r.mu.Unlock()
+		return err
+	}
+	r.mu.Unlock()
+	for {
+		e, err := src.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		r.mu.Lock()
+		r.entries = append(r.entries, e)
+		r.mu.Unlock()
+	}
+}
+
+func (r *recordingSnapshotter) snapshotEntries() []apipersistence.SnapshotEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]apipersistence.SnapshotEntry, len(r.entries))
+	copy(out, r.entries)
+	return out
+}
+
+func TestCoordinator_Snapshot_NoSnapshotter(t *testing.T) {
+	c := New(nil)
+	target := cache.New()
+
+	err := c.Snapshot(context.Background(), target)
+	if !errors.Is(err, apipersistence.ErrNoSnapshotter) {
+		t.Errorf("expected ErrNoSnapshotter, got %v", err)
+	}
+}
+
+func TestCoordinator_RegisterSnapshotter_GetAndClear(t *testing.T) {
+	c := New(nil)
+	rec := &recordingSnapshotter{name: "rec"}
+
+	if got := c.Snapshotter(); got != nil {
+		t.Errorf("Snapshotter() before register: got %v, want nil", got)
+	}
+	c.RegisterSnapshotter(rec)
+	if got := c.Snapshotter(); got != rec {
+		t.Errorf("Snapshotter() after register: got %v, want %v", got, rec)
+	}
+	c.RegisterSnapshotter(nil)
+	if got := c.Snapshotter(); got != nil {
+		t.Errorf("Snapshotter() after clear: got %v, want nil", got)
+	}
+}
+
+func TestCoordinator_Snapshot_FeedsAllEntries(t *testing.T) {
+	target := cache.New()
+	target.Lock()
+	_ = target.RawSet(context.Background(), "k1", "v1", 0)
+	_ = target.RawSet(context.Background(), "k2", "v2", 0)
+	_ = target.RawSet(context.Background(), "k3", "v3", 0)
+	target.Unlock()
+
+	rec := &recordingSnapshotter{name: "rec"}
+	c := New(nil)
+	c.RegisterSnapshotter(rec)
+
+	if err := c.Snapshot(context.Background(), target); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	entries := rec.snapshotEntries()
+	if len(entries) != 3 {
+		t.Fatalf("entries: got %d, want 3", len(entries))
+	}
+	keys := map[string]bool{}
+	for _, e := range entries {
+		keys[e.Key] = true
+	}
+	for _, k := range []string{"k1", "k2", "k3"} {
+		if !keys[k] {
+			t.Errorf("missing key %s in snapshot", k)
+		}
+	}
+	if rec.calls != 1 {
+		t.Errorf("calls = %d, want 1", rec.calls)
+	}
+}
+
+func TestCoordinator_Snapshot_PropagatesError(t *testing.T) {
+	target := cache.New()
+	target.Lock()
+	_ = target.RawSet(context.Background(), "k", "v", 0)
+	target.Unlock()
+
+	wantErr := errors.New("disk full")
+	rec := &recordingSnapshotter{name: "rec", saveErr: wantErr}
+	c := New(nil)
+	c.RegisterSnapshotter(rec)
+
+	err := c.Snapshot(context.Background(), target)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected %v, got %v", wantErr, err)
+	}
+}
+
+func TestCoordinator_Snapshot_GobRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "str", "hello", 0)
+	_ = source.RawSet(context.Background(), "list", []string{"a", "b"}, 0)
+	source.Unlock()
+
+	gob := NewGobSource(file)
+	c := New(gob)
+	c.RegisterSnapshotter(gob)
+
+	if err := c.Snapshot(context.Background(), source); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if _, err := os.Stat(file); err != nil {
+		t.Fatalf("snapshot file not created: %v", err)
+	}
+
+	// Round-trip: load the same snapshot back into a fresh cache.
+	target := cache.New()
+	if _, err := c.BootInto(context.Background(), target); err != nil {
+		t.Fatalf("BootInto: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Errorf("target.Len = %d, want 2", got)
+	}
+}
+
+func TestGobSource_SetFilename_HotReload(t *testing.T) {
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "a.dat")
+	file2 := filepath.Join(dir, "b.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "k", "v", 0)
+	source.Unlock()
+
+	gob := NewGobSource(file1)
+	c := New(gob)
+	c.RegisterSnapshotter(gob)
+
+	if err := c.Snapshot(context.Background(), source); err != nil {
+		t.Fatalf("Snapshot to file1: %v", err)
+	}
+	if _, err := os.Stat(file1); err != nil {
+		t.Fatalf("file1 not created: %v", err)
+	}
+
+	gob.SetFilename(file2)
+	if err := c.Snapshot(context.Background(), source); err != nil {
+		t.Fatalf("Snapshot to file2: %v", err)
+	}
+	if _, err := os.Stat(file2); err != nil {
+		t.Fatalf("file2 not created: %v", err)
+	}
+
+	// file1 still exists from the first save — SetFilename doesn't unlink.
+	if _, err := os.Stat(file1); err != nil {
+		t.Errorf("file1 disappeared after SetFilename: %v", err)
+	}
+}
+
+func TestSliceSnapshotSource_EOF(t *testing.T) {
+	entries := []apipersistence.SnapshotEntry{
+		{Key: "a"}, {Key: "b"}, {Key: "c"},
+	}
+	src := &sliceSnapshotSource{entries: entries}
+
+	for i := range entries {
+		got, err := src.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next #%d: %v", i, err)
+		}
+		if got.Key != entries[i].Key {
+			t.Errorf("Next #%d: got %s, want %s", i, got.Key, entries[i].Key)
+		}
+	}
+	_, err := src.Next(context.Background())
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Next after exhausted: got %v, want io.EOF", err)
+	}
+	// Second call after EOF still EOF — single-pass forward-only.
+	_, err = src.Next(context.Background())
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("Next twice after EOF: got %v, want io.EOF", err)
+	}
+}
+
+func TestGobSource_SaveSnapshot_EmptyFilename(t *testing.T) {
+	gob := NewGobSource("")
+	rec := &recordingSnapshotter{}
+	_ = rec // unused, just to exercise the path through SaveSnapshot
+	src := &sliceSnapshotSource{entries: []apipersistence.SnapshotEntry{{Key: "k"}}}
+	err := gob.SaveSnapshot(context.Background(), src)
+	if err == nil {
+		t.Error("SaveSnapshot with empty filename: expected error, got nil")
+	}
+}
+
+// Compile-time check: the recording test snapshotter satisfies the
+// api/persistence contract. Catches contract drift at build time.
+var _ apipersistence.Snapshotter = (*recordingSnapshotter)(nil)

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -12,7 +12,10 @@ import (
 
 func HandleSnapshot(cmdCtx *command.Context) command.Result {
 	executeFn := func() any {
-		if err := persistence.SaveSnapshot(cmdCtx.Context(), cmdCtx.SnapshotFile, cmdCtx.Cache); err != nil {
+		if cmdCtx.Snapshotter == nil {
+			return fmt.Errorf("snapshot: no snapshotter registered")
+		}
+		if err := cmdCtx.Snapshotter.Snapshot(cmdCtx.Context(), cmdCtx.Cache); err != nil {
 			return err
 		}
 		return "OK"

--- a/pkg/resp/handler/persistence_test.go
+++ b/pkg/resp/handler/persistence_test.go
@@ -9,6 +9,7 @@ import (
 	"gocache/pkg/clientctx"
 	"gocache/pkg/command"
 	"gocache/pkg/engine"
+	"gocache/pkg/persistence"
 	"gocache/pkg/resp/handler"
 )
 
@@ -30,13 +31,20 @@ func TestHandler_Snapshot(t *testing.T) {
 		t.Fatalf("SET: %v", res.Value)
 	}
 
-	// SNAPSHOT -- needs SnapshotFile on context
+	// SNAPSHOT — needs Snapshotter wired through the coordinator. The
+	// gob shim implements both Source (boot side) and Snapshotter
+	// (runtime save side).
+	gob := persistence.NewGobSource(snapshotFile)
+	coord := persistence.New(gob)
+	coord.RegisterSnapshotter(gob)
+
 	cmdCtx := &command.Context{
 		Client:       ctx1,
 		Op:           "SNAPSHOT",
 		Engine:       e1,
 		Cache:        c1,
 		SnapshotFile: snapshotFile,
+		Snapshotter:  coord,
 	}
 	res = handler.HandleSnapshot(cmdCtx)
 	if res.Value != "OK" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -110,6 +110,12 @@ func (srv *Server) SetPersistenceFeed(f command.MutationEmitter) {
 	srv.evaluator.SetPersistenceFeed(f)
 }
 
+// SetSnapshotInvoker wires the persistence coordinator's SAVE/BGSAVE
+// entry point into the evaluator. Pass nil to disable snapshot commands.
+func (srv *Server) SetSnapshotInvoker(s command.SnapshotInvoker) {
+	srv.evaluator.SetSnapshotInvoker(s)
+}
+
 // EmitEvent emits an event through the server's emitter.
 func (srv *Server) EmitEvent(evt events.Event) {
 	srv.emitter.Emit(evt)

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -14,7 +14,6 @@ import (
 	"gocache/pkg/engine"
 	"gocache/pkg/evaluator"
 	serverOps "gocache/pkg/operations"
-	"gocache/pkg/persistence"
 )
 
 const defaultInterval = 5 * time.Minute
@@ -121,8 +120,13 @@ func safeInterval(d time.Duration) time.Duration {
 // SnapshotWorker periodically saves a snapshot of the cache to disk.
 type SnapshotWorker struct {
 	baseWorker
-	file     string
-	fileChan chan string
+	// file is retained for op-enrichment and log correlation only — the
+	// snapshotter owns the durable path. Hot-reload updates both via
+	// UpdateFile (worker copy) + the wired SnapshotInvoker (the actual
+	// path the on-disk write hits).
+	file        string
+	fileChan    chan string
+	snapshotter pkgcommand.SnapshotInvoker
 }
 
 func NewSnapshotWorker(c *cache.Cache, e *engine.Engine, interval time.Duration, file string) *SnapshotWorker {
@@ -139,7 +143,18 @@ func NewSnapshotWorker(c *cache.Cache, e *engine.Engine, interval time.Duration,
 	}
 }
 
-// UpdateFile updates the snapshot file path at runtime.
+// SetSnapshotInvoker wires the persistence coordinator's SAVE entry point
+// into the worker. Each tick calls Snapshot through this invoker. Pass
+// nil to disable scheduled saves (operation is failed with a clear
+// reason — never a silent no-op).
+func (w *SnapshotWorker) SetSnapshotInvoker(s pkgcommand.SnapshotInvoker) {
+	w.snapshotter = s
+}
+
+// UpdateFile updates the snapshot file path at runtime. The worker copy
+// is used only for log/op enrichment — the actual durable path lives on
+// the registered Snapshotter and must be updated independently (config
+// reload calls both in main.go).
 func (w *SnapshotWorker) UpdateFile(file string) {
 	w.fileChan <- file
 }
@@ -157,8 +172,13 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 				if op != nil {
 					op.Enrich(command.FileKey, file)
 				}
+				if w.snapshotter == nil {
+					logger.Warn(opCtx).Msg("snapshot scheduled but no snapshotter registered")
+					w.failOp(op, "no snapshotter registered")
+					continue
+				}
 				if err := w.engine.Dispatch(opCtx, func() {
-					if err := persistence.SaveSnapshot(opCtx, file, w.cache); err != nil {
+					if err := w.snapshotter.Snapshot(opCtx, w.cache); err != nil {
 						logger.Warn(opCtx).Err(err).Msg("snapshot save failed")
 						w.failOp(op, err.Error())
 					} else {

--- a/pkg/workers/workers_test.go
+++ b/pkg/workers/workers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"gocache/pkg/cache"
 	"gocache/pkg/engine"
+	"gocache/pkg/persistence"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +31,12 @@ func TestSnapshotWorker_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "test_snapshot.dat")
 
+	gob := persistence.NewGobSource(file)
+	coord := persistence.New(gob)
+	coord.RegisterSnapshotter(gob)
+
 	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file)
+	w.SetSnapshotInvoker(coord)
 	w.Start(context.Background())
 	defer w.Stop()
 
@@ -110,11 +116,19 @@ func TestSnapshotWorker_UpdateFile(t *testing.T) {
 	file1 := filepath.Join(dir, "snap1.dat")
 	file2 := filepath.Join(dir, "snap2.dat")
 
+	gob := persistence.NewGobSource(file1)
+	coord := persistence.New(gob)
+	coord.RegisterSnapshotter(gob)
+
 	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file1)
+	w.SetSnapshotInvoker(coord)
 	w.Start(context.Background())
 
-	// Switch to file2.
+	// Switch to file2 — both the worker (for op-enrichment) and the gob
+	// shim (for the actual on-disk path) need to be told. main.go does
+	// the same dual update on config reload.
 	w.UpdateFile(file2)
+	gob.SetFilename(file2)
 	time.Sleep(200 * time.Millisecond)
 
 	// Stop before TempDir cleanup to avoid race on directory removal.


### PR DESCRIPTION
## Summary

PR-A of the Phase 3 split (`feat/snapshot-plugin`). Adds the third interface in the persistence triad — **Snapshotter** — alongside the existing Source (boot) and Sink (mutation feed) shapes. Per ADR-0002 and the Law-of-Demeter feedback from the prior session: snapshot save is a different shape than mutation feed (no LSN, no batching, "dump cache on demand"), so it gets its own narrow interface.

This PR is contract + wiring only. No format change. The gob shim continues to be the durable backend; the new v1 binary format (ADR-0005) lands in PR-B.

## Why split into PR-A / PR-B / PR-C

- **PR-A (this)** — narrow refactor: introduce the Snapshotter interface, route every snapshot save through `Coordinator.Snapshot`. Behaviour identical to before.
- **PR-B (next)** — implement ADR-0005's v1 binary format (varint + magic + CRC32 + optional zstd) as a second Snapshotter alongside the gob shim. Bench-gated.
- **PR-C** — `gocache-migrate` CLI for one-shot gob→v1 conversion + flip default to v1.

Splitting lets each PR carry one decision and one risk.

## What changed

### Contract (`api/persistence`)
- `Snapshotter` interface: `Name() string`, `SaveSnapshot(ctx, src SnapshotSource) error`.
- `SnapshotSource` iterator: `Next(ctx) (SnapshotEntry, error)` — `io.EOF` terminates, single-pass.
- `ErrNoSnapshotter` sentinel.

### Coordinator (`pkg/persistence`)
- `RegisterSnapshotter(s)` / `Snapshotter()` accessors (RWMutex-guarded so config reload races are safe).
- `Snapshot(ctx, *cache.Cache) error` — iterates `cache.Range`, materialises a `sliceSnapshotSource`, delegates to the registered snapshotter. Returns `ErrNoSnapshotter` when none is wired (callers decide fatal vs no-op).
- `GobSource` now implements **both** `Source` and `Snapshotter`. `SaveSnapshot` mirrors legacy `persistence.SaveSnapshot` (atomic temp+rename, fsync). New `SetFilename` for config hot-reload.

### Dispatcher plumbing (`pkg/command`, `pkg/evaluator`, `pkg/server`)
- New narrow `SnapshotInvoker` interface (distinct from `MutationEmitter` — different consumers, different surfaces).
- `cmdCtx.Snapshotter` field, threaded via `BaseEvaluator.SetSnapshotInvoker` and `Server.SetSnapshotInvoker`.

### Callers switched
- `HandleSnapshot` (SAVE command) → `cmdCtx.Snapshotter.Snapshot(...)`.
- `SnapshotWorker` (scheduled saves) → `w.snapshotter.Snapshot(...)`. Worker keeps `file` for op-enrichment; the durable path lives on the snapshotter.
- `cmd/server/main.go` shutdown step 4/6 → `coordinator.Snapshot(ctx, cache)`.
- `cmd/server/main.go` config reload → calls `gobShim.SetFilename` alongside `snapshotWorker.UpdateFile`.

### Intentionally **not** touched
- `HandleLoadSnapshot` (`LOAD_SNAPSHOT` command) still uses `persistence.LoadSnapshot`. Runtime reload from a user-supplied filename is a different shape than SAVE — cutover lands with PR-B/C alongside the format change.
- Legacy `persistence.SaveSnapshot` / `persistence.LoadSnapshot` package-level functions remain as test helpers and for the LOAD_SNAPSHOT path; PR-C will rationalise.

## Test plan

- [x] `go test -race ./...` — PASS
- [x] `go vet ./...` — PASS
- [x] `staticcheck ./...` — PASS
- [x] 8 new tests in `pkg/persistence/snapshotter_test.go` — `ErrNoSnapshotter`, register/get/clear, end-to-end fan-out, error propagation, gob round-trip through `Coordinator.Snapshot`, `SetFilename` hot-reload writes to new path, `sliceSnapshotSource` `io.EOF` semantics, empty-filename guard.
- [x] Existing `TestSnapshotWorker_CreatesFile` / `TestSnapshotWorker_UpdateFile` updated to wire the snapshotter — both pass.
- [x] Existing `TestHandler_Snapshot` updated — passes.
- [ ] CI green on this PR before merge.

## Follow-ups (PR-B / PR-C)

- Implement v1 binary format (ADR-0005): varint + `GCDB\x01` magic + 1-byte version + per-record framing + CRC32 footer + optional zstd. Streaming write path (no count header → no internal buffering).
- `gocache-migrate` CLI for one-shot gob→v1 conversion.
- Switch default snapshot format to v1, keep gob shim available for legacy reads behind a flag during the transition window.
- Reroute `HandleLoadSnapshot` through the coordinator (will need a runtime reload entry point — distinct from `BootInto` since it's mid-lifecycle).
- Flip ADR-0002 / ADR-0005 from `proposed` → `accepted` when PR-B merges.