### PR TITLE
feat(config): unify embedded plugin config with PluginConfigFor

### DIFF
--- a/api/config/plugin.go
+++ b/api/config/plugin.go
@@ -1,6 +1,32 @@
 package config
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
+
+// pluginConfigProvider is set once by the config loader (pkg/config)
+// after the server config is loaded. Embedded plugins call
+// PluginConfigFor in ConfigLoaded to get their scoped view.
+var pluginConfigProvider atomic.Value // stores func(string) PluginConfig
+
+// SetPluginConfigProvider registers the function that produces scoped
+// PluginConfig views. Called once by pkg/config during installHandle.
+// After this call, PluginConfigFor delegates to fn.
+func SetPluginConfigProvider(fn func(string) PluginConfig) {
+	pluginConfigProvider.Store(fn)
+}
+
+// PluginConfigFor returns a scoped PluginConfig view for the named
+// plugin. Safe to call from ConfigLoaded and later. Before the config
+// loader runs, returns a zero-value MapConfig (all Gets return zero,
+// SetDefault and BindEnv are no-ops).
+func PluginConfigFor(name string) PluginConfig {
+	if fn, ok := pluginConfigProvider.Load().(func(string) PluginConfig); ok {
+		return fn(name)
+	}
+	return NewMapConfig()
+}
 
 // PluginConfig is the typed read-only view of a single embedded plugin's
 // configuration subsection. The server hands one to each plugin's

--- a/api/config/plugin_test.go
+++ b/api/config/plugin_test.go
@@ -1,0 +1,31 @@
+package config_test
+
+import (
+	"testing"
+
+	"gocache/api/config"
+)
+
+func TestPluginConfigFor_BeforeProvider(t *testing.T) {
+	cfg := config.PluginConfigFor("anything")
+	if cfg == nil {
+		t.Fatal("PluginConfigFor returned nil before provider set")
+	}
+	if cfg.GetString("key") != "" {
+		t.Error("expected empty string from fallback config")
+	}
+}
+
+func TestPluginConfigFor_AfterProvider(t *testing.T) {
+	config.SetPluginConfigProvider(func(name string) config.PluginConfig {
+		m := config.NewMapConfig()
+		m.Values["name"] = name
+		return m
+	})
+	t.Cleanup(func() { config.SetPluginConfigProvider(nil) })
+
+	cfg := config.PluginConfigFor("test-plugin")
+	if got := cfg.GetString("name"); got != "test-plugin" {
+		t.Errorf("provider not called: got %q, want %q", got, "test-plugin")
+	}
+}

--- a/docs/adr/0018-plugin-config-autonomy.md
+++ b/docs/adr/0018-plugin-config-autonomy.md
@@ -61,13 +61,12 @@ Plugin declares a Go struct with `yaml:"..."` tags. Server decodes the plugin's 
 - **Cons**: Rejected by ADR-0008 — the server would need to know the plugin's struct type at compile time, or use reflection to decode into an `any`. Either approach couples the server to plugin internals. The interface-based approach keeps the server generic.
 - **Why not**: Violates plugin isolation. The server must remain ignorant of plugin-specific types.
 
-### Alternative 3: Unify lifecycle plugins onto PluginConfig
+### Alternative 3: Fully defer lifecycle plugin config to ConfigLoaded
 
-Make otlp/crashdump use `PluginConfig` instead of `os.Getenv()`.
+Originally considered impossible because `BootInit` runs before `config.Load()`. Revisited: crashdump's `BootInit` only stores config — all work happens in `ConfigLoaded`. So config reading can move entirely to `ConfigLoaded` using `PluginConfigFor`. OTLP's `BootInit` genuinely creates the exporter (timing constraint is real), so it keeps env-var bootstrap with `PluginConfig` registration in `ConfigLoaded` for consistency.
 
