### PR TITLE
feat(persistence): cutover to v1 default + dual-format LoadSnapshot

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -23,12 +23,17 @@ const (
 	DefaultSnapshotFile     = "snapshot.dat"
 	DefaultSnapshotInterval = 5 * time.Minute
 	DefaultLoadOnStartup    = true
-	// DefaultSnapshotFormat is the on-disk snapshot format. "gob" is the
-	// legacy Go gob-encoded format; "v1" is the custom binary format
-	// described in ADR-0005 (varint, magic header, CRC32, optional zstd).
-	// Default stays "gob" until the migration window for existing
-	// deployments closes — flip to "v1" in a follow-up release.
-	DefaultSnapshotFormat = "gob"
+	// DefaultSnapshotFormat is the on-disk snapshot format. "v1" is the
+	// custom binary format described in ADR-0005 (varint, magic header,
+	// CRC32, optional zstd). "gob" is the legacy Go gob-encoded format,
+	// kept readable for rollback paths but no longer the default.
+	//
+	// Existing deployments with on-disk gob snapshots: run
+	// `gocache-migrate -in old.dat -out new.dat` once before upgrading,
+	// or set persistence.snapshot_format: gob in config to stay on the
+	// legacy format. The runtime LOAD_SNAPSHOT command auto-detects
+	// either format regardless of the configured default.
+	DefaultSnapshotFormat = "v1"
 
 	// SnapshotFormatGob and SnapshotFormatV1 are the recognised values
 	// for PersistenceConfig.SnapshotFormat. Unknown values fall back

--- a/docs/adr/0005-snapshot-wire-and-file-format.md
+++ b/docs/adr/0005-snapshot-wire-and-file-format.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0005 Snapshot wire and file format
 description: Snapshots use a custom binary format (varint, magic header, CRC32, optional zstd) replacing Go's gob encoder
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,7 +34,7 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | accepted | 2026-05-03 |
 | [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | accepted | 2026-05-03 |
 | [0004](0004-command-namespacing.md) | Persistence command namespacing | proposed | 2026-05-03 |
-| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | proposed | 2026-05-03 |
+| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | accepted | 2026-05-03 |
 | [0006](0006-builtin-vs-third-party-transport.md) | Built-in vs third-party plugin transport | proposed | 2026-05-03 |
 
 ## Writing a new ADR

--- a/pkg/persistence/loader.go
+++ b/pkg/persistence/loader.go
@@ -1,0 +1,107 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+	"gocache/pkg/persistence/v1snap"
+)
+
+// SnapshotFormat identifies the on-disk format of a snapshot file.
+// Used by DetectFormat and the runtime LoadFrom helper to dispatch to
+// the right Source. The string values match the config option
+// (api/config.SnapshotFormatGob / SnapshotFormatV1).
+type SnapshotFormat string
+
+const (
+	FormatGob SnapshotFormat = "gob"
+	FormatV1  SnapshotFormat = "v1"
+)
+
+// DetectFormat sniffs the first bytes of filename and returns which
+// format it is. The v1 format starts with a 4-byte ASCII magic "GCDB"
+// (see pkg/persistence/v1snap.format.go); anything else is treated as
+// gob, matching the legacy "open and try to gob-decode" semantics.
+//
+// A missing file returns os.ErrNotExist — callers decide whether that
+// is an error or a "nothing to load" signal (HandleLoadSnapshot
+// treats it as an error; boot recovery treats it as Initial mode).
+func DetectFormat(filename string) (SnapshotFormat, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var buf [4]byte
+	n, err := io.ReadFull(f, buf[:])
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("v1snap detect: read %s: %w", filename, err)
+	}
+	// A short file (< 4 bytes) can't be v1 — its header is 5 bytes.
+	// Fall through to gob; gob's decoder will surface a clear error
+	// on a malformed stream.
+	if n == 4 && buf[0] == 'G' && buf[1] == 'C' && buf[2] == 'D' && buf[3] == 'B' {
+		return FormatV1, nil
+	}
+	return FormatGob, nil
+}
+
+// LoadFrom reads filename via the format-appropriate Source and applies
+// the snapshot to target. Used by the LOAD_SNAPSHOT runtime command —
+// distinct from Coordinator.BootInto, which loads the registered
+// startup Source. LoadFrom is mid-lifecycle, so it CLEARS target before
+// loading (matching legacy LoadSnapshot semantics).
+//
+// Format auto-detection means deployments that have flipped to v1 can
+// still load gob files explicitly via LOAD_SNAPSHOT (e.g. during a
+// rollback or to inspect an archived snapshot).
+//
+// Errors from the Source bubble up untouched. Truncated / corrupted
+// files surface either at Boot (header validation) or on iterator
+// drain (CRC mismatch, malformed records).
+func LoadFrom(ctx context.Context, filename string, target *cache.Cache) error {
+	format, err := DetectFormat(filename)
+	if err != nil {
+		return fmt.Errorf("detect format: %w", err)
+	}
+
+	var src apipersistence.Source
+	switch format {
+	case FormatV1:
+		src = v1snap.NewSource(filename)
+	case FormatGob:
+		src = NewGobSource(filename)
+	default:
+		return fmt.Errorf("unsupported snapshot format %q", format)
+	}
+
+	boot, err := src.Boot(ctx)
+	if err != nil {
+		return fmt.Errorf("boot %s: %w", filename, err)
+	}
+	defer func() { _ = boot.Close() }()
+
+	switch boot.Mode {
+	case apipersistence.BootModeInitial:
+		// Empty / missing file at this stage is unusual — DetectFormat
+		// would have surfaced it. Treat as a successful no-op clear so
+		// LOAD_SNAPSHOT against an empty file leaves target empty.
+		target.Clear(ctx)
+		return nil
+	case apipersistence.BootModeSnapshot:
+		_, err := loadSnapshotInto(ctx, boot.Snapshot, target)
+		return err
+	case apipersistence.BootModeReplay:
+		// Runtime reload from a replay log isn't supported (replay's
+		// LSN-ordered semantics don't match a one-shot user command).
+		return fmt.Errorf("LOAD_SNAPSHOT does not support replay-mode sources")
+	default:
+		return fmt.Errorf("%w: %d", apipersistence.ErrInvalidBootMode, boot.Mode)
+	}
+}

