### PR TITLE
feat(config): plugin config autonomy — BindEnv + MergeFile

### DIFF
--- a/api/config/plugin.go
+++ b/api/config/plugin.go
@@ -29,6 +29,21 @@ type PluginConfig interface {
 	GetStringSlice(key string) []string
 	IsSet(key string) bool
 	SetDefault(key string, value any)
+
+	// BindEnv maps a plugin key to one or more env var names. The first
+	// matching env var wins. The long-form GOCACHE_PLUGINS_CONFIG_<NAME>_KEY
+	// continues to work via the config loader's automatic env resolution;
+	// BindEnv adds shorter aliases (e.g. GOCACHE_AOF_FILE). Call this in
+	// Build before reading keys. See ADR-0018.
+	BindEnv(key string, envVars ...string)
+
+	// MergeFile reads a config file (YAML, JSON, or TOML — format is
+	// auto-detected from the file extension) and merges its keys into the
+	// plugin's namespace as low-priority values.
+	// Priority: env > server config > plugin file > SetDefault.
+	// A missing file is silently ignored (returns nil). A parse error is
+	// returned. See ADR-0018.
+	MergeFile(path string) error
 }
 
 // ReloadHandler is the optional capability a plugin's Provider

--- a/api/config/testhelper.go
+++ b/api/config/testhelper.go
@@ -1,0 +1,84 @@
+package config
+
+import "time"
+
+// MapConfig is a test stand-in for PluginConfig that stores values in
+// plain maps. Use it in plugin tests to construct a config view with
+// canned values — no global state, no viper dependency.
+//
+// Production code must not use MapConfig.
+type MapConfig struct {
+	Values   map[string]any
+	Defaults map[string]any
+}
+
+var _ PluginConfig = (*MapConfig)(nil)
+
+// NewMapConfig returns a ready-to-use test config.
+func NewMapConfig() *MapConfig {
+	return &MapConfig{Values: map[string]any{}, Defaults: map[string]any{}}
+}
+
+func (m *MapConfig) lookup(key string) any {
+	if v, ok := m.Values[key]; ok {
+		return v
+	}
+	if v, ok := m.Defaults[key]; ok {
+		return v
+	}
+	return nil
+}
+
+func (m *MapConfig) GetString(key string) string {
+	if v, ok := m.lookup(key).(string); ok {
+		return v
+	}
+	return ""
+}
+
+func (m *MapConfig) GetInt(key string) int {
+	if v, ok := m.lookup(key).(int); ok {
+		return v
+	}
+	return 0
+}
+
+func (m *MapConfig) GetInt64(key string) int64 {
+	if v, ok := m.lookup(key).(int64); ok {
+		return v
+	}
+	return 0
+}
+
+func (m *MapConfig) GetBool(key string) bool {
+	if v, ok := m.lookup(key).(bool); ok {
+		return v
+	}
+	return false
+}
+
+func (m *MapConfig) GetDuration(key string) time.Duration {
+	if v, ok := m.lookup(key).(time.Duration); ok {
+		return v
+	}
+	return 0
+}
+
+func (m *MapConfig) GetStringSlice(key string) []string {
+	if v, ok := m.lookup(key).([]string); ok {
+		return v
+	}
+	return nil
+}
+
+func (m *MapConfig) IsSet(key string) bool {
+	_, ok := m.Values[key]
+	return ok
+}
+
+func (m *MapConfig) SetDefault(key string, value any) {
+	m.Defaults[key] = value
+}
+
+func (m *MapConfig) BindEnv(string, ...string) {}
+func (m *MapConfig) MergeFile(string) error    { return nil }

--- a/api/persistence/registry_test.go
+++ b/api/persistence/registry_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	apiconfig "gocache/api/config"
 	apipersistence "gocache/api/persistence"
@@ -27,17 +26,6 @@ func (f *fakeProvider) Build(_ apiconfig.PluginConfig, _ apipersistence.CacheSto
 		Snapshotter: &fakeSnap{},
 	}, nil
 }
