### PR TITLE
feat(persistence): plugins self-configure via viper (ADR-0007) — drop format/file from api/config

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -20,21 +20,8 @@ const (
 	DefaultAddress          = "0.0.0.0"
 	DefaultPort             = 6379
 	DefaultLogLevel         = "info"
-	DefaultSnapshotFile     = "snapshot.dat"
 	DefaultSnapshotInterval = 5 * time.Minute
 	DefaultLoadOnStartup    = true
-	// DefaultSnapshotFormat is the on-disk snapshot format. "gob" is the
-	// legacy Go gob-encoded format; "v1" is the custom binary format
-	// described in ADR-0005 (varint, magic header, CRC32, optional zstd).
-	// Default stays "gob" until the migration window for existing
-	// deployments closes — flip to "v1" in a follow-up release.
-	DefaultSnapshotFormat = "gob"
-
-	// SnapshotFormatGob and SnapshotFormatV1 are the recognised values
-	// for PersistenceConfig.SnapshotFormat. Unknown values fall back
-	// to the gob shim with a warning at boot.
-	SnapshotFormatGob = "gob"
-	SnapshotFormatV1  = "v1"
 	DefaultMaxMemoryMB      = int64(1024)
 	DefaultEvictionPolicy   = "lru"
 	DefaultCacheShards      = 8
@@ -72,16 +59,17 @@ type ServerConfig struct {
 	RequirePass string `yaml:"require_pass" mapstructure:"require_pass"`
 }
 
-// PersistenceConfig holds persistence configuration.
+// PersistenceConfig holds the server-orchestration knobs for the
+// persistence subsystem. Plugin-specific keys (filenames, formats,
+// per-plugin tunables) live under plugins.config.<plugin-name> in
+// the YAML and are read by each plugin via pkg/config.Viper. The
+// server only owns the orchestration policy: whether to recover at
+// startup and how often to schedule periodic snapshot saves.
+//
+// See ADR-0007 for the rationale.
 type PersistenceConfig struct {
-	SnapshotFile     string        `yaml:"snapshot_file"     mapstructure:"snapshot_file"`
 	SnapshotInterval time.Duration `yaml:"snapshot_interval" mapstructure:"snapshot_interval"`
 	LoadOnStartup    bool          `yaml:"load_on_startup"   mapstructure:"load_on_startup"`
-	// SnapshotFormat selects the on-disk format. "gob" (default) keeps
-	// the legacy gob-encoded format; "v1" uses the format described in
-	// ADR-0005. Existing deployments stay on gob until a one-shot
-	// migration via the gocache-migrate CLI (ships in a follow-up).
-	SnapshotFormat string `yaml:"snapshot_format" mapstructure:"snapshot_format"`
 }
 
 // MemoryConfig holds memory management configuration.
@@ -131,10 +119,8 @@ func DefaultConfig() *Config {
 			LogLevel: DefaultLogLevel,
 		},
 		Persistence: PersistenceConfig{
-			SnapshotFile:     DefaultSnapshotFile,
 			SnapshotInterval: DefaultSnapshotInterval,
 			LoadOnStartup:    DefaultLoadOnStartup,
-			SnapshotFormat:   DefaultSnapshotFormat,
 		},
 		Memory: MemoryConfig{
 			MaxMemoryMB:          DefaultMaxMemoryMB,

--- a/api/persistence/registry.go
+++ b/api/persistence/registry.go
@@ -1,0 +1,100 @@
+package persistence
+
+import (
+	"fmt"
+	"sync"
+)
+
+// SnapshotProvider is the registration handle for an embedded snapshot
+// plugin (ADR-0007). Each plugin's init() calls RegisterSnapshotProvider
+// with a value of this type; cmd/server/main.go resolves the registered
+// provider via SnapshotProviderRegistered.
+//
+// Selection is done at compile time via blank imports of the desired
+// plugin package — there is no config string. Adding a new snapshot
+// backend is a new package + a new blank import, with no change to the
+// core surface.
+//
+// The provider is responsible for its own configuration, including hot
+// reload. Plugins typically read their config via the server's viper
+// instance (see pkg/config.Viper / pkg/config.OnReload) — that gives
+// each plugin its own subsection and watcher without dragging
+// plugin-specific keys into api/config. The server only knows that
+// "there is a snapshot provider"; it doesn't know what file format,
+// what filename, or what tuning knobs the plugin uses.
+//
+// AOF and replication will get parallel registration interfaces
+// (RegisterAOFProvider, RegisterReplicationSink) when those plugins
+// land — same pattern, different capability.
+type SnapshotProvider interface {
+	// Name identifies the provider for logs and diagnostics. Should
+	// be a stable plugin identifier (e.g. "v1-snapshot"), not a
+	// format string.
+	Name() string
+
+	// Build constructs the Source / Snapshotter pair for this provider.
+	// The plugin reads its own configuration before constructing,
+	// typically from the server's viper instance (see pkg/config.Viper).
+	// Build is called exactly once per server lifetime, after config
+	// load, before any cache traffic.
+	//
+	// Returns a non-nil error if the plugin cannot configure itself
+	// (e.g., required keys missing, file unwritable). The server
+	// surfaces the error and may continue without persistence
+	// depending on policy.
+	Build() (Source, Snapshotter, error)
+}
+
+var (
+	snapshotProviderMu sync.RWMutex
+	snapshotProvider   SnapshotProvider
+)
+
+// RegisterSnapshotProvider installs the embedded snapshot plugin.
+// Called from the plugin's init(). Exactly one provider may register
+// per binary — a second call panics with the conflicting plugin
+// names so the build misconfiguration surfaces at startup, not
+// silently as one plugin overwriting another.
+//
+// The build-time choice of which plugin to import determines which
+// provider runs. Multi-tenant binaries (two snapshot plugins coexisting)
+// would need a different registration model; this design assumes a
+// single canonical provider per binary, matching the "exactly one
+// snapshot strategy" reality of every production deployment.
+func RegisterSnapshotProvider(p SnapshotProvider) {
+	if p == nil {
+		panic("api/persistence: RegisterSnapshotProvider called with nil")
+	}
+	snapshotProviderMu.Lock()
+	defer snapshotProviderMu.Unlock()
+	if snapshotProvider != nil {
+		panic(fmt.Sprintf(
+			"api/persistence: snapshot provider already registered (%q); cannot register %q — exactly one provider per binary",
+			snapshotProvider.Name(), p.Name(),
+		))
+	}
+	snapshotProvider = p
+}
+
+// SnapshotProviderRegistered returns the registered provider, or nil if
+// no plugin was imported. Callers (cmd/server/main.go) treat nil as
+// "no snapshot persistence" and run the cache in ephemeral mode.
+//
+// The lookup is mutex-protected because tests may reset the registry
+// (see ResetSnapshotProviderForTest) — production-time access happens
+// once at startup, well after every plugin's init() has completed.
+func SnapshotProviderRegistered() SnapshotProvider {
+	snapshotProviderMu.RLock()
+	defer snapshotProviderMu.RUnlock()
+	return snapshotProvider
+}
+
+// ResetSnapshotProviderForTest clears the registered provider. Test-only
+// helper exposed so per-package tests that exercise registration can
+// run independently. Production code paths must not call this — the
+// global is intended to be set exactly once per process lifetime.
+func ResetSnapshotProviderForTest() {
+	snapshotProviderMu.Lock()
+	defer snapshotProviderMu.Unlock()
+	snapshotProvider = nil
+}

--- a/api/persistence/registry_test.go
+++ b/api/persistence/registry_test.go
@@ -1,0 +1,110 @@
+package persistence_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	apipersistence "gocache/api/persistence"
+)
+
+// fakeProvider is a test-only SnapshotProvider. Build returns a stub
+// Source/Snapshotter — registry tests don't exercise their behaviour,
+// only that registration and lookup correctly route the provider.
+type fakeProvider struct {
+	name      string
+	buildErr  error
+	buildCall int
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) Build() (apipersistence.Source, apipersistence.Snapshotter, error) {
+	f.buildCall++
+	if f.buildErr != nil {
+		return nil, nil, f.buildErr
+	}
+	return &fakeSource{}, &fakeSnap{}, nil
+}
+
+type fakeSource struct{}
+
+func (*fakeSource) Name() string { return "fake-src" }
+func (*fakeSource) Boot(_ context.Context) (apipersistence.BootResult, error) {
+	return apipersistence.BootResult{Mode: apipersistence.BootModeInitial}, nil
+}
+
+type fakeSnap struct{}
+
+func (*fakeSnap) Name() string { return "fake-snap" }
+func (*fakeSnap) SaveSnapshot(_ context.Context, _ apipersistence.SnapshotSource) error {
+	return nil
+}
+
+func TestRegistry_NoProvider_ReturnsNil(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	if got := apipersistence.SnapshotProviderRegistered(); got != nil {
+		t.Errorf("expected nil before any registration, got %v", got)
+	}
+}
+
+func TestRegistry_Register_RoundTrip(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	p := &fakeProvider{name: "test-provider"}
+	apipersistence.RegisterSnapshotProvider(p)
+
+	got := apipersistence.SnapshotProviderRegistered()
+	if got == nil {
+		t.Fatal("registered provider not returned")
+	}
+	if got.Name() != "test-provider" {
+		t.Errorf("name = %q, want test-provider", got.Name())
+	}
+
+	src, snap, err := got.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if src == nil || snap == nil {
+		t.Errorf("Build returned nils: src=%v snap=%v", src, snap)
+	}
+	if p.buildCall != 1 {
+		t.Errorf("buildCall = %d, want 1", p.buildCall)
+	}
+}
+
+func TestRegistry_DoubleRegister_Panics(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	apipersistence.RegisterSnapshotProvider(&fakeProvider{name: "first"})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on double-register, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value not a string: %T", r)
+		}
+		// Both names should appear so misconfiguration is obvious.
+		if !strings.Contains(msg, "first") || !strings.Contains(msg, "second") {
+			t.Errorf("panic message missing names: %s", msg)
+		}
+	}()
+	apipersistence.RegisterSnapshotProvider(&fakeProvider{name: "second"})
+}
+
+func TestRegistry_RegisterNil_Panics(t *testing.T) {
+	apipersistence.ResetSnapshotProviderForTest()
+	t.Cleanup(apipersistence.ResetSnapshotProviderForTest)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic on nil provider, got none")
+		}
+	}()
+	apipersistence.RegisterSnapshotProvider(nil)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"gocache/api/command"
-	apiconfig "gocache/api/config"
 	"gocache/api/crashdump"
 	"gocache/api/embedded"
 	"gocache/api/events"