--- a/pkg/persistence/loader_test.go
+++ b/pkg/persistence/loader_test.go
@@ -1,0 +1,180 @@
+package persistence
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+	"gocache/pkg/persistence/v1snap"
+)
+
+func TestDetectFormat_Gob(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	c := cache.New()
+	c.Lock()
+	_ = c.RawSet(context.Background(), "k", "v", 0)
+	c.Unlock()
+	if err := SaveSnapshot(context.Background(), file, c); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatGob {
+		t.Errorf("format = %q, want %q", got, FormatGob)
+	}
+}
+
+func TestDetectFormat_V1(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "v1.snap")
+
+	w := v1snap.NewSnapshotter(file)
+	if err := w.SaveSnapshot(context.Background(), &emptySrc{}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatV1 {
+		t.Errorf("format = %q, want %q", got, FormatV1)
+	}
+}
+
+func TestDetectFormat_MissingFile(t *testing.T) {
+	_, err := DetectFormat(filepath.Join(t.TempDir(), "nope.dat"))
+	if err == nil {
+		t.Errorf("expected error on missing file, got nil")
+	}
+}
+
+func TestDetectFormat_TooShort(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tiny.dat")
+	// 2 bytes — can't be v1 (header is 5). Should fall back to gob.
+	if err := os.WriteFile(file, []byte{0x01, 0x02}, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatGob {
+		t.Errorf("format = %q, want %q (short file should fall through to gob)", got, FormatGob)
+	}
+}
+
+func TestLoadFrom_Gob(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "k1", "v1", 0)
+	_ = source.RawSet(context.Background(), "k2", "v2", 0)
+	source.Unlock()
+	if err := SaveSnapshot(context.Background(), file, source); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Errorf("Len = %d, want 2", got)
+	}
+}
+
+func TestLoadFrom_V1(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "v1.snap")
+
+	w := v1snap.NewSnapshotter(file)
+	src := &sliceSrc{entries: []apipersistence.SnapshotEntry{
+		{Key: "a", ValueType: apipersistence.ValueTypeBytes, Encoding: apipersistence.EncodingNative, Value: []byte("alpha")},
+		{Key: "b", ValueType: apipersistence.ValueTypeBytes, Encoding: apipersistence.EncodingNative, Value: []byte("beta")},
+	}}
+	if err := w.SaveSnapshot(context.Background(), src); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Errorf("Len = %d, want 2", got)
+	}
+}
+
+func TestLoadFrom_ClearsTarget(t *testing.T) {
+	// LOAD_SNAPSHOT semantics: replace target's contents with the
+	// snapshot. Pre-existing entries should be cleared, not merged.
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "from-snap", "v", 0)
+	source.Unlock()
+	if err := SaveSnapshot(context.Background(), file, source); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	target.Lock()
+	_ = target.RawSet(context.Background(), "preexisting", "v", 0)
+	target.Unlock()
+
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if _, ok := target.RawGet("preexisting"); ok {
+		t.Errorf("preexisting key still present after LoadFrom")
+	}
+	if _, ok := target.RawGet("from-snap"); !ok {
+		t.Errorf("from-snap key missing after LoadFrom")
+	}
+}
+
+func TestLoadFrom_MissingFile(t *testing.T) {
+	target := cache.New()
+	err := LoadFrom(context.Background(), filepath.Join(t.TempDir(), "missing.dat"), target)
+	if err == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+// emptySrc satisfies api/persistence.SnapshotSource with no entries.
+// Used to write a minimal valid v1 file for DetectFormat tests.
+type emptySrc struct{}
+
+func (emptySrc) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	return apipersistence.SnapshotEntry{}, io.EOF
+}
+
+// sliceSrc is a minimal SnapshotSource for table-driven LoadFrom tests.
+type sliceSrc struct {
+	entries []apipersistence.SnapshotEntry
+	cursor  int
+}
+
+func (s *sliceSrc) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	if s.cursor >= len(s.entries) {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	e := s.entries[s.cursor]
+	s.cursor++
+	return e, nil
+}

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -40,7 +40,10 @@ func HandleLoadSnapshot(cmdCtx *command.Context) command.Result {
 	}
 
 	executeFn := func() any {
-		if err := persistence.LoadSnapshot(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
+		// Auto-detect format (gob or v1) so deployments can load either
+		// at runtime — e.g. inspecting an archived gob snapshot after
+		// flipping the default format to v1.
+		if err := persistence.LoadFrom(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
 			return err
 		}
 		return "OK"

--- a/pkg/resp/handler/persistence_test.go
+++ b/pkg/resp/handler/persistence_test.go
@@ -1,15 +1,19 @@
 package handler_test
 
 import (
+	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	apipersistence "gocache/api/persistence"
 	"gocache/pkg/cache"
 	"gocache/pkg/clientctx"
 	"gocache/pkg/command"
 	"gocache/pkg/engine"
 	"gocache/pkg/persistence"
+	"gocache/pkg/persistence/v1snap"
 	"gocache/pkg/resp/handler"
 )
 
@@ -112,4 +116,60 @@ func TestHandler_LoadSnapshot_PathTraversal(t *testing.T) {
 			t.Errorf("path %q should have been rejected, got OK", arg)
 		}
 	}
+}
+
+// TestHandler_LoadSnapshot_V1 verifies that LOAD_SNAPSHOT auto-detects
+// the v1 binary format and loads it correctly. The runtime command
+// path doesn't go through the coordinator's startup format selection,
+// so format detection has to live inside the handler — this test
+// guards the dual-format contract.
+func TestHandler_LoadSnapshot_V1(t *testing.T) {
+	dir := t.TempDir()
+	v1file := filepath.Join(dir, "v1.snap")
+
+	w := v1snap.NewSnapshotter(v1file)
+	src := &sliceSrcForTest{entries: []apipersistence.SnapshotEntry{
+		{Key: "v1key", ValueType: apipersistence.ValueTypeBytes, Encoding: apipersistence.EncodingNative, Value: []byte("v1val")},
+	}}
+	if err := w.SaveSnapshot(context.Background(), src); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	c := cache.New()
+	e := engine.New(c)
+	go e.Run()
+	t.Cleanup(func() { e.Stop() })
+
+	loadCtx := &command.Context{
+		Client:       clientctx.New(),
+		Op:           "LOAD_SNAPSHOT",
+		Args:         []string{filepath.Base(v1file)},
+		Engine:       e,
+		Cache:        c,
+		SnapshotFile: v1file,
+	}
+	res := handler.HandleLoadSnapshot(loadCtx)
+	if res.Value != "OK" {
+		t.Fatalf("LOAD_SNAPSHOT v1: %v / err=%v", res.Value, res.Err)
+	}
+
+	got := eval(t, c, e, clientctx.New(), "GET", []string{"v1key"})
+	if valueAsString(got.Value) != "v1val" {
+		t.Errorf("GET v1key after load: got %v, want v1val", got.Value)
+	}
+}
+
+// sliceSrcForTest is a minimal SnapshotSource for the v1 load test.
+type sliceSrcForTest struct {
+	entries []apipersistence.SnapshotEntry
+	cursor  int
+}
+
+func (s *sliceSrcForTest) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	if s.cursor >= len(s.entries) {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	e := s.entries[s.cursor]
+	s.cursor++
+	return e, nil
 }