-- **Pros**: One config system for all plugins.
-- **Cons**: `BootInit` runs before `config.Load()` — `PluginConfig` is not available yet. Would require either reordering boot (breaking OTLP's t=0 span coverage) or a two-phase init (complexity for no gain).
-- **Why not**: The timing constraint is real and justified. Document it; don't fight it.
+- **Adopted for crashdump**: full migration to PluginConfig in ConfigLoaded.
+- **Adopted for OTLP**: BootInit keeps `applyEnv()`; ConfigLoaded registers BindEnv + SetDefault so the config schema is documented and YAML-discoverable.
 
 ## Consequences
 
@@ -76,10 +75,13 @@ Make otlp/crashdump use `PluginConfig` instead of `os.Getenv()`.
 - Operators use ergonomic env var names: `GOCACHE_AOF_FILE` instead of `GOCACHE_PLUGINS_CONFIG_AOF_FILE`.
 - Plugins can ship their own config file as a self-contained default.
 - Test helper consolidation eliminates ~80 lines of duplicated `mapConfig` implementations.
+- Embedded plugins (crashdump, OTLP) use the same config pattern as persistence plugins — `SetDefault` + `BindEnv` + `Get*` via `PluginConfigFor`.
+- `api/config.PluginConfigFor` gives all plugins a single entry point to their scoped config, regardless of plugin type.
 
 ### Negative
 
 - `PluginConfig` interface grows by two methods. Every implementation (pluginView, nopConfig, test helpers) must add them.
+- `api/config` gains mutable package-level state (`pluginConfigProvider`). Acceptable: set once by `pkg/config` during load, read-only thereafter.
 
 ### Risks
 

--- a/pkg/config/handle.go
+++ b/pkg/config/handle.go
@@ -20,6 +20,7 @@ var serverConfig atomic.Pointer[viper.Viper]
 // once viper is fully wired (defaults + flags + env + file + watch).
 func installHandle(v *viper.Viper) {
 	serverConfig.Store(v)
+	apiconfig.SetPluginConfigProvider(PluginConfigFor)
 }
 
 // PluginConfigFor returns a typed read-only view of the named plugin's

--- a/pkg/config/handle_test.go
+++ b/pkg/config/handle_test.go
@@ -168,6 +168,20 @@ func TestOnPluginReload_NopWhenHandleUnset(t *testing.T) {
 	}
 }
 
