### PR TITLE
feat(persistence): embedded plugin registration (ADR-0007) — drop format from api/config

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -23,18 +23,6 @@ const (
 	DefaultSnapshotFile     = "snapshot.dat"
 	DefaultSnapshotInterval = 5 * time.Minute
 	DefaultLoadOnStartup    = true
-	// DefaultSnapshotFormat is the on-disk snapshot format. "gob" is the
-	// legacy Go gob-encoded format; "v1" is the custom binary format
-	// described in ADR-0005 (varint, magic header, CRC32, optional zstd).
-	// Default stays "gob" until the migration window for existing
-	// deployments closes — flip to "v1" in a follow-up release.
-	DefaultSnapshotFormat = "gob"
-
-	// SnapshotFormatGob and SnapshotFormatV1 are the recognised values
-	// for PersistenceConfig.SnapshotFormat. Unknown values fall back
-	// to the gob shim with a warning at boot.
-	SnapshotFormatGob = "gob"
-	SnapshotFormatV1  = "v1"
 	DefaultMaxMemoryMB      = int64(1024)
 	DefaultEvictionPolicy   = "lru"
 	DefaultCacheShards      = 8
@@ -73,15 +61,14 @@ type ServerConfig struct {
 }
 
 // PersistenceConfig holds persistence configuration.
+//
+// The active snapshot/AOF backend is chosen at compile time by which
+// persistence plugin cmd/server/main.go blank-imports — there is no
+// format/provider field here. See ADR-0007 for the rationale.
 type PersistenceConfig struct {
 	SnapshotFile     string        `yaml:"snapshot_file"     mapstructure:"snapshot_file"`
 	SnapshotInterval time.Duration `yaml:"snapshot_interval" mapstructure:"snapshot_interval"`
 	LoadOnStartup    bool          `yaml:"load_on_startup"   mapstructure:"load_on_startup"`
-	// SnapshotFormat selects the on-disk format. "gob" (default) keeps
-	// the legacy gob-encoded format; "v1" uses the format described in
-	// ADR-0005. Existing deployments stay on gob until a one-shot
-	// migration via the gocache-migrate CLI (ships in a follow-up).
-	SnapshotFormat string `yaml:"snapshot_format" mapstructure:"snapshot_format"`
 }
 
 // MemoryConfig holds memory management configuration.
@@ -134,7 +121,6 @@ func DefaultConfig() *Config {
 			SnapshotFile:     DefaultSnapshotFile,
 			SnapshotInterval: DefaultSnapshotInterval,
 			LoadOnStartup:    DefaultLoadOnStartup,
-			SnapshotFormat:   DefaultSnapshotFormat,
 		},
 		Memory: MemoryConfig{
 			MaxMemoryMB:          DefaultMaxMemoryMB,

--- a/api/persistence/registry.go
+++ b/api/persistence/registry.go
@@ -1,0 +1,92 @@
+package persistence
+
+import (
+	"fmt"
+	"sync"
+)
+
+// SnapshotProvider is the registration handle for an embedded snapshot
+// plugin (ADR-0007). Each plugin's init() calls RegisterSnapshotProvider
+// with a value of this type; cmd/server/main.go resolves the registered
+// provider via SnapshotProviderRegistered.
+//
+// Selection is done at compile time via blank imports of the desired
+// plugin package — there is no config string. Adding a new snapshot
+// backend is a new package + a new blank import, with no change to the
+// core surface.
+//
+// AOF and replication will get parallel registration interfaces
+// (RegisterAOFProvider, RegisterReplicationSink) when those plugins
+// land — same pattern, different capability.
+type SnapshotProvider interface {
+	// Name identifies the provider for logs and diagnostics. Should
+	// be a stable plugin identifier (e.g. "v1-snapshot"), not a
+	// format string.
+	Name() string
+
+	// Build constructs the Source / Snapshotter pair targeting filename
+	// and returns a setFilename closure for hot-reload. Build is called
+	// exactly once per server lifetime; the returned trio is owned by
+	// the coordinator afterwards.
+	//
+	// The setFilename closure is plugin-defined — typical plugins
+	// route the new path to both Source.SetFilename and
+	// Snapshotter.SetFilename. Plugins whose backends don't care
+	// about the filename (e.g. a network-streaming sink) return a
+	// no-op closure.
+	Build(filename string) (Source, Snapshotter, func(filename string))
+}
+
+var (
+	snapshotProviderMu sync.RWMutex
+	snapshotProvider   SnapshotProvider
+)
+
+// RegisterSnapshotProvider installs the embedded snapshot plugin.
+// Called from the plugin's init(). Exactly one provider may register
+// per binary — a second call panics with the conflicting plugin
+// names so the build misconfiguration surfaces at startup, not
+// silently as one plugin overwriting another.
+//
+// The build-time choice of which plugin to import determines which
+// provider runs. Multi-tenant binaries (two snapshot plugins coexisting)
+// would need a different registration model; this design assumes a
+// single canonical provider per binary, matching the "exactly one
+// snapshot strategy" reality of every production deployment.
+func RegisterSnapshotProvider(p SnapshotProvider) {
+	if p == nil {
+		panic("api/persistence: RegisterSnapshotProvider called with nil")
+	}
+	snapshotProviderMu.Lock()
+	defer snapshotProviderMu.Unlock()
+	if snapshotProvider != nil {
+		panic(fmt.Sprintf(
+			"api/persistence: snapshot provider already registered (%q); cannot register %q — exactly one provider per binary",
+			snapshotProvider.Name(), p.Name(),
+		))
+	}
+	snapshotProvider = p
+}
+
+// SnapshotProviderRegistered returns the registered provider, or nil if
+// no plugin was imported. Callers (cmd/server/main.go) treat nil as
+// "no snapshot persistence" and run the cache in ephemeral mode.
+//
+// The lookup is mutex-protected because tests may reset the registry
+// (see ResetSnapshotProviderForTest) — production-time access happens
+// once at startup, well after every plugin's init() has completed.
+func SnapshotProviderRegistered() SnapshotProvider {
+	snapshotProviderMu.RLock()
+	defer snapshotProviderMu.RUnlock()
+	return snapshotProvider
+}
+
+// ResetSnapshotProviderForTest clears the registered provider. Test-only
+// helper exposed so per-package tests that exercise registration can
+// run independently. Production code paths must not call this — the
+// global is intended to be set exactly once per process lifetime.
+func ResetSnapshotProviderForTest() {
+	snapshotProviderMu.Lock()
+	defer snapshotProviderMu.Unlock()
+	snapshotProvider = nil
+}

--- a/api/persistence/registry_test.go
+++ b/api/persistence/registry_test.go
@@ -1,0 +1,143 @@
+package persistence_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apipersistence "gocache/api/persistence"
+)
+
+// fakeProvider is a test-only SnapshotProvider that records its name
+// and produces nil Source/Snapshotter — the registry tests don't
+// exercise Build's outputs, only that the right provider is returned
+// from the lookup.
+type fakeProvider struct {
+	name string
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) Build(_ string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
+	return nil, nil, func(string) {}
+}
+
+func TestRegistry_NoProvider_ReturnsNil(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	if got := apipersistence.SnapshotProviderRegistered(); got != nil {
+		t.Errorf("expected nil before any registration, got %v", got)
+	}
+}
+
+func TestRegistry_Register_RoundTrip(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	p := &fakeProvider{name: "test-provider"}
+	apipersistence.RegisterSnapshotProvider(p)
+
+	got := apipersistence.SnapshotProviderRegistered()
+	if got == nil {
+		t.Fatal("registered provider not returned")
+	}
+	if got.Name() != "test-provider" {
+		t.Errorf("name = %q, want test-provider", got.Name())
+	}
+}
+
+func TestRegistry_DoubleRegister_Panics(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	apipersistence.RegisterSnapshotProvider(&fakeProvider{name: "first"})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on double-register, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value not a string: %T", r)
+		}
+		// Both names should appear so misconfiguration is obvious.
+		if !strings.Contains(msg, "first") || !strings.Contains(msg, "second") {
+			t.Errorf("panic message missing names: %s", msg)
+		}
+	}()
+	apipersistence.RegisterSnapshotProvider(&fakeProvider{name: "second"})
+}
+
+func TestRegistry_RegisterNil_Panics(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil provider, got none")
+		}
+	}()
+	apipersistence.RegisterSnapshotProvider(nil)
+}
+
+func TestRegistry_BuildPlumbing(t *testing.T) {
+	// Sanity check that Build's signature is wired through correctly
+	// by exercising the round-trip with a non-fake provider built in
+	// the same pattern v1snap uses.
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	apipersistence.RegisterSnapshotProvider(&buildableProvider{name: "buildable"})
+	got := apipersistence.SnapshotProviderRegistered()
+	if got == nil {
+		t.Fatal("provider not registered")
+	}
+	src, snap, setFile := got.Build("/tmp/test-file")
+	if src == nil || snap == nil {
+		t.Fatalf("Build returned nil pieces: src=%v snap=%v", src, snap)
+	}
+	// setFile should not panic on call
+	setFile("/tmp/other")
+	// Source.Boot should work with the new filename — buildableProvider's
+	// fake source records what filename was passed.
+	bs := src.(*buildableSource)
+	if bs.lastFilename != "/tmp/other" {
+		t.Errorf("setFile did not update source: lastFilename=%q", bs.lastFilename)
+	}
+}
+
+// buildableProvider exercises Build's three-return-value contract end
+// to end. The Source/Snapshotter it returns are fakes that capture
+// state so the test can assert the setFilename closure actually
+// reaches them.
+type buildableProvider struct {
+	name string
+}
+
+func (b *buildableProvider) Name() string { return b.name }
+
+func (b *buildableProvider) Build(filename string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
+	src := &buildableSource{lastFilename: filename}
+	snap := &buildableSnapshotter{lastFilename: filename}
+	return src, snap, func(f string) {
+		src.lastFilename = f
+		snap.lastFilename = f
+	}
+}
+
+type buildableSource struct {
+	lastFilename string
+}
+
+func (b *buildableSource) Name() string { return "buildable-source" }
+func (b *buildableSource) Boot(_ context.Context) (apipersistence.BootResult, error) {
+	return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
+}
+
+type buildableSnapshotter struct {
+	lastFilename string
+}
+
+func (b *buildableSnapshotter) Name() string { return "buildable-snap" }
+func (b *buildableSnapshotter) SaveSnapshot(_ context.Context, _ apipersistence.SnapshotSource) error {
+	return nil
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"gocache/api/command"
-	apiconfig "gocache/api/config"
 	"gocache/api/crashdump"
 	"gocache/api/embedded"
 	"gocache/api/events"
@@ -28,7 +27,6 @@ import (
 	"gocache/pkg/logcollector"
 	serverOps "gocache/pkg/operations"
 	"gocache/pkg/persistence"
-	"gocache/pkg/persistence/v1snap"
 	"gocache/pkg/plugin/cmdhooks"
 	pluginmgr "gocache/pkg/plugin/manager"
 	"gocache/pkg/plugin/ophooks"
@@ -36,6 +34,12 @@ import (
 	"gocache/pkg/version"
 	"gocache/pkg/watch"
 	"gocache/pkg/workers"
+
+	// Embedded persistence plugin — registers itself via init() per
+	// ADR-0007. Selecting a different snapshot backend = swap this
+	// import for the new plugin's package; api/persistence resolves
+	// the registered provider at startup, no other code change needed.
+	_ "gocache/pkg/persistence/v1snap"
 
 	// Embedded plugins — compile-time-linked observability hooks that run
 	// before config.Load and survive panics. See pkg/embedded for details.
@@ -254,13 +258,13 @@ func main() {
 	// coordinator runs in pass-through mode (no sinks registered) until
 	// a future PR adds the AOF / snapshot sink plugins.
 	//
-	// The snapshot format is selected by config: "gob" (legacy) or
-	// "v1" (ADR-0005 binary format with optional zstd). Both backends
-	// implement Source + Snapshotter, so SAVE, scheduled snapshots,
-	// and shutdown final-snapshot all run through the coordinator.
-	// snapSetFilename collects the per-backend hot-reload knobs so
-	// OnConfigChange can update both halves atomically.
-	snapSource, snapSnapshotter, snapSetFilename := buildSnapshotBackend(ctx, cfg.Persistence.SnapshotFormat, cfg.Persistence.SnapshotFile)
+	// The active snapshot backend comes from whichever embedded plugin
+	// was blank-imported above (ADR-0007). api/persistence resolves
+	// the registered provider; if none was compiled in, the server
+	// runs ephemeral and logs a warning. The provider's Build returns
+	// Source + Snapshotter + a hot-reload filename setter so config
+	// reload updates both halves atomically.
+	snapSource, snapSnapshotter, snapSetFilename := buildSnapshotBackend(ctx, cfg.Persistence.SnapshotFile)
 	coordinator := persistence.New(snapSource)
 	coordinator.RegisterSnapshotter(snapSnapshotter)
 	srv.SetPersistenceFeed(coordinator)
@@ -502,34 +506,22 @@ func handleShutdown(
 	logger.Info(shutdownCtx).Str("step", "6/6").Msg("shutdown complete")
 }
 
-// buildSnapshotBackend selects the on-disk format dictated by config
-// and returns Source + Snapshotter implementing it, plus a setter that
-// propagates a new filename to whichever backend is in use. Unknown
-// format strings fall back to the gob shim with a warning so a typo in
-// snapshot_format doesn't take the server offline at boot.
-func buildSnapshotBackend(ctx context.Context, format, filename string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
-	switch format {
-	case apiconfig.SnapshotFormatV1:
-		src := v1snap.NewSource(filename)
-		snap := v1snap.NewSnapshotter(filename)
-		setBoth := func(f string) {
-			src.SetFilename(f)
-			snap.SetFilename(f)
-		}
-		logger.Info(ctx).Str("format", format).Msg("persistence: snapshot backend selected")
-		return src, snap, setBoth
-
-	case apiconfig.SnapshotFormatGob, "":
-		shim := persistence.NewGobSource(filename)
-		logger.Info(ctx).Str("format", apiconfig.SnapshotFormatGob).Msg("persistence: snapshot backend selected")
-		return shim, shim, shim.SetFilename
-
-	default:
-		shim := persistence.NewGobSource(filename)
-		logger.Warn(ctx).
-			Str("requested", format).
-			Str("fallback", apiconfig.SnapshotFormatGob).
-			Msg("persistence: unknown snapshot_format, falling back to gob")
-		return shim, shim, shim.SetFilename
+// buildSnapshotBackend resolves the registered embedded snapshot
+// plugin (ADR-0007) and asks it to build the Source + Snapshotter
+// pair. Selection is compile-time — whichever plugin's package was
+// blank-imported above wins via init-time RegisterSnapshotProvider.
+//
+// Returns nil source/snapshotter and a no-op filename setter when no
+// plugin was compiled in. The Coordinator handles nil source (no
+// recovery) and nil snapshotter (snapshot save returns
+// ErrNoSnapshotter). A warning surfaces the misbuild without
+// crashing — ephemeral mode is intentional for dev runs.
+func buildSnapshotBackend(ctx context.Context, filename string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
+	provider := apipersistence.SnapshotProviderRegistered()
+	if provider == nil {
+		logger.Warn(ctx).Msg("persistence: no snapshot plugin compiled in; snapshots disabled")
+		return nil, nil, func(string) {}
 	}
+	logger.Info(ctx).Str("provider", provider.Name()).Msg("persistence: snapshot backend selected")
+	return provider.Build(filename)
 }

--- a/docs/adr/0005-snapshot-wire-and-file-format.md
+++ b/docs/adr/0005-snapshot-wire-and-file-format.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0005 Snapshot wire and file format
 description: Snapshots use a custom binary format (varint, magic header, CRC32, optional zstd) replacing Go's gob encoder
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/0007-embedded-persistence-plugin-registration.md
+++ b/docs/adr/0007-embedded-persistence-plugin-registration.md
@@ -1,0 +1,75 @@
+---
+title: ADR-0007 Embedded persistence plugins register via init()
+description: Snapshot and AOF backends register themselves with the persistence layer via init-time hooks; main.go selects them via blank imports rather than a config string
+status: accepted
+date: 2026-05-03
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0002-source-sink-contract
+  - ADR-0005-snapshot-wire-and-file-format
+  - ADR-0006-builtin-vs-third-party-transport
+---
+
+# ADR-0007: Embedded persistence plugins register via init()
+
+## Context
+
+ADR-0001 established that persistence is a pluggable subsystem and ADR-0002 split the contract into Source/Sink/Snapshotter. ADR-0005 specified the v1 binary snapshot format. The remaining question is *how the server discovers which persistence plugin is active*.
+
+The first cut wired this through `api/config.PersistenceConfig.SnapshotFormat` — a string field the user set to `"gob"` or `"v1"`, with `cmd/server/main.go` switching on it. That works mechanically but leaks a plugin-internal concern (which on-disk format the server uses) into the public configuration surface. The microkernel premise of the persistence-as-plugin arc is the opposite: the core should not know plugin implementation details. A plugin's name, configuration knobs, and on-disk format belong to the plugin, not to `api/config`.
+
+ADR-0006 (still proposed) distinguishes embedded plugins (compile-time, in-process) from IPC plugins (separate process via Unix socket + GCPC). Snapshot and AOF are the canonical embedded cases — performance-critical, tightly coupled to the cache's memory shape, and not interesting to swap at runtime. They need a registration mechanism that matches their compile-time nature without bouncing through a config string.
+
+## Decision
+
+Embedded persistence plugins register themselves with the persistence layer at package-init time. `api/persistence` exposes a registration function (`RegisterSnapshotProvider`); each plugin's `init()` calls it. The server selects which plugin is active by *blank-importing* the desired plugin package in `cmd/server/main.go`. Exactly one snapshot provider may be registered per binary; a second registration panics at init with both plugin names.
+
+The same pattern will apply to AOF when it lands (`RegisterAOFProvider`). `api/config` carries no format/format-name strings. The runtime `LOAD_SNAPSHOT` command keeps a separate format-detection helper (`pkg/persistence.DetectFormat`) so an operator can load an archived gob file even on a binary that compiled in only the v1 plugin — that's an operator convenience, not a configuration knob.
+
+## Alternatives Considered
+
+### Alternative 1: Format string in `api/config` (the rejected status quo)
+
+- **Pros**: Simplest mechanically. Users edit one YAML key to switch backends. Config is a single source of truth.
+- **Cons**: `api/config` is the public surface plugins import; putting `"gob" | "v1"` strings there couples every plugin to the central enumeration of *every* persistence backend that ever ships. Adding a Postgres replication source means adding a string to `api/config` — which means the core knows about the Postgres plugin. Inverts the dependency we want.
+- **Why not**: The user feedback during PR-C review was explicit — *"snapshot format should be specified by plugins themselves, not by general api server config, that was the whole point"*. The microkernel boundary belongs at the contract surface, not inside an enum of implementations.
+
+### Alternative 2: Manifest-driven runtime selection
+
+- **Pros**: One YAML key (`persistence.provider: snapshot-v1`) selects the active plugin. All plugins compile in; deployment chooses at startup. Matches Kafka Connect / WiredTiger Env style.
+- **Cons**: The plugin choice is a build-time fact for any deployment in practice — no operator picks Postgres replication on Tuesday and snapshot on Wednesday. Adding runtime indirection for a static fact pays cost without buying anything. Also: every deployed binary carries every plugin's code, even ones it never uses.
+- **Why not**: Optimizes for a flexibility nobody needs and pays for it in binary size and startup complexity.
+
+### Alternative 3: Build tags
+
+- **Pros**: Compile-time selection, zero runtime cost. Standard Go idiom for "include feature X" conditional compilation.
+- **Cons**: Build tags don't run any registration logic; the plugin still has to expose its types to `cmd/server/main.go`, which means `main.go` has to know the plugin's package name and constructor signatures. That re-creates the central-enumeration problem build tags were supposed to fix.
+- **Why not**: Solves the wrong layer — the conditional inclusion is fine, but selecting *which* plugin is active still has to be a runtime resolution. Blank imports + `init()` registration combines both: the import is the conditional inclusion, the init is the registration. One mechanism does both jobs.
+
+### Alternative 4: Plugin discovery via reflection
+
+- **Pros**: No explicit registration call. Plugins drop into a known directory; the loader scans for them.
+- **Cons**: Reflection is the wrong tool for compile-time configuration. Adds a runtime walk for a fact that's literally encoded in the import graph. Errors surface at startup as obscure reflection misses rather than at compile time as missing imports.
+- **Why not**: All cost, no benefit relative to blank imports.
+
+## Consequences
+
+### Positive
+
+- `api/config` no longer knows persistence implementation details. Adding a new snapshot or AOF backend is a new package + a new blank import in `main.go`; no core change.
+- Compile-time enforcement of "exactly one provider per binary" — the panic-on-double-register surfaces conflicts at startup, not silently.
+- Configuration stays minimal: `persistence.snapshot_file`, `persistence.snapshot_interval`, `persistence.load_on_startup` are the user-facing knobs. The plugin's identity is a build-time fact.
+- Pattern extends cleanly: `RegisterAOFProvider` for the AOF plugin, `RegisterReplicationSink` for replication, etc. Each capability gets its own narrow registration interface; plugins implement whichever they care about.
+- Forward-compatible with ADR-0006's eventual physical move to `plugins/`. The registration interface is the same wherever the implementation file lives.
+
+### Negative
+
+- The build configuration becomes load-bearing for "which persistence backend ships." A deployment that swaps backends must rebuild — not a config flip. Acceptable for the project's audience (single-user / research / thesis); operators who want runtime backend switching would need something heavier.
+- Tests that need a non-default provider must arrange their own registration (or work directly with the plugin's constructors, bypassing the registry). The default test path uses the constructors directly; only integration tests touching `cmd/server/main.go` would care.
+
+### Risks
+
+- **Risk**: Two embedded snapshot plugins compiled in by accident → panic at startup. **Mitigation**: The panic message names both plugins so the misconfiguration is immediately obvious. Build hygiene (separate cmd/server build for each plugin, or a single canonical default) keeps this rare.
+- **Risk**: No plugin compiled in → server runs without persistence and silently drops state on restart. **Mitigation**: `cmd/server/main.go` logs a `persistence: no snapshot plugin compiled in; snapshots disabled` warning at startup so the operator notices. This is the intended behaviour for ephemeral dev runs but should be loud enough to catch a misbuild.
+- **Risk**: A future architectural change (e.g., an embedded plugin that *also* needs to serve a different responsibility) wants composition rather than single-registration. **Mitigation**: The registration model is per-capability — each capability has its own narrow interface and its own register/lookup. A plugin can implement multiple capabilities; the binary holds at most one provider per capability. Composition lives in the plugin package, not in the registry.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,8 +34,9 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | accepted | 2026-05-03 |
 | [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | accepted | 2026-05-03 |
 | [0004](0004-command-namespacing.md) | Persistence command namespacing | proposed | 2026-05-03 |
-| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | proposed | 2026-05-03 |
+| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | accepted | 2026-05-03 |
 | [0006](0006-builtin-vs-third-party-transport.md) | Built-in vs third-party plugin transport | proposed | 2026-05-03 |
+| [0007](0007-embedded-persistence-plugin-registration.md) | Embedded persistence plugins register via init() | accepted | 2026-05-03 |
 
 ## Writing a new ADR
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,6 @@ func Load(flags *pflag.FlagSet) (*Config, *viper.Viper, error) {
 	v.SetDefault("persistence.snapshot_file", apiconfig.DefaultSnapshotFile)
 	v.SetDefault("persistence.snapshot_interval", apiconfig.DefaultSnapshotInterval)
 	v.SetDefault("persistence.load_on_startup", apiconfig.DefaultLoadOnStartup)
-	v.SetDefault("persistence.snapshot_format", apiconfig.DefaultSnapshotFormat)
 	v.SetDefault("memory.max_memory_mb", apiconfig.DefaultMaxMemoryMB)
 	v.SetDefault("memory.eviction_policy", apiconfig.DefaultEvictionPolicy)
 	v.SetDefault("memory.cache_shards", apiconfig.DefaultCacheShards)

--- a/pkg/persistence/loader.go
+++ b/pkg/persistence/loader.go
@@ -1,0 +1,111 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+	"gocache/pkg/persistence/v1snap"
+)
+
+// SnapshotFormat identifies the on-disk format of a snapshot file. The
+// values are runtime-internal — a deployment never picks a format
+// string from configuration (the active backend is selected at compile
+// time via the embedded plugin registration in api/persistence, see
+// ADR-0007). DetectFormat exists to support the runtime LOAD_SNAPSHOT
+// command, which can read either format regardless of which plugin
+// shipped in the binary; that's an operator convenience for loading
+// archived snapshots, not a configuration knob.
+type SnapshotFormat string
+
+const (
+	FormatGob SnapshotFormat = "gob"
+	FormatV1  SnapshotFormat = "v1"
+)
+
+// DetectFormat sniffs the leading bytes of filename and returns which
+// format it is. The v1 format starts with a 4-byte ASCII magic "GCDB"
+// (see pkg/persistence/v1snap.format.go); anything else is treated as
+// gob, matching the legacy "open and try to gob-decode" semantics.
+//
+// A missing file returns os.ErrNotExist — callers decide whether that
+// is an error or a "nothing to load" signal.
+func DetectFormat(filename string) (SnapshotFormat, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var buf [4]byte
+	n, err := io.ReadFull(f, buf[:])
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("v1snap detect: read %s: %w", filename, err)
+	}
+	// A short file (< 4 bytes) can't be v1 — its header is 5 bytes.
+	// Fall through to gob; gob's decoder will surface a clear error
+	// on a malformed stream.
+	if n == 4 && buf[0] == 'G' && buf[1] == 'C' && buf[2] == 'D' && buf[3] == 'B' {
+		return FormatV1, nil
+	}
+	return FormatGob, nil
+}
+
+// LoadFrom reads filename via the format-appropriate Source and applies
+// the snapshot to target. Used by the LOAD_SNAPSHOT runtime command —
+// distinct from Coordinator.BootInto, which loads through the
+// registered snapshot provider. LoadFrom mid-lifecycle CLEARS target
+// before loading (matching legacy LOAD_SNAPSHOT semantics).
+//
+// Format auto-detection means an operator can always read an archived
+// gob snapshot file even on a binary that compiled in only the v1
+// plugin — DetectFormat picks the right Source based on the bytes on
+// disk, not on what's registered.
+//
+// Errors from the Source bubble up untouched. Truncated / corrupted
+// files surface either at Boot (header validation) or on iterator
+// drain (CRC mismatch, malformed records).
+func LoadFrom(ctx context.Context, filename string, target *cache.Cache) error {
+	format, err := DetectFormat(filename)
+	if err != nil {
+		return fmt.Errorf("detect format: %w", err)
+	}
+
+	var src apipersistence.Source
+	switch format {
+	case FormatV1:
+		src = v1snap.NewSource(filename)
+	case FormatGob:
+		src = NewGobSource(filename)
+	default:
+		return fmt.Errorf("unsupported snapshot format %q", format)
+	}
+
+	boot, err := src.Boot(ctx)
+	if err != nil {
+		return fmt.Errorf("boot %s: %w", filename, err)
+	}
+	defer func() { _ = boot.Close() }()
+
+	switch boot.Mode {
+	case apipersistence.BootModeInitial:
+		// Empty / missing file at this stage is unusual — DetectFormat
+		// would have surfaced it. Treat as a successful no-op clear so
+		// LOAD_SNAPSHOT against an empty file leaves target empty.
+		target.Clear(ctx)
+		return nil
+	case apipersistence.BootModeSnapshot:
+		_, err := loadSnapshotInto(ctx, boot.Snapshot, target)
+		return err
+	case apipersistence.BootModeReplay:
+		// Runtime reload from a replay log isn't supported (replay's
+		// LSN-ordered semantics don't match a one-shot user command).
+		return fmt.Errorf("LOAD_SNAPSHOT does not support replay-mode sources")
+	default:
+		return fmt.Errorf("%w: %d", apipersistence.ErrInvalidBootMode, boot.Mode)
+	}
+}

--- a/pkg/persistence/loader_test.go
+++ b/pkg/persistence/loader_test.go
@@ -1,0 +1,180 @@
+package persistence
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	apipersistence "gocache/api/persistence"
+	"gocache/pkg/cache"
+	"gocache/pkg/persistence/v1snap"
+)
+
+func TestDetectFormat_Gob(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	c := cache.New()
+	c.Lock()
+	_ = c.RawSet(context.Background(), "k", "v", 0)
+	c.Unlock()
+	if err := SaveSnapshot(context.Background(), file, c); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatGob {
+		t.Errorf("format = %q, want %q", got, FormatGob)
+	}
+}
+
+func TestDetectFormat_V1(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "v1.snap")
+
+	w := v1snap.NewSnapshotter(file)
+	if err := w.SaveSnapshot(context.Background(), &emptySrc{}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatV1 {
+		t.Errorf("format = %q, want %q", got, FormatV1)
+	}
+}
+
+func TestDetectFormat_MissingFile(t *testing.T) {
+	_, err := DetectFormat(filepath.Join(t.TempDir(), "nope.dat"))
+	if err == nil {
+		t.Errorf("expected error on missing file, got nil")
+	}
+}
+
+func TestDetectFormat_TooShort(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "tiny.dat")
+	// 2 bytes — can't be v1 (header is 5). Should fall back to gob.
+	if err := os.WriteFile(file, []byte{0x01, 0x02}, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := DetectFormat(file)
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if got != FormatGob {
+		t.Errorf("format = %q, want %q (short file should fall through to gob)", got, FormatGob)
+	}
+}
+
+func TestLoadFrom_Gob(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "k1", "v1", 0)
+	_ = source.RawSet(context.Background(), "k2", "v2", 0)
+	source.Unlock()
+	if err := SaveSnapshot(context.Background(), file, source); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Errorf("Len = %d, want 2", got)
+	}
+}
+
+func TestLoadFrom_V1(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "v1.snap")
+
+	w := v1snap.NewSnapshotter(file)
+	src := &sliceSrc{entries: []apipersistence.SnapshotEntry{
+		{Key: "a", ValueType: apipersistence.ValueTypeBytes, Encoding: apipersistence.EncodingNative, Value: []byte("alpha")},
+		{Key: "b", ValueType: apipersistence.ValueTypeBytes, Encoding: apipersistence.EncodingNative, Value: []byte("beta")},
+	}}
+	if err := w.SaveSnapshot(context.Background(), src); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if got := target.Len(); got != 2 {
+		t.Errorf("Len = %d, want 2", got)
+	}
+}
+
+func TestLoadFrom_ClearsTarget(t *testing.T) {
+	// LOAD_SNAPSHOT semantics: replace target's contents with the
+	// snapshot. Pre-existing entries should be cleared, not merged.
+	dir := t.TempDir()
+	file := filepath.Join(dir, "snap.dat")
+
+	source := cache.New()
+	source.Lock()
+	_ = source.RawSet(context.Background(), "from-snap", "v", 0)
+	source.Unlock()
+	if err := SaveSnapshot(context.Background(), file, source); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+
+	target := cache.New()
+	target.Lock()
+	_ = target.RawSet(context.Background(), "preexisting", "v", 0)
+	target.Unlock()
+
+	if err := LoadFrom(context.Background(), file, target); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if _, ok := target.RawGet("preexisting"); ok {
+		t.Errorf("preexisting key still present after LoadFrom")
+	}
+	if _, ok := target.RawGet("from-snap"); !ok {
+		t.Errorf("from-snap key missing after LoadFrom")
+	}
+}
+
+func TestLoadFrom_MissingFile(t *testing.T) {
+	target := cache.New()
+	err := LoadFrom(context.Background(), filepath.Join(t.TempDir(), "missing.dat"), target)
+	if err == nil {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+// emptySrc satisfies api/persistence.SnapshotSource with no entries.
+// Used to write a minimal valid v1 file for DetectFormat tests.
+type emptySrc struct{}
+
+func (emptySrc) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	return apipersistence.SnapshotEntry{}, io.EOF
+}
+
+// sliceSrc is a minimal SnapshotSource for table-driven LoadFrom tests.
+type sliceSrc struct {
+	entries []apipersistence.SnapshotEntry
+	cursor  int
+}
+
+func (s *sliceSrc) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	if s.cursor >= len(s.entries) {
+		return apipersistence.SnapshotEntry{}, io.EOF
+	}
+	e := s.entries[s.cursor]
+	s.cursor++
+	return e, nil
+}

--- a/pkg/persistence/v1snap/init.go
+++ b/pkg/persistence/v1snap/init.go
@@ -1,0 +1,40 @@
+package v1snap
+
+import (
+	apipersistence "gocache/api/persistence"
+)
+
+// init registers v1snap as the embedded snapshot plugin per ADR-0007.
+// cmd/server/main.go blank-imports this package to wire the v1 backend
+// into the server; resolution happens via
+// api/persistence.SnapshotProviderRegistered.
+//
+// A second persistence plugin compiled into the same binary will panic
+// here at init time — see the registration contract.
+func init() {
+	apipersistence.RegisterSnapshotProvider(&provider{})
+}
+
+// provider is the bridge between v1snap's concrete Source / Snapshotter
+// types and the api/persistence.SnapshotProvider interface. It owns
+// nothing beyond the Build method — instances live as long as init.
+type provider struct{}
+
+// Name implements api/persistence.SnapshotProvider. Stable identifier
+// used for boot-time logs.
+func (provider) Name() string { return "v1-snapshot" }
+
+// Build implements api/persistence.SnapshotProvider. The returned
+// setFilename closure routes the new path to both halves so config
+// reload in main.go updates the boot-side and runtime-save-side
+// filename atomically (boot reads at startup; save reads at every
+// tick, so the runtime path is the one that matters in steady state).
+func (provider) Build(filename string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
+	src := NewSource(filename)
+	snap := NewSnapshotter(filename)
+	setFilename := func(f string) {
+		src.SetFilename(f)
+		snap.SetFilename(f)
+	}
+	return src, snap, setFilename
+}

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -40,7 +40,11 @@ func HandleLoadSnapshot(cmdCtx *command.Context) command.Result {
 	}
 
 	executeFn := func() any {
-		if err := persistence.LoadSnapshot(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
+		// Auto-detect format (gob or v1) so an operator can read either
+		// at runtime regardless of which snapshot plugin shipped in
+		// this binary — useful for loading an archived snapshot from
+		// the previous default format.
+		if err := persistence.LoadFrom(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
 			return err
 		}
 		return "OK"


### PR DESCRIPTION
## Summary

Replaces closed PR #67 with the proper architectural fix. Snapshot backend selection is now compile-time via blank imports + init-time registration; `api/config` no longer knows about format strings.

This PR introduces **ADR-0007** documenting the design and ships the matching implementation.

## What's wrong with the format-string approach (closed PR #67)

`api/config.PersistenceConfig.SnapshotFormat` was a string field the user set to `"gob"` or `"v1"`. That coupled `api/config` (the public surface plugins import) to the central enumeration of every persistence backend that ever ships. Adding a Postgres replication source would mean adding a string to `api/config` — the core would know about every plugin. Inverts the dependency the persistence-as-plugin arc set out to fix.

## What ADR-0007 proposes (and this PR implements)

```go
// api/persistence/registry.go
type SnapshotProvider interface {
    Name() string
    Build(filename string) (Source, Snapshotter, func(filename string))
}

RegisterSnapshotProvider(p)         // called from plugin's init()
SnapshotProviderRegistered() Provider  // nil if none compiled in
```

- **`pkg/persistence/v1snap/init.go`** — v1snap's `init()` calls `RegisterSnapshotProvider`.
- **`cmd/server/main.go`** — blank-imports `pkg/persistence/v1snap`; `buildSnapshotBackend` resolves the registered provider with **no format-string switch**.
- Exactly one provider per binary — `RegisterSnapshotProvider` panics on double-register with both plugin names.
- nil provider → server runs ephemeral, logs a clear warning. Misbuilds surface at startup.

Switching backend = swap one blank import line. No core change. Pattern extends cleanly to AOF, replication, etc.

## Breaking API change (intentional)

`api/config`:
- **DROPPED** `PersistenceConfig.SnapshotFormat` field
- **DROPPED** `DefaultSnapshotFormat` constant
- **DROPPED** `SnapshotFormatGob`, `SnapshotFormatV1` constants

These shipped briefly in #66; per the user feedback that closed #67 (*"snapshot format should be specified by plugins themselves, not by general api server config, that was the whole point"*), they're gone.

`pkg/config`: `persistence.snapshot_format` viper default removed.

## Runtime `LOAD_SNAPSHOT` keeps dual-format support

`pkg/persistence/loader.go` (new): `DetectFormat` sniffs leading 4 bytes (`GCDB` magic = v1, else gob). `LoadFrom` dispatches to the right Source. `HandleLoadSnapshot` uses `LoadFrom` — operators can read either format at runtime regardless of which plugin compiled in. Operator convenience, not a configuration knob (lives in `pkg/persistence`, not exposed to `api/config`).

## Documentation

- **`docs/adr/0007-embedded-persistence-plugin-registration.md`** — Nygard format, alternatives (config string / manifest / build tags / reflection), consequences, risks. Status: `accepted` (born with implementation).
- **`docs/adr/0005-*.md`** flips `proposed` → `accepted` — v1 ships properly here.
- **`docs/adr/README.md`** index updated.

ADR-0006 (built-in vs IPC plugin transport) stays `proposed` — that's the body of the next PR series, where v1snap physically moves to `plugins/snapshot-v1/` and AOF gets built. ADR-0007 documents the registration model that move will use.

## Test plan

- [x] `go test -race ./...` — PASS
- [x] `go vet ./...` — PASS
- [x] `staticcheck ./...` — PASS
- [x] **5** registry tests in `api/persistence`: no provider → nil, register round-trip, double-register panics with both names, nil panics, Build plumbing routes through fake Source/Snapshotter.
- [x] **7** loader tests in `pkg/persistence`: DetectFormat for gob/v1/missing/short files, LoadFrom for both formats, target-clear semantics on mid-lifecycle reload, missing-file error.
- [ ] CI green on this PR before merge.

## Follow-up (ADR-0006 implementation)

- Move `pkg/persistence/v1snap/` → `plugins/snapshot-v1/`. Decide the layering rule (extract `*cache.SortedSet` to `api/cache.SortedSet`, OR relax the `plugins/ → api/*` rule for embedded plugins via an explicit ADR-0006 amendment).
- Add `plugins/aof-v1/` for AOF. Same registration pattern via parallel `RegisterAOFProvider` interface.
- Flip ADR-0006 to `accepted` when both plugins ship from the new location.

This PR is the contract layer; the move is the next layer.