@@ -28,7 +27,6 @@ import (
 	"gocache/pkg/logcollector"
 	serverOps "gocache/pkg/operations"
 	"gocache/pkg/persistence"
-	"gocache/pkg/persistence/v1snap"
 	"gocache/pkg/plugin/cmdhooks"
 	pluginmgr "gocache/pkg/plugin/manager"
 	"gocache/pkg/plugin/ophooks"
@@ -36,6 +34,13 @@ import (
 	"gocache/pkg/version"
 	"gocache/pkg/watch"
 	"gocache/pkg/workers"
+
+	// Embedded persistence plugin — registers itself via init() per
+	// ADR-0007. Selecting a different snapshot backend = swap this
+	// import for the new plugin's package. The plugin reads its own
+	// config from the server's viper (see pkg/config.Viper) so main.go
+	// stays plugin-agnostic.
+	_ "gocache/pkg/persistence/v1snap"
 
 	// Embedded plugins — compile-time-linked observability hooks that run
 	// before config.Load and survive panics. See pkg/embedded for details.
@@ -47,8 +52,8 @@ import (
 	_ "gocache/plugins/crashdump"
 	_ "gocache/plugins/otlp"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 // Entry-point defaults.
@@ -86,7 +91,6 @@ func main() {
 	pflag.String("config", defaultConfigFile, "path to config file (.yaml or .json)")
 	pflag.String("address", "", "server listen address (overrides config)")
 	pflag.Int("port", 0, "server listen port (overrides config)")
-	pflag.String("snapshot-file", "", "snapshot file path (overrides config)")
 	pflag.Duration("snapshot-interval", 0, "snapshot save interval (overrides config)")
 	pflag.Bool("load-on-startup", true, "load snapshot on startup (overrides config)")
 	pflag.Int64("max-memory-mb", 0, "max memory in MB (overrides config)")
@@ -211,7 +215,7 @@ func main() {
 	logCollector.AddSource("server", logPipeR)
 
 	// Initialize the server (before plugins so we have CoreCommandNames).
-	srv := server.New(cfg.Server.GetAddr(), cacheInstance, engineInstance, cfg.Persistence.SnapshotFile, cfg.Server.RequirePass, blockingRegistry, watchManager)
+	srv := server.New(cfg.Server.GetAddr(), cacheInstance, engineInstance, cfg.Server.RequirePass, blockingRegistry, watchManager)
 	srv.SetEmitter(eventBus)
 	srv.SetTracker(tracker)
 
@@ -254,13 +258,11 @@ func main() {
 	// coordinator runs in pass-through mode (no sinks registered) until
 	// a future PR adds the AOF / snapshot sink plugins.
 	//
-	// The snapshot format is selected by config: "gob" (legacy) or
-	// "v1" (ADR-0005 binary format with optional zstd). Both backends
-	// implement Source + Snapshotter, so SAVE, scheduled snapshots,
-	// and shutdown final-snapshot all run through the coordinator.
-	// snapSetFilename collects the per-backend hot-reload knobs so
-	// OnConfigChange can update both halves atomically.
-	snapSource, snapSnapshotter, snapSetFilename := buildSnapshotBackend(ctx, cfg.Persistence.SnapshotFormat, cfg.Persistence.SnapshotFile)
+	// The active snapshot backend comes from whichever embedded plugin
+	// was blank-imported above (ADR-0007). The plugin self-configures
+	// from the server's viper instance; main.go knows nothing about
+	// formats, files, or per-plugin tunables.
+	snapSource, snapSnapshotter := buildSnapshotBackend(ctx)
 	coordinator := persistence.New(snapSource)
 	coordinator.RegisterSnapshotter(snapSnapshotter)
 	srv.SetPersistenceFeed(coordinator)
@@ -270,7 +272,6 @@ func main() {
 	_ = bootstate.Write(bootStateFile, stageSnapshotLoad)
 	if cfg.Persistence.LoadOnStartup {
 		snapOp := tracker.Start(ops.TypeSnapshot, bootOp.ID)
-		snapOp.Enrich(command.FileKey, cfg.Persistence.SnapshotFile)
 		snapOp.Enrich(command.TriggerKey, "startup")
 		snapCtx := ops.WithContext(ctx, snapOp)
 		if opHookExec != nil && opHookExec.HasAny() {
@@ -286,7 +287,7 @@ func main() {
 			eventBus.Emit(events.NewOperationComplete(snapOp.ID, string(snapOp.Type), uint64(snapOp.Duration().Nanoseconds()), "failed", err.Error(), snapOp.ContextSnapshot(false)))
 			tracker.Fail(snapOp.ID, err.Error())
 		} else {
-			logger.Info(snapCtx).Str("file", cfg.Persistence.SnapshotFile).Msg("snapshot loaded")
+			logger.Info(snapCtx).Msg("snapshot loaded")
 			snapOp.Complete()
 			if opHookExec != nil {
 				opHookExec.RunCompleteHooks(snapOp)
@@ -311,7 +312,6 @@ func main() {
 	snapshotWorker := workers.NewSnapshotWorker(
 		cacheInstance, engineInstance,
 		cfg.Persistence.SnapshotInterval,
-		cfg.Persistence.SnapshotFile,
 	)
 	cleanupWorker := workers.NewCleanupWorker(cacheInstance, engineInstance, cfg.Workers.CleanupInterval)
 	cleanupWorker.SetPersistenceFeed(coordinator)
@@ -327,11 +327,13 @@ func main() {
 	snapshotWorker.Start(ctx)
 	cleanupWorker.Start(ctx)
 
-	// Hot reload: config changes create config_reload operations.
-	v.WatchConfig()
-	v.OnConfigChange(func(e fsnotify.Event) {
+	// Hot reload: server-orchestration knobs only. Plugins subscribe
+	// to config.OnReload independently (per ADR-0007) and handle their
+	// own re-config there. Viper.WatchConfig + viper.OnConfigChange are
+	// installed by config.Load — this callback is one of many that the
+	// multiplexer fans out to.
+	config.OnReload(func(_ *viper.Viper) {
 		reloadOp := tracker.Start(ops.TypeConfigReload, "")
-		reloadOp.Enrich(command.FileKey, e.Name)
 		reloadCtx := ops.WithContext(context.Background(), reloadOp)
 		if opHookExec != nil && opHookExec.HasAny() {
 			opHookExec.RunStartHooks(reloadCtx, reloadOp)
@@ -348,7 +350,7 @@ func main() {
 			tracker.Fail(reloadOp.ID, err.Error())
 			return
 		}
-		logger.Info(reloadCtx).Str("file", e.Name).Msg("config reloaded")
+		logger.Info(reloadCtx).Msg("config reloaded")
 
 		prev := cfgPtr.Load()
 		if newCfg.Server.GetAddr() != prev.Server.GetAddr() {
@@ -356,8 +358,6 @@ func main() {
 		}
 
 		snapshotWorker.UpdateInterval(newCfg.Persistence.SnapshotInterval)
-		snapshotWorker.UpdateFile(newCfg.Persistence.SnapshotFile)
-		snapSetFilename(newCfg.Persistence.SnapshotFile)
 		cleanupWorker.UpdateInterval(newCfg.Workers.CleanupInterval)
 		cacheInstance.SetMemoryLimit(
 			reloadCtx,
@@ -481,7 +481,7 @@ func handleShutdown(
 	// sink's flush goroutine drains its buffer and Sink.Close returns.
 	coordinator.Stop(shutdownCtx)
 
-	logger.Info(shutdownCtx).Str("step", "4/6").Str("file", cfg.Persistence.SnapshotFile).Msg("saving final snapshot")
+	logger.Info(shutdownCtx).Str("step", "4/6").Msg("saving final snapshot")
 	if err := coordinator.Snapshot(shutdownCtx, cacheInstance); err != nil {
 		logger.Warn(shutdownCtx).Err(err).Msg("failed to save final snapshot")
 	} else {
@@ -502,34 +502,26 @@ func handleShutdown(
 	logger.Info(shutdownCtx).Str("step", "6/6").Msg("shutdown complete")
 }
 
-// buildSnapshotBackend selects the on-disk format dictated by config
-// and returns Source + Snapshotter implementing it, plus a setter that
-// propagates a new filename to whichever backend is in use. Unknown
-// format strings fall back to the gob shim with a warning so a typo in
-// snapshot_format doesn't take the server offline at boot.
-func buildSnapshotBackend(ctx context.Context, format, filename string) (apipersistence.Source, apipersistence.Snapshotter, func(string)) {
-	switch format {
-	case apiconfig.SnapshotFormatV1:
-		src := v1snap.NewSource(filename)
-		snap := v1snap.NewSnapshotter(filename)
-		setBoth := func(f string) {
-			src.SetFilename(f)
-			snap.SetFilename(f)
-		}
-		logger.Info(ctx).Str("format", format).Msg("persistence: snapshot backend selected")
-		return src, snap, setBoth
-
-	case apiconfig.SnapshotFormatGob, "":
-		shim := persistence.NewGobSource(filename)
-		logger.Info(ctx).Str("format", apiconfig.SnapshotFormatGob).Msg("persistence: snapshot backend selected")
-		return shim, shim, shim.SetFilename
-
-	default:
-		shim := persistence.NewGobSource(filename)
-		logger.Warn(ctx).
-			Str("requested", format).
-			Str("fallback", apiconfig.SnapshotFormatGob).
-			Msg("persistence: unknown snapshot_format, falling back to gob")
-		return shim, shim, shim.SetFilename
+// buildSnapshotBackend resolves the registered embedded snapshot
+// plugin (ADR-0007) and asks it to build the Source + Snapshotter
+// pair. The plugin owns its own configuration: where to read/write,
+// what format, what tunables. main.go knows nothing about any of it.
+//
+// Returns nil source + snapshotter when no plugin was compiled in;
+// the Coordinator handles nil gracefully (no recovery + ErrNoSnapshotter
+// from save calls). A warning surfaces the misbuild so it doesn't
+// pass silently.
+func buildSnapshotBackend(ctx context.Context) (apipersistence.Source, apipersistence.Snapshotter) {
+	provider := apipersistence.SnapshotProviderRegistered()
+	if provider == nil {
+		logger.Warn(ctx).Msg("persistence: no snapshot plugin compiled in; snapshots disabled")
+		return nil, nil
 	}
+	src, snap, err := provider.Build()
+	if err != nil {
+		logger.Error(ctx).Err(err).Str("plugin", provider.Name()).Msg("persistence: snapshot plugin Build failed; snapshots disabled")
+		return nil, nil
+	}
+	logger.Info(ctx).Str("plugin", provider.Name()).Msg("persistence: snapshot backend selected")
+	return src, snap
 }

--- a/docs/adr/0005-snapshot-wire-and-file-format.md
+++ b/docs/adr/0005-snapshot-wire-and-file-format.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0005 Snapshot wire and file format
 description: Snapshots use a custom binary format (varint, magic header, CRC32, optional zstd) replacing Go's gob encoder
-status: proposed
+status: accepted
 date: 2026-05-03
 deciders: [witherxse]
 related:

--- a/docs/adr/0007-embedded-persistence-plugin-self-config.md
+++ b/docs/adr/0007-embedded-persistence-plugin-self-config.md
@@ -1,0 +1,109 @@
+---
+title: ADR-0007 Embedded persistence plugins self-configure via viper
+description: Embedded persistence plugins register at init time, read their own configuration from the server's viper, and handle their own hot reload — server config and the api/persistence surface stay free of plugin-internal keys
+status: accepted
+date: 2026-05-04
+deciders: [witherxse]
+related:
+  - ADR-0001-persistence-as-pluggable-log-snapshot
+  - ADR-0002-source-sink-contract
+  - ADR-0005-snapshot-wire-and-file-format
+  - ADR-0006-builtin-vs-third-party-transport
+---
+
+# ADR-0007: Embedded persistence plugins self-configure via viper
+
+## Context
+
+ADR-0001 established that persistence is a pluggable subsystem and ADR-0002 split the contract into Source/Sink/Snapshotter. ADR-0005 specified the v1 binary snapshot format. The remaining question is *how the server discovers and configures the active persistence plugin*.
+
+Earlier iterations exposed plugin internals through `api/config.PersistenceConfig`: a `SnapshotFormat` string field selecting `"gob"` or `"v1"`, plus a `SnapshotFile` field holding the on-disk path. Both leaked plugin-internal concerns into the public configuration surface plugins import. The microkernel premise of the persistence-as-plugin arc is the opposite — the core knows there *is* a snapshot capability; it does not know what file the plugin writes, what format it writes in, or what tuning knobs the plugin exposes.
+
+The original feedback: *"plugins should be self configurable and self sufficient, server should only call their api but it's them who decide about their config, who decide about formatting, who decide about what they do, api persistance was suppoused to be enly thin api layer, abstraction between server and persistance plugin, but server doesn't decide about anything more than calling their methods, deciding priority, when would they be invoked"*.
+
+Plus: *"why plugins cant use viper to handle hot reloads and define their config themselves?"* — pointing at the existing config loader as the obvious mechanism rather than a custom shim.
+
+## Decision
+
+Embedded persistence plugins register themselves with the persistence layer at package-init time, then self-configure by reading their own subsection of the server's viper. The server exposes the viper handle (`pkg/config.Viper`) and a reload multiplexer (`pkg/config.OnReload`). Plugins do everything else.
+
+`api/persistence` carries only the contract surface:
+
+```go
+type SnapshotProvider interface {
+    Name() string
+    Build() (Source, Snapshotter, error)
+}
+
+RegisterSnapshotProvider(p)        // called from plugin's init()
+SnapshotProviderRegistered() Provider  // returns nil if none compiled in
+```
+
+`api/config.PersistenceConfig` shrinks to server-orchestration only:
+
+```go
+type PersistenceConfig struct {
+    LoadOnStartup    bool          // server: do we call BootInto at startup?
+    SnapshotInterval time.Duration // server: how often does the scheduler tick?
+}
+```
+
+A plugin's `init()` calls `RegisterSnapshotProvider(&provider{})`. The provider's `Build()` runs after `pkg/config.Load`, reads the plugin's own subsection (`plugins.config.<plugin-name>.*`), sets defaults, and returns the wired Source/Snapshotter. Hot reload is registered via `pkg/config.OnReload(fn)` — the plugin's callback re-reads its keys and updates its in-memory state (e.g. `Source.SetFilename`, `Snapshotter.SetFilename`).
+
+Selection is compile-time: `cmd/server/main.go` blank-imports the desired plugin package. Exactly one provider per binary; a second registration panics with both plugin names so the misbuild surfaces at startup.
+
+The `LOAD_SNAPSHOT` runtime command is removed. Its only justification was a debug/test-time reload, and it required the server to know the plugin's working directory (for path-traversal sanitization). That's plugin-internal knowledge. If a future deployment needs runtime reload, the right path is a plugin-provided command (microkernel pattern), not a core RESP command.
+
+## Alternatives Considered
+
+### Alternative 1: Format string in `api/config` (the rejected status quo)
+
+- **Pros**: Simplest mechanically. Users edit one YAML key to switch backends.
+- **Cons**: Adding a new persistence backend (Postgres replication, Kafka, S3 archive) means adding a string to `api/config`, which means the core knows about every plugin. Inverts the dependency we want — the contract surface should not enumerate implementations.
+- **Why not**: Direct user feedback rejected it during PR review of #67/#68. The microkernel boundary belongs at the contract surface, not inside an enum of implementations.
+
+### Alternative 2: Server pushes config blobs to plugins
+
+A `Build(rawConfig map[string]any)` signature where the server reads YAML, finds the subsection by plugin name, and hands a typed blob to each plugin.
+
+- **Pros**: Plugins don't need to import viper. Server stays as the single config reader.
+- **Cons**: Server still has to know "plugin subsections live at `plugins.config.<name>`", and it has to define the schema for that map. The server is still the central authority on plugin config; the plugin is just a passive recipient.
+- **Why not**: Doesn't go far enough. The user's feedback was *plugins decide about their config* — pushing a blob still has the server in the loop. Letting plugins read viper directly is the cleaner separation: the server merely exposes "here's the config source," and the plugin owns the rest.
+
+### Alternative 3: Each plugin owns its own YAML file
+
+`/etc/gocache/plugins/snapshot-v1.yaml`, with the plugin loading independently.
+
+- **Pros**: Maximally isolated — plugin owns its file end to end.
+- **Cons**: Multiple watchers, multiple parsers, fragmented operator UX. Operators with one logical service now manage N config files. Hot reload semantics differ per plugin. No single source of truth.
+- **Why not**: Optimizes for a separation that hurts ops more than it helps architecture. The shared viper instance gives plugins their own subsections without the multi-file tax.
+
+### Alternative 4: Build tags only (no runtime registry)
+
+- **Pros**: Compile-time conditional inclusion, zero runtime cost.
+- **Cons**: Build tags don't run any registration logic; the plugin still has to expose its types to `cmd/server/main.go`, which means `main.go` has to know the plugin's package name and constructor signatures. That re-creates the central-enumeration problem build tags were supposed to fix.
+- **Why not**: Solves the wrong layer. Blank imports + `init()` registration combines compile-time selection with runtime resolution in one mechanism.
+
+## Consequences
+
+### Positive
+
+- `api/config` no longer knows persistence implementation details. Adding a new snapshot or AOF backend is a new package + a new blank import in `main.go`; no core change.
+- Plugins use viper natively — defaults, types, env var overrides, hot reload via fsnotify all come for free. No reinventing config infrastructure.
+- The reload multiplexer (`pkg/config.OnReload`) lets multiple plugins react to the same config-file change independently without stepping on each other (viper's native `OnConfigChange` is single-callback).
+- Pattern extends cleanly: `RegisterAOFProvider` for the AOF plugin, `RegisterReplicationSink` for replication, etc. Each capability gets its own narrow registration interface; plugins implement whichever they care about.
+- Compile-time enforcement of "exactly one provider per binary" — the panic-on-double-register surfaces conflicts at startup, not silently.
+- `LOAD_SNAPSHOT` removal eliminates the worst leak: a server-level command needing plugin-internal knowledge (working directory). If reload is needed later, it lands as a plugin command.
+
+### Negative
+
+- The build configuration becomes load-bearing for "which persistence backend ships." A deployment that swaps backends must rebuild — not a config flip. Acceptable for the project's audience (single-user / research / thesis); operators who want runtime backend switching would need something heavier.
+- Operators who previously used `LOAD_SNAPSHOT` to reload a different snapshot file at runtime have to restart the server (or wait for a future plugin command).
+- Plugins that want viper now depend on `pkg/config` — which is fine for embedded plugins (they live in `pkg/`) but means the embedded-vs-IPC layering rule (ADR-0006, still proposed) needs to acknowledge this dependency explicitly when those plugins physically move to `plugins/` later.
+
+### Risks
+
+- **Risk**: Two embedded snapshot plugins compiled in by accident → panic at startup. **Mitigation**: The panic message names both plugins so the misconfiguration is immediately obvious. Build hygiene (separate cmd/server build for each plugin, or a single canonical default) keeps this rare.
+- **Risk**: No plugin compiled in → server runs without persistence and silently drops state on restart. **Mitigation**: `cmd/server/main.go` logs a `persistence: no snapshot plugin compiled in; snapshots disabled` warning at startup so the operator notices. Loud enough to catch a misbuild.
+- **Risk**: A plugin's reload callback panics during fan-out and breaks subsequent plugins' callbacks. **Mitigation**: Future enhancement — wrap each callback invocation in a recover. Today the multiplexer trusts callbacks (matches the pattern in the rest of the embedded plugin system).
+- **Risk**: `viper.Sub` (used by plugins to scope to their subsection) returns nil if the subsection doesn't exist; a careless plugin would NPE on first read. **Mitigation**: Plugins read keys via the full path (`v.GetString("plugins.config.snapshot-v1.file")`) rather than via `Sub`, so missing subsections gracefully return defaults.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,8 +34,9 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0002](0002-source-sink-contract.md) | Source/Sink contract with BootMode trichotomy | accepted | 2026-05-03 |
 | [0003](0003-mutation-feed-and-fsync.md) | Mutation feed: group commit + fsync policy | accepted | 2026-05-03 |
 | [0004](0004-command-namespacing.md) | Persistence command namespacing | proposed | 2026-05-03 |
-| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | proposed | 2026-05-03 |
+| [0005](0005-snapshot-wire-and-file-format.md) | Snapshot wire and file format | accepted | 2026-05-03 |
 | [0006](0006-builtin-vs-third-party-transport.md) | Built-in vs third-party plugin transport | proposed | 2026-05-03 |
+| [0007](0007-embedded-persistence-plugin-self-config.md) | Embedded persistence plugins self-configure via viper | accepted | 2026-05-04 |
 
 ## Writing a new ADR
 

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -69,8 +69,7 @@ type Context struct {
 	WatchManager     *watch.Manager
 
 	// Evaluator-level config, set by the pipeline before dispatch.
-	SnapshotFile string
-	RequirePass  string
+	RequirePass string
 
 	// Sharding routing — set by the evaluator before invoking the handler
 	// based on the command's Spec.KeyArgIndex / Spec.MultiKey.
@@ -159,7 +158,6 @@ func (c *Context) Reset() {
 	c.Transaction = nil
 	c.BlockingRegistry = nil
 	c.WatchManager = nil
-	c.SnapshotFile = ""
 	c.RequirePass = ""
 	c.Shard = 0
 	c.MultiKey = false

--- a/pkg/command/context_test.go
+++ b/pkg/command/context_test.go
@@ -32,7 +32,6 @@ func TestContext_Reset(t *testing.T) {
 		Transaction:      transaction.NewManager(),
 		BlockingRegistry: blocking.NewRegistry(),
 		WatchManager:     watch.NewManager(),
-		SnapshotFile:     "/tmp/snap.dat",
 		RequirePass:      "secret",
 		EvalFn: func(_ context.Context, _ *clientctx.ClientContext, _ string, _ []string, _ bool) Result {
 			return Result{}
@@ -57,7 +56,6 @@ func TestContext_Reset(t *testing.T) {
 		{"Transaction", ctx.Transaction == nil},
 		{"BlockingRegistry", ctx.BlockingRegistry == nil},
 		{"WatchManager", ctx.WatchManager == nil},
-		{"SnapshotFile", ctx.SnapshotFile == ""},
 		{"RequirePass", ctx.RequirePass == ""},
 		{"EvalFn", ctx.EvalFn == nil},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	apiconfig "gocache/api/config"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -77,10 +78,8 @@ func Load(flags *pflag.FlagSet) (*Config, *viper.Viper, error) {
 	v.SetDefault("server.port", apiconfig.DefaultPort)
 	v.SetDefault("server.log_level", apiconfig.DefaultLogLevel)
 	v.SetDefault("server.require_pass", "")
-	v.SetDefault("persistence.snapshot_file", apiconfig.DefaultSnapshotFile)
 	v.SetDefault("persistence.snapshot_interval", apiconfig.DefaultSnapshotInterval)
 	v.SetDefault("persistence.load_on_startup", apiconfig.DefaultLoadOnStartup)
-	v.SetDefault("persistence.snapshot_format", apiconfig.DefaultSnapshotFormat)
 	v.SetDefault("memory.max_memory_mb", apiconfig.DefaultMaxMemoryMB)
 	v.SetDefault("memory.eviction_policy", apiconfig.DefaultEvictionPolicy)
 	v.SetDefault("memory.cache_shards", apiconfig.DefaultCacheShards)
@@ -127,7 +126,6 @@ func Load(flags *pflag.FlagSet) (*Config, *viper.Viper, error) {
 	bindFlag(v, "server.address", flags, "address")
 	bindFlag(v, "server.port", flags, "port")
 	bindFlag(v, "server.log_level", flags, "log-level")
-	bindFlag(v, "persistence.snapshot_file", flags, "snapshot-file")
 	bindFlag(v, "persistence.snapshot_interval", flags, "snapshot-interval")
 	bindFlag(v, "persistence.load_on_startup", flags, "load-on-startup")
 	bindFlag(v, "memory.max_memory_mb", flags, "max-memory-mb")
@@ -135,7 +133,22 @@ func Load(flags *pflag.FlagSet) (*Config, *viper.Viper, error) {
 	bindFlag(v, "workers.cleanup_interval", flags, "cleanup-interval")
 
 	cfg, err := Unmarshal(v)
-	return cfg, v, err
+	if err != nil {
+		return nil, v, err
+	}
+
+	// Wire viper to the global handle and the reload multiplexer so
+	// embedded plugins (and other callers) can subscribe to config
+	// reloads via OnReload. Viper's native OnConfigChange is
+	// single-callback; we install one fan-out handler here and let
+	// callers register independent callbacks against it.
+	setServerViper(v)
+	v.OnConfigChange(func(_ fsnotify.Event) {
+		fireReload(v)
+	})
+	v.WatchConfig()
+
+	return cfg, v, nil
 }
 
 // Reload re-reads the current Viper state into a fresh Config struct.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,9 +38,6 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.Server.Port != 6379 {
 		t.Errorf("expected port 6379, got %d", cfg.Server.Port)
 	}
-	if cfg.Persistence.SnapshotFile != "snapshot.dat" {
-		t.Errorf("expected snapshot.dat, got %s", cfg.Persistence.SnapshotFile)
-	}
 	if cfg.Persistence.SnapshotInterval != 5*time.Minute {
 		t.Errorf("expected 5m, got %v", cfg.Persistence.SnapshotInterval)
 	}
@@ -71,9 +68,6 @@ func TestLoad_YAML(t *testing.T) {
 	if cfg.Server.Port != 7379 {
 		t.Errorf("expected 7379, got %d", cfg.Server.Port)
 	}
-	if cfg.Persistence.SnapshotFile != "yaml_test.dat" {
-		t.Errorf("expected yaml_test.dat, got %s", cfg.Persistence.SnapshotFile)
-	}
 	if cfg.Persistence.SnapshotInterval != 10*time.Minute {
 		t.Errorf("expected 10m, got %v", cfg.Persistence.SnapshotInterval)
 	}
@@ -103,9 +97,6 @@ func TestLoad_JSON(t *testing.T) {
 	}
 	if cfg.Server.Port != 7379 {
 		t.Errorf("expected 7379, got %d", cfg.Server.Port)
-	}
-	if cfg.Persistence.SnapshotFile != "json_test.dat" {
-		t.Errorf("expected json_test.dat, got %s", cfg.Persistence.SnapshotFile)
 	}
 	if cfg.Persistence.SnapshotInterval != 10*time.Minute {
 		t.Errorf("expected 10m, got %v", cfg.Persistence.SnapshotInterval)

--- a/pkg/config/viper_handle.go
+++ b/pkg/config/viper_handle.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/spf13/viper"
+)
+
+// Viper returns the server's viper instance, or nil before Load has run.
+// Embedded plugins (per ADR-0007) use it to read their own config
+// sub-section and to subscribe to hot reload via OnReload.
+//
+// Returns nil during plugin init() because Load runs from main()
+// after every package's init has fired. Plugins that need viper
+// at boot time grab it inside SnapshotProvider.Build, which is
+// called by main.go after Load completes.
+func Viper() *viper.Viper {
+	return serverViper.Load()
+}
+
+var serverViper atomic.Pointer[viper.Viper]
+
+// setServerViper installs the global viper handle. Called by Load
+// once viper is fully wired (defaults + flags + env + file + watch).
+func setServerViper(v *viper.Viper) {
+	serverViper.Store(v)
+}
+
+// OnReload registers fn to be invoked whenever the server's viper
+// reloads its config (fsnotify-driven, fired by viper's own
+// OnConfigChange). Multiple plugins can register independent
+// callbacks via this multiplexer — viper's native OnConfigChange
+// is single-callback-per-instance, so the server hijacks it once
+// in Load and fans out to every registered callback here.
+//
+// The callback runs on viper's reload goroutine. Implementations
+// should be quick — typical use is "re-read my subsection, update
+// internal state". Hot-path work belongs elsewhere.
+//
+// Safe to call from init() (registration is just an append) or
+// from Build (after Load). Reload events fire from Load onwards;
+// callbacks registered before Load will simply receive every
+// future reload.
+func OnReload(fn func(*viper.Viper)) {
+	reloadHooksMu.Lock()
+	defer reloadHooksMu.Unlock()
+	reloadHooks = append(reloadHooks, fn)
+}
+
+var (
+	reloadHooksMu sync.Mutex
+	reloadHooks   []func(*viper.Viper)
+)
+
+// fireReload invokes every registered reload callback with v. Called
+// by the OnConfigChange handler installed by Load. Snapshots the
+// callback list under the mutex so registrations during fan-out
+// don't race the iteration.
+func fireReload(v *viper.Viper) {
+	reloadHooksMu.Lock()
+	fns := make([]func(*viper.Viper), len(reloadHooks))
+	copy(fns, reloadHooks)
+	reloadHooksMu.Unlock()
+
+	for _, fn := range fns {
+		fn(v)
+	}
+}
+
+// resetReloadHooksForTest clears the registered reload callbacks.
+// Test-only helper exposed so per-package tests can isolate their
+// registrations. Production code must not call this — the global
+// is intended to be append-only across the process lifetime.
+func resetReloadHooksForTest() {
+	reloadHooksMu.Lock()
+	defer reloadHooksMu.Unlock()
+	reloadHooks = nil
+}
+
+// SetViperForTest installs v as the global server viper for the
+// duration of a test. Returns the previous value so callers can
+// restore state via t.Cleanup. Only embedded plugin tests should
+// reach for this — production code paths set the viper exactly
+// once via pkg/config.Load.
+func SetViperForTest(v *viper.Viper) (prev *viper.Viper) {
+	prev = serverViper.Load()
+	serverViper.Store(v)
+	return prev
+}
+
+// FireReloadForTest invokes registered reload callbacks with v.
+// Test-only helper for plugins that want to verify their
+// OnReload-registered handler runs without standing up a real
+// fsnotify pipeline.
+func FireReloadForTest(v *viper.Viper) {
+	fireReload(v)
+}

--- a/pkg/config/viper_handle_test.go
+++ b/pkg/config/viper_handle_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Note: these tests use unexported helpers (setServerViper, fireReload,
+// resetReloadHooksForTest) so they live in the config package proper
+// rather than config_test.
+
+func TestViper_NilBeforeSet(t *testing.T) {
+	// Snapshot+restore the global so test order doesn't matter.
+	prev := serverViper.Load()
+	t.Cleanup(func() { serverViper.Store(prev) })
+
+	serverViper.Store(nil)
+	if got := Viper(); got != nil {
+		t.Errorf("expected nil before setServerViper, got %v", got)
+	}
+}
+
+func TestViper_RoundTrip(t *testing.T) {
+	prev := serverViper.Load()
+	t.Cleanup(func() { serverViper.Store(prev) })
+
+	v := viper.New()
+	setServerViper(v)
+	if got := Viper(); got != v {
+		t.Errorf("Viper() = %v, want %v", got, v)
+	}
+}
+
+func TestOnReload_FanOut(t *testing.T) {
+	resetReloadHooksForTest()
+	t.Cleanup(resetReloadHooksForTest)
+
+	var (
+		mu    sync.Mutex
+		hits  []string
+	)
+	OnReload(func(_ *viper.Viper) {
+		mu.Lock()
+		defer mu.Unlock()
+		hits = append(hits, "a")
+	})
+	OnReload(func(_ *viper.Viper) {
+		mu.Lock()
+		defer mu.Unlock()
+		hits = append(hits, "b")
+	})
+
+	fireReload(viper.New())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 hits, got %d", len(hits))
+	}
+	if hits[0] != "a" || hits[1] != "b" {
+		t.Errorf("hits = %v, want [a b]", hits)
+	}
+}
+
+func TestOnReload_PassesViper(t *testing.T) {
+	resetReloadHooksForTest()
+	t.Cleanup(resetReloadHooksForTest)
+
+	v := viper.New()
+	v.Set("test.key", "test-value")
+
+	var got string
+	OnReload(func(rv *viper.Viper) {
+		got = rv.GetString("test.key")
+	})
+	fireReload(v)
+	if got != "test-value" {
+		t.Errorf("callback did not receive viper instance: got %q", got)
+	}
+}
+
+func TestOnReload_RegistrationDuringFanOutDoesNotRace(t *testing.T) {
+	// A callback that registers another callback should not race or
+	// reorder — fireReload snapshots the slice before iterating.
+	resetReloadHooksForTest()
+	t.Cleanup(resetReloadHooksForTest)
+
+	var firstFired, secondFired bool
+	OnReload(func(_ *viper.Viper) {
+		firstFired = true
+		// Register a second callback during the fan-out.
+		OnReload(func(_ *viper.Viper) {
+			secondFired = true
+		})
+	})
+
+	fireReload(viper.New())
+	if !firstFired {
+		t.Error("first callback did not fire")
+	}
+	// Second callback should NOT have fired this round — registered
+	// after the snapshot was taken. It will fire on the next reload.
+	if secondFired {
+		t.Error("second callback fired during the same round it was registered")
+	}
+
+	fireReload(viper.New())
+	if !secondFired {
+		t.Error("second callback did not fire on the next round")
+	}
+}

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -75,7 +75,6 @@ type BaseEvaluator struct {
 	transactionManager *transaction.Manager
 	handlers           map[string]command.Handler
 	specs              map[string]command.Spec
-	snapshotFile       string
 	requirePass        string
 	blockingRegistry   *blocking.Registry
 	watchManager       *watch.Manager
@@ -88,14 +87,13 @@ type BaseEvaluator struct {
 	snapshotInvoker    command.SnapshotInvoker
 }
 
-func New(c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *BaseEvaluator {
+func New(c *cache.Cache, e *engine.Engine, requirePass string, br *blocking.Registry, wm *watch.Manager) *BaseEvaluator {
 	b := &BaseEvaluator{
 		cache:              c,
 		engine:             e,
 		transactionManager: transaction.NewManager(),
 		handlers:           make(map[string]command.Handler),
 		specs:              make(map[string]command.Spec),
-		snapshotFile:       snapshotFile,
 		requirePass:        requirePass,
 		blockingRegistry:   br,
 		watchManager:       wm,
@@ -372,7 +370,6 @@ func (b *BaseEvaluator) fillCmdCtx(c *command.Context, ctx *clientctx.ClientCont
 	c.Transaction = b.transactionManager
 	c.BlockingRegistry = b.blockingRegistry
 	c.WatchManager = b.watchManager
-	c.SnapshotFile = b.snapshotFile
 	c.RequirePass = b.requirePass
 	c.MultiKey = spec.MultiKey
 	switch {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -25,7 +25,7 @@ func newTestEvaluator() (*BaseEvaluator, *engine.Engine, *serverOps.Tracker) {
 	go e.Run()
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
-	eval := New(c, e, "test.dat", "", br, wm)
+	eval := New(c, e, "", br, wm)
 	tracker := serverOps.NewTracker()
 	eval.SetTracker(tracker)
 	return eval, e, tracker

--- a/pkg/evaluator/readonly_test.go
+++ b/pkg/evaluator/readonly_test.go
@@ -84,8 +84,7 @@ func TestSpec_ReadOnly_Classification(t *testing.T) {
 		resp.CmdMulti:        false,
 		resp.CmdDiscard:      false,
 		resp.CmdExec:         false,
-		resp.CmdSnapshot:     false,
-		resp.CmdLoadSnapshot: false,
+		resp.CmdSnapshot: false,
 
 		// Server
 		resp.CmdDBSize:   true,

--- a/pkg/persistence/v1snap/init.go
+++ b/pkg/persistence/v1snap/init.go
@@ -1,0 +1,93 @@
+package v1snap
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+
+	"gocache/api/logger"
+	apipersistence "gocache/api/persistence"
+	pkgconfig "gocache/pkg/config"
+)
+
+// init registers v1snap as the embedded snapshot plugin per ADR-0007.
+// cmd/server/main.go blank-imports this package to wire the v1 backend
+// into the server; resolution happens via
+// api/persistence.SnapshotProviderRegistered.
+//
+// A second persistence plugin compiled into the same binary will panic
+// at registration time — see api/persistence.RegisterSnapshotProvider.
+func init() {
+	apipersistence.RegisterSnapshotProvider(&provider{})
+}
+
+// configKey is the YAML / viper key prefix where this plugin reads its
+// own configuration. The full key (e.g. plugins.config.snapshot-v1.file)
+// is the convention for embedded persistence plugins; each plugin
+// claims a sub-key under plugins.config.<plugin-name>.
+const configKey = "plugins.config.snapshot-v1"
+
+// keyFile is the plugin's filename setting under configKey.
+const keyFile = "file"
+
+// defaultFile is the plugin's default on-disk path. Operators override
+// via plugins.config.snapshot-v1.file in YAML, the equivalent
+// GOCACHE_PLUGINS_CONFIG_SNAPSHOT-V1_FILE env var, or directly through
+// viper.Set in tests.
+const defaultFile = "snapshot.dat"
+
+// provider is the bridge between v1snap's concrete Source / Snapshotter
+// types and the api/persistence.SnapshotProvider interface. It owns the
+// running Source and Snapshotter so the hot-reload callback can update
+// their filename on the fly without rebuilding either.
+type provider struct {
+	src  *Source
+	snap *Snapshotter
+}
+
+// Name implements api/persistence.SnapshotProvider. Stable identifier
+// used for boot-time logs.
+func (provider) Name() string { return "v1-snapshot" }
+
+// Build reads the plugin's configuration from the server's viper,
+// constructs Source + Snapshotter pointing at the configured file,
+// and registers a hot-reload callback so config changes propagate
+// to the running halves without a server restart.
+//
+// Returns an error if viper isn't available — Build is meant to be
+// called after pkg/config.Load runs (which wires the global handle);
+// any earlier call is a programming bug, not a config problem.
+func (p *provider) Build() (apipersistence.Source, apipersistence.Snapshotter, error) {
+	v := pkgconfig.Viper()
+	if v == nil {
+		return nil, nil, fmt.Errorf("v1snap: server viper not initialised — Build called before config.Load")
+	}
+
+	v.SetDefault(configKey+"."+keyFile, defaultFile)
+
+	file := v.GetString(configKey + "." + keyFile)
+	p.src = NewSource(file)
+	p.snap = NewSnapshotter(file)
+
+	pkgconfig.OnReload(p.onReload)
+
+	logger.InfoNoCtx().Str("plugin", "v1-snapshot").Str("file", file).Msg("v1snap: configured")
+	return p.src, p.snap, nil
+}
+
+// onReload re-reads the plugin's configuration on a server-wide reload
+// signal. Today the only knob is the filename — when it changes both
+// the Source and Snapshotter SetFilename methods are invoked under
+// their internal mutexes, so an in-flight save won't tear.
+func (p *provider) onReload(v *viper.Viper) {
+	if p.src == nil || p.snap == nil {
+		return
+	}
+	newFile := v.GetString(configKey + "." + keyFile)
+	if newFile == "" {
+		return
+	}
+	p.src.SetFilename(newFile)
+	p.snap.SetFilename(newFile)
+	logger.InfoNoCtx().Str("plugin", "v1-snapshot").Str("file", newFile).Msg("v1snap: filename updated via hot reload")
+}

--- a/pkg/persistence/v1snap/init_test.go
+++ b/pkg/persistence/v1snap/init_test.go
@@ -1,0 +1,128 @@
+package v1snap
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	apipersistence "gocache/api/persistence"
+	pkgconfig "gocache/pkg/config"
+)
+
+// swapServerViper installs v as the global server viper for the
+// duration of the test. Restores whatever was there before on Cleanup,
+// so test order doesn't matter.
+func swapServerViper(t *testing.T, v *viper.Viper) {
+	t.Helper()
+	prev := pkgconfig.SetViperForTest(v)
+	t.Cleanup(func() { pkgconfig.SetViperForTest(prev) })
+}
+
+// TestProvider_Build_ReadsViperSubsection verifies the plugin pulls
+// its filename from plugins.config.snapshot-v1.file rather than from
+// any server-config struct field.
+func TestProvider_Build_ReadsViperSubsection(t *testing.T) {
+	dir := t.TempDir()
+	wantFile := filepath.Join(dir, "configured.snap")
+
+	v := viper.New()
+	v.Set("plugins.config.snapshot-v1.file", wantFile)
+	swapServerViper(t, v)
+
+	p := &provider{}
+	src, snap, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if src == nil || snap == nil {
+		t.Fatalf("Build returned nil: src=%v snap=%v", src, snap)
+	}
+
+	// Save a snapshot via the plugin and verify it lands at the
+	// configured path — proves the filename plumbing connected.
+	if err := snap.SaveSnapshot(context.Background(), emptySrc{}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+	if _, err := os.Stat(wantFile); err != nil {
+		t.Errorf("snapshot not at configured path: %v", err)
+	}
+}
+
+// TestProvider_Build_AppliesDefault verifies the plugin sets a default
+// filename when the viper subsection key is absent.
+func TestProvider_Build_AppliesDefault(t *testing.T) {
+	v := viper.New()
+	swapServerViper(t, v)
+
+	p := &provider{}
+	if _, _, err := p.Build(); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := v.GetString("plugins.config.snapshot-v1.file"); got != defaultFile {
+		t.Errorf("default not applied: got %q, want %q", got, defaultFile)
+	}
+}
+
+// TestProvider_Build_NilViper verifies Build refuses to run before
+// pkg/config.Load wires the server viper.
+func TestProvider_Build_NilViper(t *testing.T) {
+	swapServerViper(t, nil)
+
+	p := &provider{}
+	_, _, err := p.Build()
+	if err == nil {
+		t.Error("expected error when viper is nil, got none")
+	}
+}
+
+// TestProvider_HotReload exercises the OnReload callback: starting
+// from one filename, changing the viper key, and triggering reload
+// updates the live Source/Snapshotter.
+func TestProvider_HotReload(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.snap")
+	second := filepath.Join(dir, "second.snap")
+
+	v := viper.New()
+	v.Set("plugins.config.snapshot-v1.file", first)
+	swapServerViper(t, v)
+
+	p := &provider{}
+	_, snap, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if err := snap.SaveSnapshot(context.Background(), emptySrc{}); err != nil {
+		t.Fatalf("SaveSnapshot first: %v", err)
+	}
+	if _, err := os.Stat(first); err != nil {
+		t.Errorf("first snapshot missing: %v", err)
+	}
+
+	// Simulate config reload — change the key, fire the callback
+	// directly. Production fires it via pkg/config.fireReload after
+	// viper's fsnotify watcher detects the file change.
+	v.Set("plugins.config.snapshot-v1.file", second)
+	p.onReload(v)
+
+	if err := snap.SaveSnapshot(context.Background(), emptySrc{}); err != nil {
+		t.Fatalf("SaveSnapshot second: %v", err)
+	}
+	if _, err := os.Stat(second); err != nil {
+		t.Errorf("second snapshot missing after hot reload: %v", err)
+	}
+}
+
+// emptySrc is a SnapshotSource yielding zero entries — enough for
+// the writer to produce a valid empty v1 file.
+type emptySrc struct{}
+
+func (emptySrc) Next(_ context.Context) (apipersistence.SnapshotEntry, error) {
+	return apipersistence.SnapshotEntry{}, io.EOF
+}

--- a/pkg/resp/commands.go
+++ b/pkg/resp/commands.go
@@ -45,8 +45,7 @@ const (
 	CmdExec    = "EXEC"
 	CmdDiscard = "DISCARD"
 
-	CmdSnapshot     = "SNAPSHOT"
-	CmdLoadSnapshot = "LOAD_SNAPSHOT"
+	CmdSnapshot = "SNAPSHOT"
 
 	CmdDBSize = "DBSIZE"
 	CmdInfo   = "INFO"

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -2,14 +2,15 @@ package handler
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"gocache/api/logger"
 	"gocache/pkg/command"
-	"gocache/pkg/persistence"
 )
 
+// HandleSnapshot handles SAVE / SNAPSHOT — triggers an immediate
+// snapshot save through the registered persistence plugin (via
+// cmdCtx.Snapshotter, which is the Coordinator). The plugin owns
+// where and how to write; this handler only dispatches.
 func HandleSnapshot(cmdCtx *command.Context) command.Result {
 	executeFn := func() any {
 		if cmdCtx.Snapshotter == nil {
@@ -25,62 +26,4 @@ func HandleSnapshot(cmdCtx *command.Context) command.Result {
 		logger.Error(cmdCtx.Context()).Err(res.Err).Msg("snapshot command failed")
 	}
 	return res
-}
-
-func HandleLoadSnapshot(cmdCtx *command.Context) command.Result {
-	requested := cmdCtx.Args[0]
-
-	// Restrict LOAD_SNAPSHOT to files within the configured snapshot directory
-	// to prevent arbitrary file reads via path traversal. Authenticated clients
-	// must not be able to read /etc/passwd or other files readable by the
-	// server user.
-	filename, err := sanitizeSnapshotPath(cmdCtx.SnapshotFile, requested)
-	if err != nil {
-		return command.Result{Err: err}
-	}
-
-	executeFn := func() any {
-		if err := persistence.LoadSnapshot(cmdCtx.Context(), filename, cmdCtx.Cache); err != nil {
-			return err
-		}
-		return "OK"
-	}
-	res := command.Dispatch(cmdCtx, executeFn)
-	if res.Err != nil {
-		logger.Error(cmdCtx.Context()).Err(res.Err).Str("file", filename).Msg("loadsnapshot command failed")
-	}
-	return res
-}
-
-// sanitizeSnapshotPath returns an absolute path guaranteed to be within the
-// directory of baseSnapshotFile. It rejects absolute paths, parent-directory
-// traversal, and any path that escapes the base directory after cleaning.
-func sanitizeSnapshotPath(baseSnapshotFile, requested string) (string, error) {
-	if baseSnapshotFile == "" {
-		return "", fmt.Errorf("snapshots disabled: no snapshot_file configured")
-	}
-	if requested == "" {
-		return "", fmt.Errorf("empty filename")
-	}
-	// Reject absolute paths and explicit traversal up-front.
-	if filepath.IsAbs(requested) || strings.Contains(requested, "..") {
-		return "", fmt.Errorf("path not allowed")
-	}
-
-	baseDir, err := filepath.Abs(filepath.Dir(baseSnapshotFile))
-	if err != nil {
-		return "", fmt.Errorf("resolve base dir: %w", err)
-	}
-	// filepath.Base returns the final path element (not interior segments),
-	// so anything the caller sent like "sub/file" collapses to "file".
-	// Combined with the absolute-path/".." rejection above, the result is
-	// guaranteed to live directly under baseDir.
-	final := filepath.Join(baseDir, filepath.Base(requested))
-
-	// Defense in depth: verify the result is within baseDir after cleaning.
-	cleaned := filepath.Clean(final)
-	if !strings.HasPrefix(cleaned, baseDir+string(filepath.Separator)) && cleaned != baseDir {
-		return "", fmt.Errorf("path not allowed")
-	}
-	return cleaned, nil
 }

--- a/pkg/resp/handler/persistence_test.go
+++ b/pkg/resp/handler/persistence_test.go
@@ -13,9 +13,12 @@ import (
 	"gocache/pkg/resp/handler"
 )
 
+// TestHandler_Snapshot exercises SAVE through the coordinator + a
+// registered snapshotter. The plugin owns format/filename — we use the
+// gob shim here as a stand-in for the registered persistence plugin so
+// the test stays plugin-agnostic. (The real binary uses v1snap; the
+// gob shim still implements both Source and Snapshotter for tests.)
 func TestHandler_Snapshot(t *testing.T) {
-	// Use a temp dir so the LOAD_SNAPSHOT path-traversal guard has a
-	// well-defined base directory.
 	dir := t.TempDir()
 	snapshotFile := filepath.Join(dir, "test_handler_snapshot.dat")
 
@@ -25,26 +28,21 @@ func TestHandler_Snapshot(t *testing.T) {
 	t.Cleanup(func() { e1.Stop() })
 	ctx1 := clientctx.New()
 
-	// SET a value
 	res := eval(t, c1, e1, ctx1, "SET", []string{"snap", "data"})
 	if res.Value != "OK" {
 		t.Fatalf("SET: %v", res.Value)
 	}
 
-	// SNAPSHOT — needs Snapshotter wired through the coordinator. The
-	// gob shim implements both Source (boot side) and Snapshotter
-	// (runtime save side).
 	gob := persistence.NewGobSource(snapshotFile)
 	coord := persistence.New(gob)
 	coord.RegisterSnapshotter(gob)
 
 	cmdCtx := &command.Context{
-		Client:       ctx1,
-		Op:           "SNAPSHOT",
-		Engine:       e1,
-		Cache:        c1,
-		SnapshotFile: snapshotFile,
-		Snapshotter:  coord,
+		Client:      ctx1,
+		Op:          "SNAPSHOT",
+		Engine:      e1,
+		Cache:       c1,
+		Snapshotter: coord,
 	}
 	res = handler.HandleSnapshot(cmdCtx)
 	if res.Value != "OK" {
@@ -53,63 +51,5 @@ func TestHandler_Snapshot(t *testing.T) {
 
 	if _, err := os.Stat(snapshotFile); os.IsNotExist(err) {
 		t.Fatalf("%s was not created", snapshotFile)
-	}
-
-	// Load into fresh cache. Call HandleLoadSnapshot directly so we can set
-	// SnapshotFile (eval() uses a minimal command.Context without config).
-	c2 := cache.New()
-	e2 := engine.New(c2)
-	go e2.Run()
-	t.Cleanup(func() { e2.Stop() })
-	ctx2 := clientctx.New()
-
-	loadCtx := &command.Context{
-		Client:       ctx2,
-		Op:           "LOAD_SNAPSHOT",
-		Args:         []string{filepath.Base(snapshotFile)},
-		Engine:       e2,
-		Cache:        c2,
-		SnapshotFile: snapshotFile,
-	}
-	res = handler.HandleLoadSnapshot(loadCtx)
-	if res.Value != "OK" {
-		t.Fatalf("LOAD_SNAPSHOT: %v", res.Value)
-	}
-
-	res = eval(t, c2, e2, ctx2, "GET", []string{"snap"})
-	if valueAsString(res.Value) != "data" {
-		t.Errorf("GET snap: expected data, got %v", res.Value)
-	}
-}
-
-func TestHandler_LoadSnapshot_PathTraversal(t *testing.T) {
-	// Verify that LOAD_SNAPSHOT rejects absolute paths, parent traversal,
-	// and subpaths that escape the base snapshot directory.
-	dir := t.TempDir()
-	baseSnapshot := filepath.Join(dir, "ok.snap")
-
-	c := cache.New()
-	e := engine.New(c)
-	go e.Run()
-	t.Cleanup(func() { e.Stop() })
-
-	bad := []string{
-		"/etc/passwd",
-		"../../etc/passwd",
-		"sub/../../escape",
-	}
-	for _, arg := range bad {
-		loadCtx := &command.Context{
-			Client:       clientctx.New(),
-			Op:           "LOAD_SNAPSHOT",
-			Args:         []string{arg},
-			Engine:       e,
-			Cache:        c,
-			SnapshotFile: baseSnapshot,
-		}
-		res := handler.HandleLoadSnapshot(loadCtx)
-		if res.Value == "OK" {
-			t.Errorf("path %q should have been rejected, got OK", arg)
-		}
 	}
 }

--- a/pkg/resp/handler/register.go
+++ b/pkg/resp/handler/register.go
@@ -123,9 +123,8 @@ func Registrations() map[string]command.Registration {
 		resp.CmdDiscard: regKeyless(HandleDiscard, 0, 0),
 		resp.CmdExec:    regMulti(HandleExec, 0, 0),
 
-		// Persistence — both touch the entire keyspace.
-		resp.CmdSnapshot:     regMulti(HandleSnapshot, 0, 0),
-		resp.CmdLoadSnapshot: regMulti(HandleLoadSnapshot, 1, 1),
+		// Persistence — touches the entire keyspace.
+		resp.CmdSnapshot: regMulti(HandleSnapshot, 0, 0),
 
 		// Server / client-state commands.
 		resp.CmdDBSize:   regMultiRO(HandleDBSize, 0, 0), // counts every key

--- a/pkg/server/bench_test.go
+++ b/pkg/server/bench_test.go
@@ -56,7 +56,7 @@ func newInProcRig(b *testing.B) *inProcRig {
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
 
-	ev := evaluator.New(c, e, "", "", br, wm)
+	ev := evaluator.New(c, e, "", br, wm)
 	ev.SetTracker(serverOps.NewTracker())
 	// Match production: cmd/server/main.go always wires the event bus, even
 	// when no plugins are loaded. Without this, the evaluator's emitter
@@ -104,7 +104,7 @@ func newTCPRig(b *testing.B) *tcpRig {
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
 
-	srv := New("127.0.0.1:0", c, e, "", "", br, wm)
+	srv := New("127.0.0.1:0", c, e, "", br, wm)
 	srv.SetTracker(serverOps.NewTracker())
 	srv.SetEmitter(events.NewBus())
 
@@ -198,7 +198,7 @@ func TestHSET_PromotedHash_O1(t *testing.T) {
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
-	ev := evaluator.New(c, e, "", "", br, wm)
+	ev := evaluator.New(c, e, "", br, wm)
 	ev.SetTracker(serverOps.NewTracker())
 	cli := clientctx.New()
 
@@ -240,7 +240,7 @@ func runPromotedCollectionO1(t *testing.T, deadline time.Duration, n int, makeAr
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
-	ev := evaluator.New(c, e, "", "", br, wm)
+	ev := evaluator.New(c, e, "", br, wm)
 	ev.SetTracker(serverOps.NewTracker())
 	cli := clientctx.New()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,9 +51,9 @@ type Server struct {
 	opHookExecutor   evaluator.OpHookExecutor
 }
 
-func New(addr string, c *cache.Cache, e *engine.Engine, snapshotFile, requirePass string, br *blocking.Registry, wm *watch.Manager) *Server {
+func New(addr string, c *cache.Cache, e *engine.Engine, requirePass string, br *blocking.Registry, wm *watch.Manager) *Server {
 	tracker := serverOps.NewTracker()
-	ev := evaluator.New(c, e, snapshotFile, requirePass, br, wm)
+	ev := evaluator.New(c, e, requirePass, br, wm)
 	ev.SetTracker(tracker)
 	return &Server{
 		addr:             addr,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -28,7 +28,7 @@ func startTestServer(t *testing.T, requirePass string) (*Server, string) {
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
 
-	srv := New("127.0.0.1:0", c, e, "", requirePass, br, wm)
+	srv := New("127.0.0.1:0", c, e, requirePass, br, wm)
 	srv.SetTracker(serverOps.NewTracker())
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -159,7 +159,7 @@ func TestServer_Shutdown(t *testing.T) {
 
 	br := blocking.NewRegistry()
 	wm := watch.NewManager()
-	srv := New("127.0.0.1:0", c, e, "", "", br, wm)
+	srv := New("127.0.0.1:0", c, e, "", br, wm)
 	srv.SetTracker(serverOps.NewTracker())
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -216,7 +216,7 @@ func TestServer_TCPNoDelay(t *testing.T) {
 	wm := watch.NewManager()
 	c.OnMutate = wm.NotifyMutation
 
-	srv := New("127.0.0.1:0", c, e, "", "", br, wm)
+	srv := New("127.0.0.1:0", c, e, "", br, wm)
 	srv.SetTracker(serverOps.NewTracker())
 
 	inner, err := net.Listen("tcp", "127.0.0.1:0")

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -117,19 +117,15 @@ func safeInterval(d time.Duration) time.Duration {
 	return d
 }
 
-// SnapshotWorker periodically saves a snapshot of the cache to disk.
+// SnapshotWorker periodically calls the persistence coordinator's
+// snapshot entry point. The worker owns scheduling (interval ticker)
+// and operation lifecycle; the plugin owns where the snapshot lands.
 type SnapshotWorker struct {
 	baseWorker
-	// file is retained for op-enrichment and log correlation only — the
-	// snapshotter owns the durable path. Hot-reload updates both via
-	// UpdateFile (worker copy) + the wired SnapshotInvoker (the actual
-	// path the on-disk write hits).
-	file        string
-	fileChan    chan string
 	snapshotter pkgcommand.SnapshotInvoker
 }
 
-func NewSnapshotWorker(c *cache.Cache, e *engine.Engine, interval time.Duration, file string) *SnapshotWorker {
+func NewSnapshotWorker(c *cache.Cache, e *engine.Engine, interval time.Duration) *SnapshotWorker {
 	return &SnapshotWorker{
 		baseWorker: baseWorker{
 			cache:        c,
@@ -138,8 +134,6 @@ func NewSnapshotWorker(c *cache.Cache, e *engine.Engine, interval time.Duration,
 			stopChan:     make(chan struct{}),
 			intervalChan: make(chan time.Duration, 1),
 		},
-		file:     file,
-		fileChan: make(chan string, 1),
 	}
 }
 
@@ -151,14 +145,6 @@ func (w *SnapshotWorker) SetSnapshotInvoker(s pkgcommand.SnapshotInvoker) {
 	w.snapshotter = s
 }
 
-// UpdateFile updates the snapshot file path at runtime. The worker copy
-// is used only for log/op enrichment — the actual durable path lives on
-// the registered Snapshotter and must be updated independently (config
-// reload calls both in main.go).
-func (w *SnapshotWorker) UpdateFile(file string) {
-	w.fileChan <- file
-}
-
 func (w *SnapshotWorker) Start(parentCtx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	w.wg.Add(1)
@@ -167,11 +153,7 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
-				file := w.file
 				op, opCtx := w.startOp(parentCtx, ops.TypeSnapshot)
-				if op != nil {
-					op.Enrich(command.FileKey, file)
-				}
 				if w.snapshotter == nil {
 					logger.Warn(opCtx).Msg("snapshot scheduled but no snapshotter registered")
 					w.failOp(op, "no snapshotter registered")
@@ -182,7 +164,7 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 						logger.Warn(opCtx).Err(err).Msg("snapshot save failed")
 						w.failOp(op, err.Error())
 					} else {
-						logger.Debug(opCtx).Str("file", file).Msg("snapshot saved")
+						logger.Debug(opCtx).Msg("snapshot saved")
 						w.completeOp(op)
 					}
 				}); err != nil {
@@ -191,8 +173,6 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 				}
 			case d := <-w.intervalChan:
 				ticker.Reset(safeInterval(d))
-			case f := <-w.fileChan:
-				w.file = f
 			case <-w.stopChan:
 				ticker.Stop()
 				return

--- a/pkg/workers/workers_test.go
+++ b/pkg/workers/workers_test.go
@@ -35,7 +35,7 @@ func TestSnapshotWorker_CreatesFile(t *testing.T) {
 	coord := persistence.New(gob)
 	coord.RegisterSnapshotter(gob)
 
-	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file)
+	w := NewSnapshotWorker(c, e, 50*time.Millisecond)
 	w.SetSnapshotInvoker(coord)
 	w.Start(context.Background())
 	defer w.Stop()
@@ -106,38 +106,11 @@ func TestWorker_UpdateInterval(t *testing.T) {
 	w.UpdateInterval(50 * time.Millisecond)
 }
 
-func TestSnapshotWorker_UpdateFile(t *testing.T) {
-	c, e := setup(t)
-	e.Dispatch(context.Background(), func() {
-		_ = c.RawSet(context.Background(), "k", "v", 0)
-	})
-
-	dir := t.TempDir()
-	file1 := filepath.Join(dir, "snap1.dat")
-	file2 := filepath.Join(dir, "snap2.dat")
-
-	gob := persistence.NewGobSource(file1)
-	coord := persistence.New(gob)
-	coord.RegisterSnapshotter(gob)
-
-	w := NewSnapshotWorker(c, e, 50*time.Millisecond, file1)
-	w.SetSnapshotInvoker(coord)
-	w.Start(context.Background())
-
-	// Switch to file2 — both the worker (for op-enrichment) and the gob
-	// shim (for the actual on-disk path) need to be told. main.go does
-	// the same dual update on config reload.
-	w.UpdateFile(file2)
-	gob.SetFilename(file2)
-	time.Sleep(200 * time.Millisecond)
-
-	// Stop before TempDir cleanup to avoid race on directory removal.
-	w.Stop()
-
-	if _, err := os.Stat(file2); os.IsNotExist(err) {
-		t.Error("expected snapshot at updated file path")
-	}
-}
+// Hot-reload of the snapshot file path is now the plugin's
+// responsibility — it watches its own viper subsection (see
+// pkg/persistence/v1snap/init.go). The worker no longer holds the
+// filename, so there's no SnapshotWorker-side hot-reload path to
+// test here.
 
 func TestSafeInterval_ZeroDefault(t *testing.T) {
 	d := safeInterval(0)


### PR DESCRIPTION
## Summary

Replaces closed PR #68 with the proper architectural fix. The persistence-as-plugin arc is now actually finished: `api/persistence` is just contract; plugins handle their own configuration end-to-end via viper.

This is **ADR-0007** + matching implementation. It addresses the earlier feedback that closed #67 and #68:

> *"plugins should be self configurable and self sufficient, server should only call their api but it's them who decide about their config, who decide about formatting, who decide about what they do, api persistance was suppoused to be enly thin api layer"*

> *"why plugins cant use viper to handle hot reloads and define their config themselves?"*

## What the server still owns

```go
type PersistenceConfig struct {
    LoadOnStartup    bool          // do we recover at startup?
    SnapshotInterval time.Duration // how often does the scheduler tick?
}
```

That's it. The server decides *whether* and *when* persistence runs. Everything else — format, filename, compression knobs, future tunables — belongs to the plugin.

## What the plugin owns

```yaml
plugins:
  config:
    snapshot-v1:
      file: snapshot.dat
      # plugin can add any keys here — api/config never enumerates them
```

Each plugin reads its own subsection of the server's viper. The server just exposes:
- **`pkg/config.Viper()`** — the viper handle
- **`pkg/config.OnReload(fn)`** — multiplexer over viper's single-callback `OnConfigChange` so multiple plugins can subscribe independently

`v1snap.init()` registers the provider; `Build()` reads its keys from viper and registers a hot-reload callback. Hot reload re-reads keys via viper directly and propagates `SetFilename` to the running Source/Snapshotter.

## Mechanism

`api/persistence/registry.go` (new):
```go
type SnapshotProvider interface {
    Name() string
    Build() (Source, Snapshotter, error)  // no args — plugin self-configures
}

RegisterSnapshotProvider(p)        // panics on double-register
SnapshotProviderRegistered() Provider
```

`pkg/config/viper_handle.go` (new): `Viper()` getter, `OnReload(fn)` multiplexer, test helpers. `Load` installs `viper.OnConfigChange(fireReload) + WatchConfig` so all reload events flow through the multiplexer.

`pkg/persistence/v1snap/init.go` (new): `init()` registers; `Build()` reads `plugins.config.snapshot-v1.file` (default `snapshot.dat`); `onReload` re-reads on config-file change and updates the live Source/Snapshotter.

## Removals (breaking, intentional)

`api/config`:
- **DROPPED** `PersistenceConfig.SnapshotFile` field
- **DROPPED** `DefaultSnapshotFile` constant
- **DROPPED** `PersistenceConfig.SnapshotFormat` (added briefly in #66)
- **DROPPED** `DefaultSnapshotFormat` / `SnapshotFormatGob` / `SnapshotFormatV1`

`pkg/server` / `pkg/evaluator`: `New` signatures lose the `snapshotFile` parameter.

`pkg/command.Context`: `SnapshotFile` field gone.

**`LOAD_SNAPSHOT` command removed.** Its only role was a debug-time runtime reload, and it required the server to know the plugin's working directory (for path-traversal sanitization). That's plugin-internal knowledge. If runtime reload is ever needed, it ships as a plugin-provided command (microkernel pattern), not a core RESP command.

`SnapshotWorker` drops `file` / `fileChan` / `UpdateFile` — worker schedules ticks; plugin handles paths.

## Documentation

- **`docs/adr/0007-embedded-persistence-plugin-self-config.md`** (new): full design with alternatives (config string / server pushes blobs / per-plugin YAML / build tags), consequences, risks. Status `accepted` — born with implementation.
- **ADR-0005** flips `proposed → accepted` — v1 snapshot format ships as a proper plugin here.
- **`docs/adr/README.md`** index updated.

ADR-0006 (built-in vs IPC plugin transport) stays `proposed` — that's the next chunk, where v1snap physically moves to `plugins/` and AOF gets built. ADR-0007 establishes the registration model that move will use.

## Test plan

- [x] `go test -race ./...` — PASS
- [x] `go vet ./...` — PASS
- [x] `staticcheck ./...` — PASS
- [x] **4** registry tests in `api/persistence`: no-provider → nil, register round-trip, double-register panics with both names, nil panics.
- [x] **4** viper-handle tests in `pkg/config`: nil before set, round-trip, OnReload fan-out across multiple callbacks, OnReload registrations during fan-out don't race or fire mid-round.
- [x] **4** plugin self-config tests in `pkg/persistence/v1snap`: Build reads viper subsection (verified by save landing at configured path), default applied when key absent, nil viper rejected, hot reload via onReload propagates new filename and subsequent saves go to the new path.
- [x] All existing tests updated for signature changes (`SnapshotFile` field gone, `New()` signatures shrunk, `LOAD_SNAPSHOT` deleted).
- [ ] CI green on this PR before merge.

## Next chunk (after this merges)

ADR-0006 implementation: extract `pkg/persistence/v1snap/` → `plugins/snapshot-v1/` (requires either extracting `*cache.SortedSet` to `api/cache` or amending the layering rule for embedded plugins). Then AOF as `plugins/aof-v1/` with parallel `RegisterAOFProvider`. Both follow the registration + viper-self-config pattern this PR establishes.