### PR TITLE
docs(adr): flip 0001/0002/0003 to accepted

### DIFF
--- a/docs/adr/0001-persistence-as-pluggable-log-snapshot.md
+++ b/docs/adr/0001-persistence-as-pluggable-log-snapshot.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0001 Persistence as pluggable log+snapshot+LSN
 description: Persistence moves from in-tree gob snapshot worker to a pluggable log+snapshot model with monotonic LSNs, allowing built-in and third-party providers
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/0002-source-sink-contract.md
+++ b/docs/adr/0002-source-sink-contract.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0002 Source/Sink contract with BootMode trichotomy
 description: Persistence contract splits into Source (recovery-side, supplies state on boot) and Sink (mutation-side, consumes ongoing writes), with a BootMode trichotomy of Snapshot/Replay/Initial
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/0003-mutation-feed-and-fsync.md
+++ b/docs/adr/0003-mutation-feed-and-fsync.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0003 Mutation feed — group commit and fsync policy
 description: Mutations flow to Sinks via a buffered group-commit channel (1ms or 64KB triggers); fsync is a per-Sink policy with three levels (Always, EverySec, No)
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,9 +30,9 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [0001](0001-persistence-as-pluggable-log-snapshot.md) | Persistence as pluggable log+snapshot+LSN | proposed | 2026-05-03 |
-| [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | proposed | 2026-05-03 |
-| [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | proposed | 2026-05-03 |
+| [0001](0001-persistence-as-pluggable-log-snapshot.md) | Persistence as pluggable log+snapshot+LSN | accepted | 2026-05-03 |
+| [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | accepted | 2026-05-03 |
+| [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | accepted | 2026-05-03 |
 | [0004](0004-command-namespacing.md) | Persistence command namespacing | proposed | 2026-05-03 |
 | [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | proposed | 2026-05-03 |
 | [0006](0006-builtin-vs-third-party-transport.md) | Built-in vs third-party plugin transport | proposed | 2026-05-03 |


### PR DESCRIPTION
## Summary

The matching code has shipped — flip the three ADRs from `proposed` to `accepted` in both per-file frontmatter and the index table.

| ADR | Was | Now | Implementation in main |
|-----|-----|-----|-----------------------|
| 0001 | proposed | accepted | Coordinator + LSN + Source/Sink/Snapshotter + mutation feed (#62, #63, #64) |
| 0002 | proposed | accepted | Source, Sink, Snapshotter as separate `api/persistence` interfaces (#62, #64) |
| 0003 | proposed | accepted | Per-sink group commit (1ms / 64KB / 80% high-water) + FsyncPolicy enum (#63) |

ADR-0004 (command renames), ADR-0005 (v1 binary format), ADR-0006 (transport split) stay `proposed` — not yet implemented.

## Note on ADR-0002 + Snapshotter

ADR-0002 originally split persistence into Source/Sink. The Snapshotter interface added in #64 is a third shape per the same Law-of-Demeter principle ("separate shapes get separate interfaces") — it extends rather than contradicts the ADR-0002 decision, so the ADR stands as written.

## Test plan

- [x] No code changes — frontmatter and index only
- [ ] CI green