### PR DESCRIPTION
## Summary

Phase 3 cutover. Closes the v1 snapshot arc.

| Change | Where | Risk |
|--------|-------|------|
| Default `snapshot_format` flips `gob` → `v1` | `api/config/config.go` | Existing on-disk gob snapshots stop loading at boot — breaking change accepted (personal project) |
| `LOAD_SNAPSHOT` auto-detects format | new `pkg/persistence/loader.go` | None — adds capability, no removal |
| ADR-0005 flips `proposed` → `accepted` | `docs/adr/0005-*.md` + index | Docs only |

No migration CLI — the audience is a single-user / research deployment, so the breaking change is acceptable. Users with an existing gob snapshot can either:
- delete it (simplest) — server boots empty
- set `persistence.snapshot_format: gob` in config (rollback path)

## What changed

### `pkg/persistence/loader.go` (new)
- `DetectFormat(filename) (SnapshotFormat, error)` — sniffs first 4 bytes; `GCDB` = v1, anything else = gob (legacy "open and try to gob-decode" semantics).
- `LoadFrom(ctx, filename, target)` — builds the right Source for the detected format, calls `Boot`, applies via `loadSnapshotInto`. Mid-lifecycle (clears target first, matching legacy `LOAD_SNAPSHOT` semantics).