-
-type noopConfig struct{}
-
-func (noopConfig) GetString(string) string          { return "" }
-func (noopConfig) GetInt(string) int                { return 0 }
-func (noopConfig) GetInt64(string) int64            { return 0 }
-func (noopConfig) GetBool(string) bool              { return false }
-func (noopConfig) GetDuration(string) time.Duration { return 0 }
-func (noopConfig) GetStringSlice(string) []string   { return nil }
-func (noopConfig) IsSet(string) bool                { return false }
-func (noopConfig) SetDefault(string, any)           {}
 
 type fakeSource struct{}
 
@@ -76,7 +64,7 @@ func TestRegistry_Register_RoundTrip(t *testing.T) {
 		t.Errorf("name = %q, want test-provider", got.Name())
 	}
 
-	backend, err := got.Build(noopConfig{}, nil)
+	backend, err := got.Build(apiconfig.NewMapConfig(), nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}

--- a/docs/adr/0018-plugin-config-autonomy.md
+++ b/docs/adr/0018-plugin-config-autonomy.md
@@ -1,0 +1,87 @@
+---
+title: ADR-0018 Plugin config autonomy — BindEnv and MergeFile
+description: Extend PluginConfig so plugins can declare short env var names and load their own config files
+status: proposed
+date: 2026-05-24
+deciders: [witherxse]
+related:
+  - ADR-0008
+  - Plugins
+---
+
+# ADR-0018: Plugin config autonomy — BindEnv and MergeFile
+
+## Context
+
+ADR-0008 established a library-agnostic `PluginConfig` interface backed by viper's `plugins.config.<name>.*` namespace. Plugins read scoped keys (`"file"`) that resolve to the full path (`plugins.config.aof.file`) inside viper. This works for YAML config but has two gaps:
+
+1. **Env var ergonomics.** Viper's `AutomaticEnv` maps keys to env vars by uppercasing and replacing dots with underscores: `plugins.config.aof.file` → `GOCACHE_PLUGINS_CONFIG_AOF_FILE`. Operators expect `GOCACHE_AOF_FILE`. Plugins have no way to declare shorter aliases.
+
+2. **No plugin-owned config file.** A plugin that ships its own `aof.yaml` cannot load it through `PluginConfig`. The only config sources are the server's YAML file + env vars. Operators managing many plugins must edit the central config file for every plugin-specific knob.
+
+Lifecycle plugins (otlp, crashdump) use raw `os.Getenv()` in `BootInit` because they run before `config.Load()`. This is a timing constraint inherent to the embedded plugin lifecycle, not a design flaw — they need configuration before the config system exists.
+
+## Decision
+
+We extend `PluginConfig` with two methods:
+
+```go
+BindEnv(key string, envVars ...string)
+MergeFile(path string) error
+```
+
+`BindEnv` registers short env var aliases for a plugin key. The long-form name (`GOCACHE_PLUGINS_CONFIG_AOF_FILE`) continues to work via `AutomaticEnv`. Plugins call `cfg.BindEnv("file", "GOCACHE_AOF_FILE")` in `Build` before reading keys.
+
+`MergeFile` reads a plugin-owned config file (YAML, JSON, or TOML — format auto-detected) and merges its keys under the plugin's namespace as defaults. Missing file is silently ignored; parse error is returned.
+
+Merge priority (highest to lowest):
+1. CLI flags
+2. Env vars (BindEnv short names + AutomaticEnv long names)
+3. Server config file (`gocache.yaml` under `plugins.config.<name>.*`)
+4. Plugin config file (flat keys merged under prefix)
+5. `SetDefault` values
+
+We also consolidate the three duplicated `PluginConfig` test implementations into a single exported `MapConfig` in `api/config/`.
+
+## Alternatives Considered
+
+### Alternative 1: Plugin-level viper instance
+
+Give each plugin its own viper with its own env prefix (`GOCACHE_AOF_*`), config file, and defaults.
+
+- **Pros**: Full isolation, plugin controls everything.
+- **Cons**: Fragments the config space — operators can't put all plugin config in one YAML file. Duplicates env-prefix wiring in every plugin. Breaks the single-viper reload model (fsnotify watches one file, not N).
+- **Why not**: The centralized config file is a feature, not a limitation. Operators want one YAML with sections, not N files to manage. Adding a per-plugin file as an optional merge source preserves both.
+
+### Alternative 2: Config struct with struct tags
+
+Plugin declares a Go struct with `yaml:"..."` tags. Server decodes the plugin's config section into the struct automatically.
+
+- **Pros**: Type-safe, no string key lookups.
+- **Cons**: Rejected by ADR-0008 — the server would need to know the plugin's struct type at compile time, or use reflection to decode into an `any`. Either approach couples the server to plugin internals. The interface-based approach keeps the server generic.
+- **Why not**: Violates plugin isolation. The server must remain ignorant of plugin-specific types.
+
+### Alternative 3: Unify lifecycle plugins onto PluginConfig
+
+Make otlp/crashdump use `PluginConfig` instead of `os.Getenv()`.
+
+- **Pros**: One config system for all plugins.
+- **Cons**: `BootInit` runs before `config.Load()` — `PluginConfig` is not available yet. Would require either reordering boot (breaking OTLP's t=0 span coverage) or a two-phase init (complexity for no gain).
+- **Why not**: The timing constraint is real and justified. Document it; don't fight it.
+
+## Consequences
+
+### Positive
+
+- Operators use ergonomic env var names: `GOCACHE_AOF_FILE` instead of `GOCACHE_PLUGINS_CONFIG_AOF_FILE`.
+- Plugins can ship their own config file as a self-contained default.
+- Test helper consolidation eliminates ~80 lines of duplicated `mapConfig` implementations.
+
+### Negative
+
+- `PluginConfig` interface grows by two methods. Every implementation (pluginView, nopConfig, test helpers) must add them.
+
+### Risks
+
+- **Risk**: `BindEnv` short-name collision — two plugins bind `GOCACHE_FILE`. **Mitigation**: Convention (use `GOCACHE_<PLUGIN>_<KEY>`). Document in plugin author guide. No runtime enforcement needed — operator error.
+- **Risk**: `MergeFile` called after `Build` returns could introduce ordering-dependent behavior. **Mitigation**: Document that `MergeFile` is intended for use in `Build` only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0015](0015-mset-allocation-reduction.md) | MSET allocation reduction | accepted | 2026-05-19 |
 | [0016](0016-aof-wire-and-file-format.md) | AOF wire and file format | accepted | 2026-05-21 |
 | [0017](0017-mutation-replay-execution-path.md) | Mutation replay execution path | accepted | 2026-05-21 |
