### PR TITLE
refactor(persistence): decouple pkg/persistence from pkg/cache via Ca…

### DIFF
--- a/api/persistence/store.go
+++ b/api/persistence/store.go
@@ -1,0 +1,22 @@
+package persistence
+
+import "context"
+
+// CacheStore is the persistence coordinator's view of the cache.
+// The server's *cache.Cache satisfies this interface; the coordinator
+// never imports pkg/cache.
+type CacheStore interface {
+	// CaptureSnapshot returns every live entry as a SnapshotEntry slice.
+	// Packed values are copied out of slab storage; sorted sets are
+	// flattened to map[string]float64. The slice is safe to use after
+	// the call returns — no aliases into cache-internal memory.
+	CaptureSnapshot() []SnapshotEntry
+
+	// LoadEntry applies one snapshot entry to the cache. Packed entries
+	// go through the slab path; native sorted-set entries are
+	// reconstructed from map[string]float64.
+	LoadEntry(ctx context.Context, e SnapshotEntry) error
+
+	// Clear drops every entry in the cache.
+	Clear(ctx context.Context)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -264,6 +264,7 @@ func main() {
 	// formats, files, or per-plugin tunables.
 	snapSource, snapSnapshotter := buildSnapshotBackend(ctx)
 	coordinator := persistence.New(snapSource)
+	coordinator.SetStore(cacheInstance)
 	coordinator.RegisterSnapshotter(snapSnapshotter)
 	srv.SetPersistenceFeed(coordinator)
 	srv.SetSnapshotInvoker(coordinator)
@@ -278,7 +279,7 @@ func main() {
 			opHookExec.RunStartHooks(snapCtx, snapOp)
 		}
 		eventBus.Emit(events.NewOperationStart(snapOp.ID, string(snapOp.Type), bootOp.ID, snapOp.ContextSnapshot(false)))
-		if _, err := coordinator.BootInto(snapCtx, cacheInstance); err != nil {
+		if _, err := coordinator.BootInto(snapCtx); err != nil {
 			logger.Warn(snapCtx).Err(err).Msg("failed to load snapshot")
 			snapOp.Fail(err.Error())
 			if opHookExec != nil {
@@ -481,7 +482,7 @@ func handleShutdown(
 	coordinator.Stop(shutdownCtx)
 
 	logger.Info(shutdownCtx).Str("step", "4/6").Msg("saving final snapshot")
-	if err := coordinator.Snapshot(shutdownCtx, cacheInstance); err != nil {
+	if err := coordinator.Snapshot(shutdownCtx); err != nil {
 		logger.Warn(shutdownCtx).Err(err).Msg("failed to save final snapshot")
 	} else {
 		logger.Info(shutdownCtx).Msg("final snapshot saved successfully")

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -41,15 +41,17 @@ func TestCache_Snapshot(t *testing.T) {
 
 	gob := persistence.NewGobSource(file)
 	coord := persistence.New(gob)
+	coord.SetStore(c)
 	coord.RegisterSnapshotter(gob)
 
-	if err := coord.Snapshot(context.Background(), c); err != nil {
+	if err := coord.Snapshot(context.Background()); err != nil {
 		t.Fatalf("save: %v", err)
 	}
 
 	c2 := cache.New()
 	coord2 := persistence.New(persistence.NewGobSource(file))
-	if _, err := coord2.BootInto(context.Background(), c2); err != nil {
+	coord2.SetStore(c2)
+	if _, err := coord2.BootInto(context.Background()); err != nil {
 		t.Fatalf("load: %v", err)
 	}
 

--- a/pkg/cache/store.go
+++ b/pkg/cache/store.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	apipersistence "gocache/api/persistence"
+)
+
+var _ apipersistence.CacheStore = (*Cache)(nil)
+
+// CaptureSnapshot walks all entries and returns a serializable snapshot.
+// Caller must hold c.Lock() or ensure exclusive access (e.g. engine.Dispatch).
+func (c *Cache) CaptureSnapshot() []apipersistence.SnapshotEntry {
+	var entries []apipersistence.SnapshotEntry
+	c.Range(func(key string, entry Entry, expiration int64) bool {
+		var v any
+		switch {
+		case entry.Encoding == EncPacked:
+			src := c.ResolvePacked(entry)
+			buf := make([]byte, len(src))
+			copy(buf, src)
+			v = buf
+		case entry.ValueType == ObjTypeSortedSet:
+			if z, ok := entry.Value.(*SortedSet); ok {
+				v = z.Members()
+			} else {
+				v = entry.Value
+			}
+		default:
+			v = entry.Value
+		}
+		entries = append(entries, apipersistence.SnapshotEntry{
+			Key:        key,
+			ValueType:  apipersistence.ValueType(entry.ValueType),
+			Encoding:   apipersistence.Encoding(entry.Encoding),
+			Value:      v,
+			Expiration: expiration,
+		})
+		return true
+	})
+	return entries
+}
+
+func (c *Cache) LoadEntry(_ context.Context, e apipersistence.SnapshotEntry) error {
+	if e.Encoding == apipersistence.EncodingPacked {
+		var buf []byte
+		switch v := e.Value.(type) {
+		case []byte:
+			buf = v
+		case string:
+			buf = []byte(v)
+		default:
+			return fmt.Errorf("packed entry has non-byte payload: %T", e.Value)
+		}
+		c.RawLoadPacked(e.Key, ValueType(e.ValueType), buf, e.Expiration)
+		return nil
+	}
+	value := e.Value
+	if e.ValueType == apipersistence.ValueTypeSortedSet {
+		members, ok := value.(map[string]float64)
+		if !ok {
+			return fmt.Errorf("sorted-set entry has non-map payload: %T", e.Value)
+		}
+		z := NewSortedSet()
+		for member, score := range members {
+			z.Add(member, score)
+		}
+		value = z
+	}
+	c.RawLoad(e.Key, value, e.Expiration)
+	return nil
+}

--- a/pkg/command/context.go
+++ b/pkg/command/context.go
@@ -39,7 +39,7 @@ type MutationEmitter interface {
 // Nil means "no snapshotter wired" — handler returns an error to the
 // client rather than silently no-oping a SAVE command.
 type SnapshotInvoker interface {
-	Snapshot(ctx context.Context, target *cache.Cache) error
+	Snapshot(ctx context.Context) error
 	LastSaveUnix() int64
 }
 

--- a/pkg/persistence/coordinator.go
+++ b/pkg/persistence/coordinator.go
@@ -11,7 +11,6 @@ import (
 
 	"gocache/api/logger"
 	apipersistence "gocache/api/persistence"
-	"gocache/pkg/cache"
 )
 
 // Coordinator orchestrates the persistence Source and Sinks. On boot it
@@ -28,6 +27,11 @@ import (
 type Coordinator struct {
 	source apipersistence.Source
 	sinks  []apipersistence.Sink
+
+	// store is the coordinator's abstract view of the cache. Set via
+	// SetStore before BootInto / Snapshot. The coordinator never imports
+	// pkg/cache — all cache access flows through this interface.
+	store apipersistence.CacheStore
 
 	// snapshotter is the registered point-in-time snapshot writer.
 	// Optional — Coordinator.Snapshot returns ErrNoSnapshotter when nil.
@@ -157,6 +161,11 @@ func (c *Coordinator) Source() apipersistence.Source { return c.source }
 // Sinks returns the registered sinks (may be empty).
 func (c *Coordinator) Sinks() []apipersistence.Sink { return c.sinks }
 
+// SetStore wires the cache abstraction used by BootInto and Snapshot.
+// Must be called before either method. Passing nil is valid only when
+// neither boot nor snapshot will be invoked (pure pass-through mode).
+func (c *Coordinator) SetStore(s apipersistence.CacheStore) { c.store = s }
+
 // RegisterSnapshotter installs the point-in-time snapshot writer. Safe to
 // call before or after Start. A nil argument clears the registration.
 // Replacing an existing snapshotter is allowed — useful when config
@@ -174,32 +183,26 @@ func (c *Coordinator) Snapshotter() apipersistence.Snapshotter {
 	return c.snapshotter
 }
 
-// Snapshot writes a point-in-time dump of target to the registered
-// snapshotter. Iterates the cache, materialises a SnapshotSource backed
-// by the captured slice, then delegates to snapshotter.SaveSnapshot.
+// Snapshot writes a point-in-time dump to the registered snapshotter.
+// Iterates the cache via the CacheStore interface, materialises a
+// SnapshotSource backed by the captured slice, then delegates to
+// snapshotter.SaveSnapshot.
 //
 // Returns ErrNoSnapshotter when none is registered — callers can choose
 // to treat that as fatal (SAVE command) or as a no-op (scheduled worker
 // when persistence is disabled).
-//
-// The cache snapshot is captured eagerly into a slice before the
-// snapshotter sees it. That keeps the snapshotter simple (it just walks
-// Next/io.EOF) at the cost of buffering all entries in memory once. The
-// upcoming v1 streaming format (ADR-0005) can reduce buffering by
-// writing each record as it's yielded; the gob shim already buffers
-// internally so this PR is no worse than the legacy SaveSnapshot.
-func (c *Coordinator) Snapshot(ctx context.Context, target *cache.Cache) error {
+func (c *Coordinator) Snapshot(ctx context.Context) error {
 	s := c.Snapshotter()
 	if s == nil {
 		return apipersistence.ErrNoSnapshotter
 	}
-	// Optional LSN seeding — snapshotters that record the cursor in
-	// their on-disk format (v1 binary format, ADR-0005) implement
-	// LSNSeeder. Skip silently for snapshotters that don't.
+	if c.store == nil {
+		return fmt.Errorf("persistence: coordinator store not set")
+	}
 	if seeder, ok := s.(apipersistence.LSNSeeder); ok {
 		seeder.SetLSN(c.CurrentLSN())
 	}
-	entries := captureSnapshotEntries(target)
+	entries := c.store.CaptureSnapshot()
 	src := &sliceSnapshotSource{entries: entries}
 	if err := s.SaveSnapshot(ctx, src); err != nil {
 		return err
@@ -208,47 +211,6 @@ func (c *Coordinator) Snapshot(ctx context.Context, target *cache.Cache) error {
 	return nil
 }
 
-// captureSnapshotEntries walks the cache and returns every live entry as
-// an api/persistence.SnapshotEntry. Packed values are copied out of the
-// slab allocator so the snapshotter sees a stable []byte independent of
-// slab lifecycle. ValueType and Encoding cast directly from the cache
-// enums to the api enums — the values are aligned by construction (see
-// type comments in api/persistence/types.go).
-//
-// SortedSet values are flattened to map[string]float64 here so the api
-// boundary stays free of pkg/cache types — plugins receive only generic
-// Go primitives (see ADR-0008). The conversion is the same shape as
-// hash/list/set already use.
-func captureSnapshotEntries(target *cache.Cache) []apipersistence.SnapshotEntry {
-	var entries []apipersistence.SnapshotEntry
-	target.Range(func(key string, entry cache.Entry, expiration int64) bool {
-		var v any
-		switch {
-		case entry.Encoding == cache.EncPacked:
-			src := target.ResolvePacked(entry)
-			buf := make([]byte, len(src))
-			copy(buf, src)
-			v = buf
-		case entry.ValueType == cache.ObjTypeSortedSet:
-			if z, ok := entry.Value.(*cache.SortedSet); ok {
-				v = z.Members()
-			} else {
-				v = entry.Value
-			}
-		default:
-			v = entry.Value
-		}
-		entries = append(entries, apipersistence.SnapshotEntry{
-			Key:        key,
-			ValueType:  apipersistence.ValueType(entry.ValueType),
-			Encoding:   apipersistence.Encoding(entry.Encoding),
-			Value:      v,
-			Expiration: expiration,
-		})
-		return true
-	})
-	return entries
-}
 
 // sliceSnapshotSource is a SnapshotSource backed by a pre-captured slice.
 // Forward-only single-pass — Next walks the slice and returns io.EOF once
@@ -269,7 +231,7 @@ func (s *sliceSnapshotSource) Next(_ context.Context) (apipersistence.SnapshotEn
 }
 
 // BootInto drives the recovery path: fetches the BootResult from the
-// Source, applies it to the target cache, and seeds the LSN cursor. The
+// Source, applies it to the CacheStore, and seeds the LSN cursor. The
 // returned LSN is the resume point for runtime mutation allocation.
 //
 // For BootModeInitial (or nil source), returns (ZeroLSN, nil) without
@@ -280,7 +242,7 @@ func (s *sliceSnapshotSource) Next(_ context.Context) (apipersistence.SnapshotEn
 //
 // On error, the cache may be in a partially-loaded state — callers should
 // abort startup rather than continue serving traffic against a torn cache.
-func (c *Coordinator) BootInto(ctx context.Context, target *cache.Cache) (apipersistence.LSN, error) {
+func (c *Coordinator) BootInto(ctx context.Context) (apipersistence.LSN, error) {
 	if c.source == nil {
 		logger.Debug(ctx).Msg("persistence coordinator: no source registered, BootMode=initial")
 		return apipersistence.ZeroLSN, nil
@@ -305,7 +267,7 @@ func (c *Coordinator) BootInto(ctx context.Context, target *cache.Cache) (apiper
 		if boot.Snapshot == nil {
 			return 0, fmt.Errorf("source %s declared BootModeSnapshot with nil Snapshot", c.source.Name())
 		}
-		loaded, err := loadSnapshotInto(ctx, boot.Snapshot, target)
+		loaded, err := c.loadSnapshotInto(ctx, boot.Snapshot)
 		if err != nil {
 			return 0, fmt.Errorf("source %s snapshot: %w", c.source.Name(), err)
 		}
@@ -321,7 +283,7 @@ func (c *Coordinator) BootInto(ctx context.Context, target *cache.Cache) (apiper
 		if boot.Replay == nil {
 			return 0, fmt.Errorf("source %s declared BootModeReplay with nil Replay", c.source.Name())
 		}
-		last, applied, err := replayInto(ctx, boot.Replay, target)
+		last, applied, err := replayInto(ctx, boot.Replay)
 		if err != nil {
 			return 0, fmt.Errorf("source %s replay: %w", c.source.Name(), err)
 		}
@@ -340,8 +302,11 @@ func (c *Coordinator) BootInto(ctx context.Context, target *cache.Cache) (apiper
 
 // loadSnapshotInto drains a SnapshotIterator into the cache. Returns the
 // number of entries loaded.
-func loadSnapshotInto(ctx context.Context, it apipersistence.SnapshotIterator, target *cache.Cache) (int, error) {
-	target.Clear(ctx)
+func (c *Coordinator) loadSnapshotInto(ctx context.Context, it apipersistence.SnapshotIterator) (int, error) {
+	if c.store == nil {
+		return 0, fmt.Errorf("persistence: coordinator store not set")
+	}
+	c.store.Clear(ctx)
 	loaded := 0
 	now := time.Now().UnixNano()
 	for {
@@ -355,7 +320,7 @@ func loadSnapshotInto(ctx context.Context, it apipersistence.SnapshotIterator, t
 		if e.Expiration > 0 && e.Expiration < now {
 			continue
 		}
-		if err := applyEntry(ctx, e, target); err != nil {
+		if err := c.store.LoadEntry(ctx, e); err != nil {
 			logger.Warn(ctx).Err(err).Str("key", e.Key).Msg("persistence: skipping malformed entry")
 			continue
 		}
@@ -369,7 +334,7 @@ func loadSnapshotInto(ctx context.Context, it apipersistence.SnapshotIterator, t
 // mutations against the cache (that requires the engine adapter wired in
 // feat/persistence-mutation-feed). Returning early is correct: the
 // snapshot path is the recovery path that ships now.
-func replayInto(ctx context.Context, it apipersistence.ReplayIterator, _ *cache.Cache) (apipersistence.LSN, int, error) {
+func replayInto(ctx context.Context, it apipersistence.ReplayIterator) (apipersistence.LSN, int, error) {
 	var last apipersistence.LSN
 	count := 0
 	for {
@@ -389,42 +354,3 @@ func replayInto(ctx context.Context, it apipersistence.ReplayIterator, _ *cache.
 	}
 }
 
-// applyEntry writes one snapshot entry into the target cache. It mirrors
-// the existing LoadSnapshot logic — the only difference is the api types
-// instead of pkg/persistence's internal struct. Conversion between the
-// api enums and pkg/cache enums is a numeric cast (the values are aligned
-// — see the type comments in api/persistence/types.go).
-//
-// SortedSet values cross the api boundary as map[string]float64 (per
-// ADR-0008); reconstruct the cache-internal *SortedSet here before
-// handing to RawLoad. Other native types (list, hash, set, bytes) flow
-// through unchanged because they're already generic Go primitives.
-func applyEntry(_ context.Context, e apipersistence.SnapshotEntry, target *cache.Cache) error {
-	if e.Encoding == apipersistence.EncodingPacked {
-		var buf []byte
-		switch v := e.Value.(type) {
-		case []byte:
-			buf = v
-		case string:
-			buf = []byte(v)
-		default:
-			return fmt.Errorf("packed entry has non-byte payload: %T", e.Value)
-		}
-		target.RawLoadPacked(e.Key, cache.ValueType(e.ValueType), buf, e.Expiration)
-		return nil
-	}
-	value := e.Value
-	if e.ValueType == apipersistence.ValueTypeSortedSet {
-		members, ok := value.(map[string]float64)
-		if !ok {
-			return fmt.Errorf("sorted-set entry has non-map payload: %T", e.Value)
-		}
-		z := cache.NewSortedSet()
-		for member, score := range members {
-			z.Add(member, score)
-		}
-		value = z
-	}
-	target.RawLoad(e.Key, value, e.Expiration)
-	return nil
-}

--- a/pkg/persistence/coordinator_test.go
+++ b/pkg/persistence/coordinator_test.go
@@ -16,8 +16,9 @@ import (
 func TestCoordinator_BootInto_NilSource(t *testing.T) {
 	c := New(nil)
 	target := cache.New()
+	c.SetStore(target)
 
-	lsn, err := c.BootInto(context.Background(), target)
+	lsn, err := c.BootInto(context.Background())
 	if err != nil {
 		t.Fatalf("BootInto with nil source: unexpected error: %v", err)
 	}
@@ -42,15 +43,17 @@ func TestCoordinator_BootInto_GobRoundTrip(t *testing.T) {
 
 	gob := NewGobSource(file)
 	writer := New(gob)
+	writer.SetStore(src)
 	writer.RegisterSnapshotter(gob)
-	if err := writer.Snapshot(context.Background(), src); err != nil {
+	if err := writer.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 
 	target := cache.New()
 	co := New(NewGobSource(file))
+	co.SetStore(target)
 
-	lsn, err := co.BootInto(context.Background(), target)
+	lsn, err := co.BootInto(context.Background())
 	if err != nil {
 		t.Fatalf("BootInto: %v", err)
 	}
@@ -76,8 +79,9 @@ func TestCoordinator_BootInto_GobRoundTrip(t *testing.T) {
 func TestCoordinator_BootInto_MissingFileTreatedAsInitial(t *testing.T) {
 	target := cache.New()
 	co := New(NewGobSource("/nonexistent/path/snapshot.dat"))
+	co.SetStore(target)
 
-	lsn, err := co.BootInto(context.Background(), target)
+	lsn, err := co.BootInto(context.Background())
 	if err != nil {
 		t.Fatalf("BootInto on missing file: %v", err)
 	}
@@ -101,14 +105,16 @@ func TestCoordinator_BootInto_SkipsExpired(t *testing.T) {
 
 	gob := NewGobSource(file)
 	writer := New(gob)
+	writer.SetStore(src)
 	writer.RegisterSnapshotter(gob)
-	if err := writer.Snapshot(context.Background(), src); err != nil {
+	if err := writer.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 
 	target := cache.New()
 	co := New(NewGobSource(file))
-	if _, err := co.BootInto(context.Background(), target); err != nil {
+	co.SetStore(target)
+	if _, err := co.BootInto(context.Background()); err != nil {
 		t.Fatalf("BootInto: %v", err)
 	}
 
@@ -186,8 +192,9 @@ func (s *fakeSource) Boot(_ context.Context) (apipersistence.BootResult, error) 
 func TestCoordinator_BootInto_PropagatesSourceError(t *testing.T) {
 	wantErr := errors.New("source-side failure")
 	co := New(&fakeSource{name: "fake", err: wantErr})
+	co.SetStore(cache.New())
 
-	_, err := co.BootInto(context.Background(), cache.New())
+	_, err := co.BootInto(context.Background())
 	if err == nil {
 		t.Fatal("expected error from BootInto")
 	}
@@ -201,8 +208,9 @@ func TestCoordinator_BootInto_InvalidBootMode(t *testing.T) {
 		name: "fake",
 		res:  apipersistence.BootResult{Mode: 99},
 	})
+	co.SetStore(cache.New())
 
-	_, err := co.BootInto(context.Background(), cache.New())
+	_, err := co.BootInto(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid BootMode")
 	}
@@ -216,8 +224,9 @@ func TestCoordinator_BootInto_SnapshotModeRequiresIterator(t *testing.T) {
 		name: "fake",
 		res:  apipersistence.BootResult{Mode: apipersistence.BootModeSnapshot}, // Snapshot nil
 	})
+	co.SetStore(cache.New())
 
-	_, err := co.BootInto(context.Background(), cache.New())
+	_, err := co.BootInto(context.Background())
 	if err == nil {
 		t.Fatal("expected error for nil Snapshot iterator under BootModeSnapshot")
 	}
@@ -237,7 +246,8 @@ func TestCoordinator_BootInto_ReplayAdvancesLSNCursor(t *testing.T) {
 		},
 	})
 
-	lsn, err := co.BootInto(context.Background(), cache.New())
+	co.SetStore(cache.New())
+	lsn, err := co.BootInto(context.Background())
 	if err != nil {
 		t.Fatalf("BootInto: %v", err)
 	}
@@ -282,8 +292,9 @@ func TestCoordinator_LastSaveUnix(t *testing.T) {
 		t.Errorf("LastSaveUnix before any save = %d, want 0", got)
 	}
 
+	co.SetStore(cache.New())
 	before := time.Now().Unix()
-	if err := co.Snapshot(context.Background(), cache.New()); err != nil {
+	if err := co.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	after := time.Now().Unix()

--- a/pkg/persistence/gobshim.go
+++ b/pkg/persistence/gobshim.go
@@ -12,7 +12,6 @@ import (
 
 	"gocache/api/logger"
 	apipersistence "gocache/api/persistence"
-	"gocache/pkg/cache"
 )
 
 // GobSource adapts the existing gob-encoded snapshot format to the
@@ -133,8 +132,8 @@ func (s *GobSource) SaveSnapshot(ctx context.Context, src apipersistence.Snapsho
 		}
 		entries = append(entries, SnapshotEntry{
 			Key:        e.Key,
-			ValueType:  cache.ValueType(e.ValueType),
-			Encoding:   cache.Encoding(e.Encoding),
+			ValueType:  int(e.ValueType),
+			Encoding:   int(e.Encoding),
 			Value:      e.Value,
 			Expiration: e.Expiration,
 		})
@@ -238,6 +237,3 @@ var _ apipersistence.Snapshotter = (*GobSource)(nil)
 // Compile-time assertion: gobIterator implements SnapshotIterator.
 var _ apipersistence.SnapshotIterator = (*gobIterator)(nil)
 
-// Sentinel — use cache.Cache only via this file's narrow surface so a
-// future refactor can swap the loader without re-grepping.
-var _ = (*cache.Cache)(nil)

--- a/pkg/persistence/persistence.go
+++ b/pkg/persistence/persistence.go
@@ -2,8 +2,6 @@ package persistence
 
 import (
 	"encoding/gob"
-
-	"gocache/pkg/cache"
 )
 
 func init() {
@@ -12,10 +10,13 @@ func init() {
 	gob.Register([]string{})
 }
 
+// SnapshotEntry is the gob-internal on-disk representation. ValueType and
+// Encoding are int (not uint8) to preserve gob wire compatibility with
+// snapshots written before the api/persistence types existed.
 type SnapshotEntry struct {
 	Key        string
-	ValueType  cache.ValueType
-	Encoding   cache.Encoding
+	ValueType  int
+	Encoding   int
 	Value      any
 	Expiration int64
 }

--- a/pkg/persistence/snapshotter_test.go
+++ b/pkg/persistence/snapshotter_test.go
@@ -61,8 +61,9 @@ func (r *recordingSnapshotter) snapshotEntries() []apipersistence.SnapshotEntry 
 func TestCoordinator_Snapshot_NoSnapshotter(t *testing.T) {
 	c := New(nil)
 	target := cache.New()
+	c.SetStore(target)
 
-	err := c.Snapshot(context.Background(), target)
+	err := c.Snapshot(context.Background())
 	if !errors.Is(err, apipersistence.ErrNoSnapshotter) {
 		t.Errorf("expected ErrNoSnapshotter, got %v", err)
 	}
@@ -95,9 +96,10 @@ func TestCoordinator_Snapshot_FeedsAllEntries(t *testing.T) {
 
 	rec := &recordingSnapshotter{name: "rec"}
 	c := New(nil)
+	c.SetStore(target)
 	c.RegisterSnapshotter(rec)
 
-	if err := c.Snapshot(context.Background(), target); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 
@@ -128,9 +130,10 @@ func TestCoordinator_Snapshot_PropagatesError(t *testing.T) {
 	wantErr := errors.New("disk full")
 	rec := &recordingSnapshotter{name: "rec", saveErr: wantErr}
 	c := New(nil)
+	c.SetStore(target)
 	c.RegisterSnapshotter(rec)
 
-	err := c.Snapshot(context.Background(), target)
+	err := c.Snapshot(context.Background())
 	if !errors.Is(err, wantErr) {
 		t.Errorf("expected %v, got %v", wantErr, err)
 	}
@@ -148,9 +151,10 @@ func TestCoordinator_Snapshot_GobRoundTrip(t *testing.T) {
 
 	gob := NewGobSource(file)
 	c := New(gob)
+	c.SetStore(source)
 	c.RegisterSnapshotter(gob)
 
-	if err := c.Snapshot(context.Background(), source); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	if _, err := os.Stat(file); err != nil {
@@ -159,7 +163,8 @@ func TestCoordinator_Snapshot_GobRoundTrip(t *testing.T) {
 
 	// Round-trip: load the same snapshot back into a fresh cache.
 	target := cache.New()
-	if _, err := c.BootInto(context.Background(), target); err != nil {
+	c.SetStore(target)
+	if _, err := c.BootInto(context.Background()); err != nil {
 		t.Fatalf("BootInto: %v", err)
 	}
 	if got := target.Len(); got != 2 {
@@ -179,9 +184,10 @@ func TestGobSource_SetFilename_HotReload(t *testing.T) {
 
 	gob := NewGobSource(file1)
 	c := New(gob)
+	c.SetStore(source)
 	c.RegisterSnapshotter(gob)
 
-	if err := c.Snapshot(context.Background(), source); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot to file1: %v", err)
 	}
 	if _, err := os.Stat(file1); err != nil {
@@ -189,7 +195,7 @@ func TestGobSource_SetFilename_HotReload(t *testing.T) {
 	}
 
 	gob.SetFilename(file2)
-	if err := c.Snapshot(context.Background(), source); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot to file2: %v", err)
 	}
 	if _, err := os.Stat(file2); err != nil {
@@ -263,6 +269,7 @@ func TestCoordinator_Snapshot_SeedsLSN(t *testing.T) {
 
 	rec := &recordingLSNSnapshotter{recordingSnapshotter: recordingSnapshotter{name: "v1-mock"}}
 	c := New(nil)
+	c.SetStore(target)
 	c.RegisterSnapshotter(rec)
 	// Burn LSNs so CurrentLSN is non-zero — verifies the coordinator
 	// reads its own cursor instead of always passing ZeroLSN.
@@ -270,7 +277,7 @@ func TestCoordinator_Snapshot_SeedsLSN(t *testing.T) {
 	c.AllocateLSN()
 	c.AllocateLSN()
 
-	if err := c.Snapshot(context.Background(), target); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	if rec.seededLSN != apipersistence.LSN(3) {
@@ -288,9 +295,10 @@ func TestCoordinator_Snapshot_NoSeedWhenNoLSNSeeder(t *testing.T) {
 
 	rec := &recordingSnapshotter{name: "gob-mock"}
 	c := New(nil)
+	c.SetStore(target)
 	c.RegisterSnapshotter(rec)
 	c.AllocateLSN() // make CurrentLSN > 0
-	if err := c.Snapshot(context.Background(), target); err != nil {
+	if err := c.Snapshot(context.Background()); err != nil {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	// No assertion on seededLSN — the recording snapshotter doesn't

--- a/pkg/resp/handler/persistence.go
+++ b/pkg/resp/handler/persistence.go
@@ -17,7 +17,7 @@ func HandleSnapshot(cmdCtx *command.Context) command.Result {
 		if cmdCtx.Snapshotter == nil {
 			return fmt.Errorf("snapshot: no snapshotter registered")
 		}
-		if err := cmdCtx.Snapshotter.Snapshot(cmdCtx.Context(), cmdCtx.Cache); err != nil {
+		if err := cmdCtx.Snapshotter.Snapshot(cmdCtx.Context()); err != nil {
 			return err
 		}
 		return "OK"
@@ -43,9 +43,8 @@ func HandleBgsave(cmdCtx *command.Context) command.Result {
 		return command.Result{Err: fmt.Errorf("snapshot: no snapshotter registered")}
 	}
 	snapshotter := cmdCtx.Snapshotter
-	c := cmdCtx.Cache
 	go func() {
-		if err := snapshotter.Snapshot(context.Background(), c); err != nil {
+		if err := snapshotter.Snapshot(context.Background()); err != nil {
 			logger.ErrorNoCtx().Err(err).Msg("BGSAVE failed")
 		}
 	}()

--- a/pkg/resp/handler/persistence_test.go
+++ b/pkg/resp/handler/persistence_test.go
@@ -31,6 +31,7 @@ func TestHandler_Snapshot(t *testing.T) {
 
 	gob := persistence.NewGobSource(snapshotFile)
 	coord := persistence.New(gob)
+	coord.SetStore(c1)
 	coord.RegisterSnapshotter(gob)
 
 	cmdCtx := &command.Context{
@@ -59,6 +60,7 @@ func TestHandler_Save(t *testing.T) {
 
 	gob := persistence.NewGobSource(snapshotFile)
 	coord := persistence.New(gob)
+	coord.SetStore(c)
 	coord.RegisterSnapshotter(gob)
 
 	cmdCtx := &command.Context{
@@ -98,6 +100,7 @@ func TestHandler_Bgsave(t *testing.T) {
 
 	gob := persistence.NewGobSource(snapshotFile)
 	coord := persistence.New(gob)
+	coord.SetStore(c)
 	coord.RegisterSnapshotter(gob)
 
 	cmdCtx := &command.Context{
@@ -149,6 +152,7 @@ func TestHandler_Lastsave(t *testing.T) {
 
 	gob := persistence.NewGobSource(snapshotFile)
 	coord := persistence.New(gob)
+	coord.SetStore(c)
 	coord.RegisterSnapshotter(gob)
 
 	// Before any save, LASTSAVE should return 0.

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -160,7 +160,7 @@ func (w *SnapshotWorker) Start(parentCtx context.Context) {
 					continue
 				}
 				if err := w.engine.Dispatch(opCtx, func() {
-					if err := w.snapshotter.Snapshot(opCtx, w.cache); err != nil {
+					if err := w.snapshotter.Snapshot(opCtx); err != nil {
 						logger.Warn(opCtx).Err(err).Msg("snapshot save failed")
 						w.failOp(op, err.Error())
 					} else {

--- a/pkg/workers/workers_test.go
+++ b/pkg/workers/workers_test.go
@@ -33,6 +33,7 @@ func TestSnapshotWorker_CreatesFile(t *testing.T) {
 
 	gob := persistence.NewGobSource(file)
 	coord := persistence.New(gob)
+	coord.SetStore(c)
 	coord.RegisterSnapshotter(gob)
 
 	w := NewSnapshotWorker(c, e, 50*time.Millisecond)


### PR DESCRIPTION
…cheStore interface

Introduce api/persistence.CacheStore (3 methods: CaptureSnapshot, LoadEntry, Clear) as the abstraction boundary between the persistence coordinator and cache internals. The coordinator no longer imports pkg/cache — all cache access flows through the interface, enforcing the layering rule that api/ is the sole connection between subsystems.

Key changes:
- Coordinator holds CacheStore via SetStore(), Snapshot/BootInto no longer take *cache.Cache parameters
- Capture/apply logic moved from coordinator to pkg/cache/store.go
- Gob-internal SnapshotEntry keeps int-backed fields for wire compatibility
- Nil-store guards prevent panics when SetStore is omitted