### `pkg/resp/handler/persistence.go`
- `HandleLoadSnapshot` swaps `persistence.LoadSnapshot` for `persistence.LoadFrom`. Same path-traversal guards, but now handles both formats.

### `api/config/config.go`
- `DefaultSnapshotFormat` flips `"gob"` → `"v1"`. Doc comment updated to point at the gob fallback for users who need it.

### Docs
- `docs/adr/0005-snapshot-wire-and-file-format.md` — `status: accepted`
- `docs/adr/README.md` — index row updated

## Test plan

- [x] `go test -race ./...` — PASS
- [x] `go vet ./...` — PASS
- [x] `staticcheck ./...` — PASS
- [x] **6** new loader tests: `DetectFormat` for gob / v1 / missing / too-short, `LoadFrom` for both formats, target-clear semantics.
- [x] **1** new handler test: `HandleLoadSnapshot` round-trip through a v1 file. Existing gob handler test still passes (now via auto-detect rather than gob-only path).
- [ ] CI green on this PR before merge.

## Phase 3 status after this merges

- ✅ Snapshotter contract (#64)
- ✅ v1 binary format (#66)
- ✅ Cutover (this PR)

ADRs 0001/0002/0003/0005 all accepted. ADRs 0004 (command renames `SAVE`/`BGSAVE`/`LASTSAVE`/`BGREWRITEAOF`) and 0006 (embedded vs IPC plugin transport) stay `proposed` — those are independent next chunks of the persistence-as-plugin arc.