+| [0018](0018-plugin-config-autonomy.md) | Plugin config autonomy (BindEnv + MergeFile) | proposed | 2026-05-24 |
 
 ## Writing a new ADR
 

--- a/pkg/config/handle_test.go
+++ b/pkg/config/handle_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -163,6 +165,115 @@ func TestOnPluginReload_NopWhenHandleUnset(t *testing.T) {
 
 	if _, ok := observed.(nopConfig); !ok {
 		t.Errorf("expected nopConfig when handle unset, got %T", observed)
+	}
+}
+
+func TestPluginBindEnv(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	t.Setenv("GOCACHE_AOF_FILE", "from-env.aof")
+
+	v := viper.New()
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	cfg.BindEnv("file", "GOCACHE_AOF_FILE")
+
+	if got := cfg.GetString("file"); got != "from-env.aof" {
+		t.Errorf("BindEnv: got %q, want %q", got, "from-env.aof")
+	}
+}
+
+func TestPluginBindEnv_OverridesDefault(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	t.Setenv("GOCACHE_AOF_FILE", "env-wins.aof")
+
+	v := viper.New()
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	cfg.SetDefault("file", "default.aof")
+	cfg.BindEnv("file", "GOCACHE_AOF_FILE")
+
+	if got := cfg.GetString("file"); got != "env-wins.aof" {
+		t.Errorf("env should override default: got %q", got)
+	}
+}
+
+func TestPluginMergeFile(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "aof.yaml")
+	os.WriteFile(pluginFile, []byte("file: merged.aof\nfsync: always\n"), 0644)
+
+	v := viper.New()
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	if err := cfg.MergeFile(pluginFile); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	if got := cfg.GetString("file"); got != "merged.aof" {
+		t.Errorf("merged key: got %q, want %q", got, "merged.aof")
+	}
+	if got := cfg.GetString("fsync"); got != "always" {
+		t.Errorf("merged key: got %q, want %q", got, "always")
+	}
+}
+
+func TestPluginMergeFile_ServerConfigWins(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "aof.yaml")
+	os.WriteFile(pluginFile, []byte("file: from-plugin.aof\n"), 0644)
+
+	v := viper.New()
+	v.Set("plugins.config.aof.file", "from-server.aof")
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	if err := cfg.MergeFile(pluginFile); err != nil {
+		t.Fatalf("MergeFile: %v", err)
+	}
+	if got := cfg.GetString("file"); got != "from-server.aof" {
+		t.Errorf("server config should win: got %q, want %q", got, "from-server.aof")
+	}
+}
+
+func TestPluginMergeFile_MissingFile(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	v := viper.New()
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	if err := cfg.MergeFile("/nonexistent/path/aof.yaml"); err != nil {
+		t.Errorf("missing file should not error: %v", err)
+	}
+}
+
+func TestPluginMergeFile_InvalidFile(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "bad.yaml")
+	os.WriteFile(pluginFile, []byte(":\n  :\n    - :\n  bad: [unmatched"), 0644)
+
+	v := viper.New()
+	installHandle(v)
+
+	cfg := PluginConfigFor("aof")
+	if err := cfg.MergeFile(pluginFile); err == nil {
+		t.Error("expected error for invalid YAML, got nil")
 	}
 }
 