+func TestAPIPluginConfigFor_DelegatesToPkgConfig(t *testing.T) {
+	prev := serverConfig.Load()
+	t.Cleanup(func() { serverConfig.Store(prev) })
+
+	v := viper.New()
+	v.Set("plugins.config.myplugin.key", "value-from-server")
+	installHandle(v)
+
+	cfg := apiconfig.PluginConfigFor("myplugin")
+	if got := cfg.GetString("key"); got != "value-from-server" {
+		t.Errorf("api-level PluginConfigFor: got %q, want %q", got, "value-from-server")
+	}
+}
+
 func TestPluginBindEnv(t *testing.T) {
 	prev := serverConfig.Load()
 	t.Cleanup(func() { serverConfig.Store(prev) })

--- a/plugins/crashdump/crashdump.go
+++ b/plugins/crashdump/crashdump.go
@@ -15,8 +15,6 @@ package crashdump
 
 import (
 	"context"
-	"os"
-	"strconv"
 
 	"gocache/api/config"
 	"gocache/api/crashdump"
@@ -24,9 +22,10 @@ import (
 	"gocache/api/logger"
 )
 
-// Env var overrides. Evaluated in BootInit so they take effect even when
-// config.Load hasn't run yet.
 const (
+	keyDir      = "dir"
+	keyDisabled = "disabled"
+
 	envDir      = "GOCACHE_CRASHDUMP_DIR"
 	envDisabled = "GOCACHE_CRASHDUMP_DISABLED"
 	defaultDir  = crashdump.DefaultCrashdumpDir
@@ -43,24 +42,18 @@ func init() {
 
 func (p *plugin) Name() string { return "crashdump" }
 
-func (p *plugin) BootInit(_ context.Context) error {
-	if v := os.Getenv(envDir); v != "" {
-		p.dir = v
-	}
-	if v := os.Getenv(envDisabled); v != "" {
-		if parsed, err := strconv.ParseBool(v); err == nil {
-			p.disabled = parsed
-		}
-	}
-	return nil
-}
+func (p *plugin) BootInit(_ context.Context) error { return nil }
 
-// ConfigLoaded is where scan-and-report runs. We wait for the proper
-// logger to be initialized (with the configured level + writer) so the
-// WARN lines flow through the log collector into the event bus and then
-// out to observability plugins. Scanning in BootInit would predate that
-// wiring and the entries would only hit stderr.
 func (p *plugin) ConfigLoaded(ctx context.Context, _ *config.Config) error {
+	cfg := config.PluginConfigFor("crashdump")
+	cfg.SetDefault(keyDir, defaultDir)
+	cfg.SetDefault(keyDisabled, false)
+	cfg.BindEnv(keyDir, envDir)
+	cfg.BindEnv(keyDisabled, envDisabled)
+
+	p.dir = cfg.GetString(keyDir)
+	p.disabled = cfg.GetBool(keyDisabled)
+
 	if p.disabled {
 		return nil
 	}

--- a/plugins/otlp/otlp.go
+++ b/plugins/otlp/otlp.go
@@ -22,13 +22,18 @@ import (
 	"gocache/api/logger"
 )
 
-// Env var overrides. Plugin reads them in BootInit, before config.Load.
 const (
-	envEndpoint    = "GOCACHE_EMBEDDED_OTLP_ENDPOINT"
-	envService     = "GOCACHE_EMBEDDED_OTLP_SERVICE"
-	envTimeoutMs   = "GOCACHE_EMBEDDED_OTLP_TIMEOUT_MS"
-	envInsecure    = "GOCACHE_EMBEDDED_OTLP_INSECURE"
-	envDisabled    = "GOCACHE_EMBEDDED_OTLP_DISABLED"
+	keyEndpoint  = "endpoint"
+	keyService   = "service"
+	keyTimeoutMs = "timeout_ms"
+	keyInsecure  = "insecure"
+	keyDisabled  = "disabled"
+
+	envEndpoint  = "GOCACHE_EMBEDDED_OTLP_ENDPOINT"
+	envService   = "GOCACHE_EMBEDDED_OTLP_SERVICE"
+	envTimeoutMs = "GOCACHE_EMBEDDED_OTLP_TIMEOUT_MS"
+	envInsecure  = "GOCACHE_EMBEDDED_OTLP_INSECURE"
+	envDisabled  = "GOCACHE_EMBEDDED_OTLP_DISABLED"
 	defaultService = "gocache"
 	defaultTimeout = 3 * time.Second
 	shutdownGrace  = 2 * time.Second
@@ -121,11 +126,19 @@ func (p *plugin) BootInit(ctx context.Context) error {
 	return nil
 }
 
-// ConfigLoaded emits a short child span under the process span to mark
-// the boundary. Optional endpoint override from config is NOT applied
-// here — changing the exporter after BootInit is too risky (we'd need
-// to drain the pending batcher first). Env-var-only wins.
 func (p *plugin) ConfigLoaded(ctx context.Context, cfg *config.Config) error {
+	pcfg := config.PluginConfigFor("otlp_embedded")
+	pcfg.SetDefault(keyEndpoint, "")
+	pcfg.SetDefault(keyService, defaultService)
+	pcfg.SetDefault(keyTimeoutMs, int(defaultTimeout.Milliseconds()))
+	pcfg.SetDefault(keyInsecure, false)
+	pcfg.SetDefault(keyDisabled, false)
+	pcfg.BindEnv(keyEndpoint, envEndpoint)
+	pcfg.BindEnv(keyService, envService)
+	pcfg.BindEnv(keyTimeoutMs, envTimeoutMs)
+	pcfg.BindEnv(keyInsecure, envInsecure)
+	pcfg.BindEnv(keyDisabled, envDisabled)
+
 	if p.tracer == nil || p.processSpan == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Expose `PluginConfigFor(name)` from `api/config` via a provider callback so all plugin types (persistence + embedded) use the same config pattern: `SetDefault` + `BindEnv` + `Get*`
- `pkg/config.installHandle` wires the provider during server config load
- **Crashdump**: full migration from `os.Getenv()` in BootInit to `PluginConfig` in ConfigLoaded — config now also reads from `gocache.yaml` under `plugins.config.crashdump.*`
- **OTLP**: registers config schema (SetDefault + BindEnv) in ConfigLoaded; BootInit keeps `applyEnv()` because the OTLP exporter must be created before `config.Load()` runs
- **Gobservability/Dummy**: out of scope (standalone binary / no config)
- Updated ADR-0018 with the revised alternative 3 (adopted, not rejected)

## Test plan

- [x] `TestPluginConfigFor_BeforeProvider` — fallback MapConfig before provider set
- [x] `TestPluginConfigFor_AfterProvider` — delegates to registered provider
- [x] `TestAPIPluginConfigFor_DelegatesToPkgConfig` — api-level accessor resolves through pkg/config after installHandle
- [x] OTLP existing tests pass (BootInit + ConfigLoaded lifecycle)
- [x] `go build -tags "aof crashdump otlp" ./...`
- [x] `go test -tags "aof crashdump otlp" -race ./...`
- [x] `go vet ./...`