--- a/pkg/config/plugin_view.go
+++ b/pkg/config/plugin_view.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/viper"
@@ -44,6 +46,28 @@ func (p pluginView) GetStringSlice(key string) []string      { return p.v.GetStr
 func (p pluginView) IsSet(key string) bool                   { return p.v.IsSet(p.qualified(key)) }
 func (p pluginView) SetDefault(key string, value any)        { p.v.SetDefault(p.qualified(key), value) }
 
+func (p pluginView) BindEnv(key string, envVars ...string) {
+	_ = p.v.BindEnv(append([]string{p.qualified(key)}, envVars...)...)
+}
+
+func (p pluginView) MergeFile(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	tmp := viper.New()
+	tmp.SetConfigFile(path)
+	if err := tmp.ReadInConfig(); err != nil {
+		return fmt.Errorf("plugin config merge: %w", err)
+	}
+	for _, key := range tmp.AllKeys() {
+		qualified := p.qualified(key)
+		if !p.v.IsSet(qualified) {
+			p.v.SetDefault(qualified, tmp.Get(key))
+		}
+	}
+	return nil
+}
+
 // Compile-time check that pluginView satisfies the contract.
 var _ apiconfig.PluginConfig = pluginView{}
 
@@ -65,5 +89,7 @@ func (nopConfig) GetDuration(string) time.Duration    { return 0 }
 func (nopConfig) GetStringSlice(string) []string      { return nil }
 func (nopConfig) IsSet(string) bool                   { return false }
 func (nopConfig) SetDefault(string, any)              {}
+func (nopConfig) BindEnv(string, ...string)           {}
+func (nopConfig) MergeFile(string) error              { return nil }
 
 var _ apiconfig.PluginConfig = nopConfig{}

--- a/plugins/aof/init.go
+++ b/plugins/aof/init.go
@@ -37,6 +37,8 @@ func (provider) Name() string { return "aof" }
 func (p *provider) Build(cfg apiconfig.PluginConfig, store apipersistence.CacheStore) (*apipersistence.Backend, error) {
 	cfg.SetDefault(keyFile, defaultFile)
 	cfg.SetDefault(keyFsync, defaultFsync)
+	cfg.BindEnv(keyFile, "GOCACHE_AOF_FILE")
+	cfg.BindEnv(keyFsync, "GOCACHE_AOF_FSYNC")
 
 	file := cfg.GetString(keyFile)
 	if file == "" {

--- a/plugins/aof/init_test.go
+++ b/plugins/aof/init_test.go
@@ -9,13 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	apiconfig "gocache/api/config"
 	apipersistence "gocache/api/persistence"
 )
-
-var _ apiconfig.PluginConfig = (*mapConfig)(nil)
 
 func TestSinkAndSource_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.aof")
@@ -141,8 +138,8 @@ func TestProvider_Build(t *testing.T) {
 	t.Cleanup(apipersistence.ResetProvidersForTest)
 
 	p := &provider{}
-	cfg := newMapConfig()
-	cfg.values[keyFile] = filepath.Join(t.TempDir(), "test.aof")
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = filepath.Join(t.TempDir(), "test.aof")
 
 	backend, err := p.Build(cfg, nil)
 	if err != nil {
@@ -172,7 +169,7 @@ func TestProvider_Build_AppliesDefaults(t *testing.T) {
 	apipersistence.ResetProvidersForTest()
 	t.Cleanup(apipersistence.ResetProvidersForTest)
 
-	cfg := newMapConfig()
+	cfg := apiconfig.NewMapConfig()
 	p := &provider{}
 	backend, err := p.Build(cfg, nil)
 	if err != nil {
@@ -190,8 +187,8 @@ func TestProvider_Build_AppliesDefaults(t *testing.T) {
 }
 
 func TestProvider_Build_EmptyFile_Errors(t *testing.T) {
-	cfg := newMapConfig()
-	cfg.values[keyFile] = ""
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = ""
 
 	p := &provider{}
 	_, err := p.Build(cfg, nil)
@@ -202,9 +199,9 @@ func TestProvider_Build_EmptyFile_Errors(t *testing.T) {
 
 func TestProvider_OnConfigReload(t *testing.T) {
 	dir := t.TempDir()
-	cfg := newMapConfig()
-	cfg.values[keyFile] = filepath.Join(dir, "test.aof")
-	cfg.values[keyFsync] = "no"
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = filepath.Join(dir, "test.aof")
+	cfg.Values[keyFsync] = "no"
 
 	p := &provider{}
 	backend, err := p.Build(cfg, nil)
@@ -218,8 +215,8 @@ func TestProvider_OnConfigReload(t *testing.T) {
 		t.Fatalf("initial policy = %v, want FsyncNo", sink.FsyncPolicy())
 	}
 
-	reloadCfg := newMapConfig()
-	reloadCfg.values[keyFsync] = "always"
+	reloadCfg := apiconfig.NewMapConfig()
+	reloadCfg.Values[keyFsync] = "always"
 	p.OnConfigReload(reloadCfg)
 
 	if sink.FsyncPolicy() != apipersistence.FsyncAlways {
@@ -466,9 +463,9 @@ func TestBGREWRITEAOF_ConcurrentRejection(t *testing.T) {
 	t.Cleanup(apipersistence.ResetProvidersForTest)
 
 	dir := t.TempDir()
-	cfg := newMapConfig()
-	cfg.values[keyFile] = filepath.Join(dir, "test.aof")
-	cfg.values[keyFsync] = "no"
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = filepath.Join(dir, "test.aof")
+	cfg.Values[keyFsync] = "no"
 
 	store := &fakeStore{
 		entries: []apipersistence.SnapshotEntry{
@@ -508,39 +505,6 @@ func TestBGREWRITEAOF_ConcurrentRejection(t *testing.T) {
 }
 
 // --- test helpers ---
-
-type mapConfig struct {
-	values   map[string]any
-	defaults map[string]any
-}
-
-func newMapConfig() *mapConfig {
-	return &mapConfig{values: map[string]any{}, defaults: map[string]any{}}
-}
-
-func (m *mapConfig) lookup(key string) any {
-	if v, ok := m.values[key]; ok {
-		return v
-	}
-	if v, ok := m.defaults[key]; ok {
-		return v
-	}
-	return nil
-}
-
-func (m *mapConfig) GetString(key string) string {
-	if v, ok := m.lookup(key).(string); ok {
-		return v
-	}
-	return ""
-}
-func (m *mapConfig) GetInt(string) int                     { return 0 }
-func (m *mapConfig) GetInt64(string) int64                 { return 0 }
-func (m *mapConfig) GetBool(string) bool                   { return false }
-func (m *mapConfig) GetDuration(string) time.Duration      { return 0 }
-func (m *mapConfig) GetStringSlice(string) []string        { return nil }
-func (m *mapConfig) IsSet(key string) bool                 { _, ok := m.values[key]; return ok }
-func (m *mapConfig) SetDefault(key string, value any)      { m.defaults[key] = value }
 
 type fakeStore struct {
 	entries []apipersistence.SnapshotEntry

--- a/plugins/snapshot/init.go
+++ b/plugins/snapshot/init.go
@@ -26,6 +26,7 @@ func (provider) Name() string { return "snapshot" }
 
 func (p *provider) Build(cfg apiconfig.PluginConfig, _ apipersistence.CacheStore) (*apipersistence.Backend, error) {
 	cfg.SetDefault(keyFile, defaultFile)
+	cfg.BindEnv(keyFile, "GOCACHE_SNAPSHOT_FILE")
 	file := cfg.GetString(keyFile)
 	if file == "" {
 		return nil, fmt.Errorf("snapshot: %q is required", keyFile)

--- a/plugins/snapshot/init_test.go
+++ b/plugins/snapshot/init_test.go
@@ -6,80 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
-
 	apiconfig "gocache/api/config"
 	apipersistence "gocache/api/persistence"
 )
-
-// mapConfig is the test stand-in for apiconfig.PluginConfig. It keeps
-// values in a plain map so tests can construct a config view with
-// canned values and pass it directly to Build / OnConfigReload — no
-// global state, no swap-and-restore on a process-wide handle.
-type mapConfig struct {
-	values   map[string]any
-	defaults map[string]any
-}
-
-func newMapConfig() *mapConfig {
-	return &mapConfig{values: map[string]any{}, defaults: map[string]any{}}
-}
-
-func (m *mapConfig) lookup(key string) any {
-	if v, ok := m.values[key]; ok {
-		return v
-	}
-	if v, ok := m.defaults[key]; ok {
-		return v
-	}
-	return nil
-}
-
-func (m *mapConfig) GetString(key string) string {
-	if v, ok := m.lookup(key).(string); ok {
-		return v
-	}
-	return ""
-}
-func (m *mapConfig) GetInt(key string) int {
-	if v, ok := m.lookup(key).(int); ok {
-		return v
-	}
-	return 0
-}
-func (m *mapConfig) GetInt64(key string) int64 {
-	if v, ok := m.lookup(key).(int64); ok {
-		return v
-	}
-	return 0
-}
-func (m *mapConfig) GetBool(key string) bool {
-	if v, ok := m.lookup(key).(bool); ok {
-		return v
-	}
-	return false
-}
-func (m *mapConfig) GetDuration(key string) time.Duration {
-	if v, ok := m.lookup(key).(time.Duration); ok {
-		return v
-	}
-	return 0
-}
-func (m *mapConfig) GetStringSlice(key string) []string {
-	if v, ok := m.lookup(key).([]string); ok {
-		return v
-	}
-	return nil
-}
-func (m *mapConfig) IsSet(key string) bool {
-	_, ok := m.values[key]
-	return ok
-}
-func (m *mapConfig) SetDefault(key string, value any) {
-	m.defaults[key] = value
-}
-
-var _ apiconfig.PluginConfig = (*mapConfig)(nil)
 
 // TestProvider_Build_ReadsScopedKey verifies the plugin pulls its
 // filename from the scoped "file" key (no full path).
@@ -87,8 +16,8 @@ func TestProvider_Build_ReadsScopedKey(t *testing.T) {
 	dir := t.TempDir()
 	wantFile := filepath.Join(dir, "configured.snap")
 
-	cfg := newMapConfig()
-	cfg.values[keyFile] = wantFile
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = wantFile
 
 	p := &provider{}
 	backend, err := p.Build(cfg, nil)
@@ -110,7 +39,7 @@ func TestProvider_Build_ReadsScopedKey(t *testing.T) {
 // TestProvider_Build_AppliesDefault verifies the plugin's SetDefault
 // call provides a fallback when the operator hasn't set "file".
 func TestProvider_Build_AppliesDefault(t *testing.T) {
-	cfg := newMapConfig()
+	cfg := apiconfig.NewMapConfig()
 
 	p := &provider{}
 	if _, err := p.Build(cfg, nil); err != nil {
@@ -125,8 +54,8 @@ func TestProvider_Build_AppliesDefault(t *testing.T) {
 // TestProvider_Build_RequiredKeyEmpty verifies that an empty filename
 // (e.g. operator explicitly set the key to "") surfaces as an error.
 func TestProvider_Build_RequiredKeyEmpty(t *testing.T) {
-	cfg := newMapConfig()
-	cfg.values[keyFile] = "" // explicit empty wins over the SetDefault inside Build
+	cfg := apiconfig.NewMapConfig()
+	cfg.Values[keyFile] = "" // explicit empty wins over the SetDefault inside Build
 
 	p := &provider{}
 	_, err := p.Build(cfg, nil)
@@ -143,8 +72,8 @@ func TestProvider_OnConfigReload(t *testing.T) {
 	first := filepath.Join(dir, "first.snap")
 	second := filepath.Join(dir, "second.snap")
 
-	cfgInitial := newMapConfig()
-	cfgInitial.values[keyFile] = first
+	cfgInitial := apiconfig.NewMapConfig()
+	cfgInitial.Values[keyFile] = first
 
 	p := &provider{}
 	backend, err := p.Build(cfgInitial, nil)
@@ -160,8 +89,8 @@ func TestProvider_OnConfigReload(t *testing.T) {
 		t.Errorf("first snapshot missing: %v", err)
 	}
 
-	cfgReloaded := newMapConfig()
-	cfgReloaded.values[keyFile] = second
+	cfgReloaded := apiconfig.NewMapConfig()
+	cfgReloaded.Values[keyFile] = second
 	p.OnConfigReload(cfgReloaded)
 
 	if err := snap.SaveSnapshot(context.Background(), emptySrc{}); err != nil {


### PR DESCRIPTION
## Summary

- Extend `PluginConfig` interface with `BindEnv(key, envVars...)` and `MergeFile(path) error` so plugins can register short env var aliases and load their own config files (ADR-0018)
- Implement both methods on `pluginView` (viper-backed) and `nopConfig` (zero-value stub)
- Add shared `MapConfig` test helper in `api/config/testhelper.go`, replacing three duplicated implementations across `plugins/aof`, `plugins/snapshot`, and `api/persistence` tests (~140 lines removed)
- Wire `BindEnv` calls in AOF (`GOCACHE_AOF_FILE`, `GOCACHE_AOF_FSYNC`) and snapshot (`GOCACHE_SNAPSHOT_FILE`) plugins

Merge priority: CLI flags > env vars (BindEnv aliases + AutomaticEnv) > server config > plugin config file > SetDefault.

## Test plan

- [x] `TestPluginBindEnv` — env var resolves through pluginView
- [x] `TestPluginBindEnv_OverridesDefault` — env var beats SetDefault
- [x] `TestPluginMergeFile` — temp YAML merged, values resolve
- [x] `TestPluginMergeFile_ServerConfigWins` — server config overrides plugin file
- [x] `TestPluginMergeFile_MissingFile` — no error on absent file
- [x] `TestPluginMergeFile_InvalidFile` — returns error on corrupt YAML
- [x] All existing plugin tests migrated to shared `MapConfig` and passing
- [x] `go build -tags "aof crashdump otlp" ./...`
- [x] `go test -tags "aof crashdump otlp" -race ./...`
- [x] `go vet ./...`