### PR TITLE
feat: unified plugin config + operation context propagation

### DIFF
--- a/api/embedded/embedded.go
+++ b/api/embedded/embedded.go
@@ -25,6 +25,7 @@ import (
 
 	"gocache/api/config"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 )
 
 // Plugin is the interface an embedded plugin implements.
@@ -46,7 +47,7 @@ import (
 type Plugin interface {
 	Name() string
 	BootInit(ctx context.Context) error
-	ConfigLoaded(ctx context.Context, cfg *config.Config) error
+	ConfigLoaded(ctx context.Context, cfg *config.Config, pcfg config.PluginConfig) error
 	ProcessShutdown(ctx context.Context) error
 }
 
@@ -94,7 +95,7 @@ func Names() []string {
 // iteration continues; strict plugins halt the process via Fatal.
 func BootAll(ctx context.Context) {
 	for _, r := range registry {
-		invoke(ctx, r, "boot_init", func() error { return r.plugin.BootInit(ctx) })
+		invoke(ctx, r, "boot_init", func(pctx context.Context) error { return r.plugin.BootInit(pctx) })
 	}
 }
 
@@ -103,7 +104,8 @@ func BootAll(ctx context.Context) {
 // as BootAll.
 func ConfigLoadedAll(ctx context.Context, cfg *config.Config) {
 	for _, r := range registry {
-		invoke(ctx, r, "config_loaded", func() error { return r.plugin.ConfigLoaded(ctx, cfg) })
+		pcfg := config.PluginConfigFor(r.plugin.Name())
+		invoke(ctx, r, "config_loaded", func(pctx context.Context) error { return r.plugin.ConfigLoaded(pctx, cfg, pcfg) })
 	}
 }
 
@@ -115,7 +117,7 @@ func ConfigLoadedAll(ctx context.Context, cfg *config.Config) {
 func ShutdownAll(ctx context.Context) {
 	for i := len(registry) - 1; i >= 0; i-- {
 		r := registry[i]
-		invoke(ctx, r, "process_shutdown", func() error { return r.plugin.ProcessShutdown(ctx) })
+		invoke(ctx, r, "process_shutdown", func(pctx context.Context) error { return r.plugin.ProcessShutdown(pctx) })
 	}
 }
 
@@ -129,26 +131,39 @@ func ShutdownAll(ctx context.Context) {
 // we don't want a strict failure to silently degrade into the non-strict
 // "continue" log line below. The redundant return makes the contract
 // explicit at the callsite.
-func invoke(ctx context.Context, r registration, phase string, fn func() error) {
+func invoke(ctx context.Context, r registration, phase string, fn func(context.Context) error) {
+	var parentID string
+	if parent := ops.FromContext(ctx); parent != nil {
+		parentID = parent.ID
+	}
+	pluginOp := ops.New(ops.TypePluginStart, parentID)
+	pluginOp.Enrich("_plugin", r.plugin.Name())
+	pluginOp.Enrich("_phase", phase)
+	pluginCtx := ops.WithContext(ctx, pluginOp)
+
 	defer func() {
 		if rec := recover(); rec != nil {
+			pluginOp.Fail(fmt.Sprintf("panic: %v", rec))
 			if r.mustSucceed {
-				logger.Fatal(ctx).Str("embedded_plugin", r.plugin.Name()).Str("phase", phase).
+				logger.Fatal(pluginCtx).Str("embedded_plugin", r.plugin.Name()).Str("phase", phase).
 					Interface("panic", rec).Msg("strict embedded plugin panicked")
 				return
 			}
-			logger.Error(ctx).Str("embedded_plugin", r.plugin.Name()).Str("phase", phase).
+			logger.Error(pluginCtx).Str("embedded_plugin", r.plugin.Name()).Str("phase", phase).
 				Interface("panic", rec).Msg("embedded plugin panicked — continuing")
 		}
 	}()
-	if err := fn(); err != nil {
+	if err := fn(pluginCtx); err != nil {
+		pluginOp.Fail(err.Error())
 		wrapped := fmt.Errorf("embedded plugin %q %s: %w", r.plugin.Name(), phase, err)
 		if r.mustSucceed {
-			logger.Fatal(ctx).Err(wrapped).Msg("strict embedded plugin failed")
+			logger.Fatal(pluginCtx).Err(wrapped).Msg("strict embedded plugin failed")
 			return
 		}
-		logger.Error(ctx).Err(wrapped).Msg("embedded plugin failed — continuing")
+		logger.Error(pluginCtx).Err(wrapped).Msg("embedded plugin failed — continuing")
+		return
 	}
+	pluginOp.Complete()
 }
 
 // ResetForTesting clears the registry. Test-only.

--- a/api/embedded/embedded_test.go
+++ b/api/embedded/embedded_test.go
@@ -36,7 +36,7 @@ func (p *recordingPlugin) BootInit(ctx context.Context) error {
 	return p.bootErr
 }
 
-func (p *recordingPlugin) ConfigLoaded(_ context.Context, _ *config.Config) error {
+func (p *recordingPlugin) ConfigLoaded(_ context.Context, _ *config.Config, _ config.PluginConfig) error {
 	p.configs++
 	p.configured = true
 	return p.cfgErr
@@ -170,7 +170,7 @@ type orderedPlugin struct {
 
 func (p *orderedPlugin) Name() string                                        { return p.name }
 func (p *orderedPlugin) BootInit(context.Context) error                      { return nil }
-func (p *orderedPlugin) ConfigLoaded(context.Context, *config.Config) error  { return nil }
+func (p *orderedPlugin) ConfigLoaded(context.Context, *config.Config, config.PluginConfig) error { return nil }
 func (p *orderedPlugin) ProcessShutdown(context.Context) error {
 	*p.order = append(*p.order, p.name)
 	return nil

--- a/api/gcpc/v1/gcpc.pb.go
+++ b/api/gcpc/v1/gcpc.pb.go
@@ -95,6 +95,7 @@ type EnvelopeV1 struct {
 	//	*EnvelopeV1_Event
 	//	*EnvelopeV1_OperationHookRequest
 	//	*EnvelopeV1_OperationHookResponse
+	//	*EnvelopeV1_ConfigUpdate
 	Payload       isEnvelopeV1_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -295,6 +296,15 @@ func (x *EnvelopeV1) GetOperationHookResponse() *OperationHookResponseV1 {
 	return nil
 }
 
+func (x *EnvelopeV1) GetConfigUpdate() *PluginConfigV1 {
+	if x != nil {
+		if x, ok := x.Payload.(*EnvelopeV1_ConfigUpdate); ok {
+			return x.ConfigUpdate
+		}
+	}
+	return nil
+}
+
 type isEnvelopeV1_Payload interface {
 	isEnvelopeV1_Payload()
 }
@@ -363,6 +373,10 @@ type EnvelopeV1_OperationHookResponse struct {
 	OperationHookResponse *OperationHookResponseV1 `protobuf:"bytes,81,opt,name=operation_hook_response,json=operationHookResponse,proto3,oneof"`
 }
 
+type EnvelopeV1_ConfigUpdate struct {
+	ConfigUpdate *PluginConfigV1 `protobuf:"bytes,90,opt,name=config_update,json=configUpdate,proto3,oneof"`
+}
+
 func (*EnvelopeV1_Register) isEnvelopeV1_Payload() {}
 
 func (*EnvelopeV1_RegisterAck) isEnvelopeV1_Payload() {}
@@ -394,6 +408,8 @@ func (*EnvelopeV1_Event) isEnvelopeV1_Payload() {}
 func (*EnvelopeV1_OperationHookRequest) isEnvelopeV1_Payload() {}
 
 func (*EnvelopeV1_OperationHookResponse) isEnvelopeV1_Payload() {}
+
+func (*EnvelopeV1_ConfigUpdate) isEnvelopeV1_Payload() {}
 
 // RegisterV1 is sent by the plugin after connecting to announce capabilities.
 type RegisterV1 struct {
@@ -631,7 +647,8 @@ type RegisterAckV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Accepted      bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
 	Reason        string                 `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
-	GrantedScopes []string               `protobuf:"bytes,3,rep,name=granted_scopes,json=grantedScopes,proto3" json:"granted_scopes,omitempty"` // scopes actually granted (intersection of requested and allowed)
+	GrantedScopes []string               `protobuf:"bytes,3,rep,name=granted_scopes,json=grantedScopes,proto3" json:"granted_scopes,omitempty"`                                        // scopes actually granted (intersection of requested and allowed)
+	Config        map[string]string      `protobuf:"bytes,4,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // plugin's YAML config section (flat keys)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -687,6 +704,58 @@ func (x *RegisterAckV1) GetGrantedScopes() []string {
 	return nil
 }
 
+func (x *RegisterAckV1) GetConfig() map[string]string {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// PluginConfigV1 is sent by the server to push config updates on hot reload.
+type PluginConfigV1 struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Entries       map[string]string      `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginConfigV1) Reset() {
+	*x = PluginConfigV1{}
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginConfigV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginConfigV1) ProtoMessage() {}
+
+func (x *PluginConfigV1) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginConfigV1.ProtoReflect.Descriptor instead.
+func (*PluginConfigV1) Descriptor() ([]byte, []int) {
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PluginConfigV1) GetEntries() map[string]string {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
 // HealthCheckV1 is sent by the server periodically to verify plugin liveness.
 type HealthCheckV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -697,7 +766,7 @@ type HealthCheckV1 struct {
 
 func (x *HealthCheckV1) Reset() {
 	*x = HealthCheckV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[5]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +778,7 @@ func (x *HealthCheckV1) String() string {
 func (*HealthCheckV1) ProtoMessage() {}
 
 func (x *HealthCheckV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[5]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +791,7 @@ func (x *HealthCheckV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckV1.ProtoReflect.Descriptor instead.
 func (*HealthCheckV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{5}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *HealthCheckV1) GetTimestamp() uint64 {
@@ -743,7 +812,7 @@ type HealthResponseV1 struct {
 
 func (x *HealthResponseV1) Reset() {
 	*x = HealthResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[6]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -755,7 +824,7 @@ func (x *HealthResponseV1) String() string {
 func (*HealthResponseV1) ProtoMessage() {}
 
 func (x *HealthResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[6]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -768,7 +837,7 @@ func (x *HealthResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponseV1.ProtoReflect.Descriptor instead.
 func (*HealthResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{6}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *HealthResponseV1) GetOk() bool {
@@ -795,7 +864,7 @@ type ShutdownV1 struct {
 
 func (x *ShutdownV1) Reset() {
 	*x = ShutdownV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[7]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -807,7 +876,7 @@ func (x *ShutdownV1) String() string {
 func (*ShutdownV1) ProtoMessage() {}
 
 func (x *ShutdownV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[7]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -820,7 +889,7 @@ func (x *ShutdownV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownV1.ProtoReflect.Descriptor instead.
 func (*ShutdownV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{7}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ShutdownV1) GetDeadlineNs() uint64 {
@@ -839,7 +908,7 @@ type ShutdownAckV1 struct {
 
 func (x *ShutdownAckV1) Reset() {
 	*x = ShutdownAckV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[8]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -851,7 +920,7 @@ func (x *ShutdownAckV1) String() string {
 func (*ShutdownAckV1) ProtoMessage() {}
 
 func (x *ShutdownAckV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[8]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -864,7 +933,7 @@ func (x *ShutdownAckV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShutdownAckV1.ProtoReflect.Descriptor instead.
 func (*ShutdownAckV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{8}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{9}
 }
 
 // CommandRequestV1 is sent by the server to invoke a plugin command.
@@ -874,13 +943,14 @@ type CommandRequestV1 struct {
 	Args          []string               `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`                                                                                   // command arguments as strings
 	RequestId     string                 `protobuf:"bytes,3,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`                                                        // correlation ID for multiplexed responses
 	Metadata      map[string]string      `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // REX metadata (bare keys, no shared.rex. prefix)
+	Context       map[string]string      `protobuf:"bytes,5,rep,name=context,proto3" json:"context,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`   // operation context (filtered for plugin visibility)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CommandRequestV1) Reset() {
 	*x = CommandRequestV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[9]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -892,7 +962,7 @@ func (x *CommandRequestV1) String() string {
 func (*CommandRequestV1) ProtoMessage() {}
 
 func (x *CommandRequestV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[9]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -905,7 +975,7 @@ func (x *CommandRequestV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommandRequestV1.ProtoReflect.Descriptor instead.
 func (*CommandRequestV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{9}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CommandRequestV1) GetCommand() string {
@@ -936,6 +1006,13 @@ func (x *CommandRequestV1) GetMetadata() map[string]string {
 	return nil
 }
 
+func (x *CommandRequestV1) GetContext() map[string]string {
+	if x != nil {
+		return x.Context
+	}
+	return nil
+}
+
 // CommandResponseV1 is the plugin's response to a CommandRequestV1.
 type CommandResponseV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -947,7 +1024,7 @@ type CommandResponseV1 struct {
 
 func (x *CommandResponseV1) Reset() {
 	*x = CommandResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[10]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -959,7 +1036,7 @@ func (x *CommandResponseV1) String() string {
 func (*CommandResponseV1) ProtoMessage() {}
 
 func (x *CommandResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[10]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -972,7 +1049,7 @@ func (x *CommandResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommandResponseV1.ProtoReflect.Descriptor instead.
 func (*CommandResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{10}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CommandResponseV1) GetRequestId() string {
@@ -1006,7 +1083,7 @@ type HookRequestV1 struct {
 
 func (x *HookRequestV1) Reset() {
 	*x = HookRequestV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[11]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1018,7 +1095,7 @@ func (x *HookRequestV1) String() string {
 func (*HookRequestV1) ProtoMessage() {}
 
 func (x *HookRequestV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[11]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1031,7 +1108,7 @@ func (x *HookRequestV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HookRequestV1.ProtoReflect.Descriptor instead.
 func (*HookRequestV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{11}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HookRequestV1) GetRequestId() string {
@@ -1104,7 +1181,7 @@ type HookResponseV1 struct {
 
 func (x *HookResponseV1) Reset() {
 	*x = HookResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[12]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1116,7 +1193,7 @@ func (x *HookResponseV1) String() string {
 func (*HookResponseV1) ProtoMessage() {}
 
 func (x *HookResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[12]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1129,7 +1206,7 @@ func (x *HookResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HookResponseV1.ProtoReflect.Descriptor instead.
 func (*HookResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{12}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *HookResponseV1) GetRequestId() string {
@@ -1180,7 +1257,7 @@ type ResultV1 struct {
 
 func (x *ResultV1) Reset() {
 	*x = ResultV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[13]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1192,7 +1269,7 @@ func (x *ResultV1) String() string {
 func (*ResultV1) ProtoMessage() {}
 
 func (x *ResultV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[13]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1205,7 +1282,7 @@ func (x *ResultV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultV1.ProtoReflect.Descriptor instead.
 func (*ResultV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{13}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ResultV1) GetValue() isResultV1_Value {
@@ -1349,7 +1426,7 @@ type ResultArrayV1 struct {
 
 func (x *ResultArrayV1) Reset() {
 	*x = ResultArrayV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[14]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1361,7 +1438,7 @@ func (x *ResultArrayV1) String() string {
 func (*ResultArrayV1) ProtoMessage() {}
 
 func (x *ResultArrayV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[14]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1374,7 +1451,7 @@ func (x *ResultArrayV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultArrayV1.ProtoReflect.Descriptor instead.
 func (*ResultArrayV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{14}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ResultArrayV1) GetElements() []*ResultV1 {
@@ -1394,7 +1471,7 @@ type ResultMapV1 struct {
 
 func (x *ResultMapV1) Reset() {
 	*x = ResultMapV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[15]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1406,7 +1483,7 @@ func (x *ResultMapV1) String() string {
 func (*ResultMapV1) ProtoMessage() {}
 
 func (x *ResultMapV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[15]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1419,7 +1496,7 @@ func (x *ResultMapV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultMapV1.ProtoReflect.Descriptor instead.
 func (*ResultMapV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{15}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ResultMapV1) GetEntries() []*ResultEntryV1 {
@@ -1440,7 +1517,7 @@ type ResultEntryV1 struct {
 
 func (x *ResultEntryV1) Reset() {
 	*x = ResultEntryV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[16]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1452,7 +1529,7 @@ func (x *ResultEntryV1) String() string {
 func (*ResultEntryV1) ProtoMessage() {}
 
 func (x *ResultEntryV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[16]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1465,7 +1542,7 @@ func (x *ResultEntryV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultEntryV1.ProtoReflect.Descriptor instead.
 func (*ResultEntryV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{16}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ResultEntryV1) GetKey() string {
@@ -1485,15 +1562,16 @@ func (x *ResultEntryV1) GetValue() *ResultV1 {
 // ServerQueryV1 is sent by a plugin to query server state.
 type ServerQueryV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"` // correlation ID for response matching
-	Topic         string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`                          // query topic: "health", "plugins", "stats"
+	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`                                                    // correlation ID for response matching
+	Topic         string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`                                                                             // query topic: "health", "plugins", "stats"
+	Params        map[string]string      `protobuf:"bytes,3,rep,name=params,proto3" json:"params,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // topic-specific parameters
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ServerQueryV1) Reset() {
 	*x = ServerQueryV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[17]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1505,7 +1583,7 @@ func (x *ServerQueryV1) String() string {
 func (*ServerQueryV1) ProtoMessage() {}
 
 func (x *ServerQueryV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[17]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1518,7 +1596,7 @@ func (x *ServerQueryV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerQueryV1.ProtoReflect.Descriptor instead.
 func (*ServerQueryV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{17}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ServerQueryV1) GetRequestId() string {
@@ -1535,6 +1613,13 @@ func (x *ServerQueryV1) GetTopic() string {
 	return ""
 }
 
+func (x *ServerQueryV1) GetParams() map[string]string {
+	if x != nil {
+		return x.Params
+	}
+	return nil
+}
+
 // ServerQueryResponseV1 is the server's response to a ServerQueryV1.
 type ServerQueryResponseV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1547,7 +1632,7 @@ type ServerQueryResponseV1 struct {
 
 func (x *ServerQueryResponseV1) Reset() {
 	*x = ServerQueryResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[18]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1559,7 +1644,7 @@ func (x *ServerQueryResponseV1) String() string {
 func (*ServerQueryResponseV1) ProtoMessage() {}
 
 func (x *ServerQueryResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[18]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1572,7 +1657,7 @@ func (x *ServerQueryResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerQueryResponseV1.ProtoReflect.Descriptor instead.
 func (*ServerQueryResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{18}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ServerQueryResponseV1) GetRequestId() string {
@@ -1607,7 +1692,7 @@ type EventSubscribeV1 struct {
 
 func (x *EventSubscribeV1) Reset() {
 	*x = EventSubscribeV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[19]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1619,7 +1704,7 @@ func (x *EventSubscribeV1) String() string {
 func (*EventSubscribeV1) ProtoMessage() {}
 
 func (x *EventSubscribeV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[19]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1632,7 +1717,7 @@ func (x *EventSubscribeV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventSubscribeV1.ProtoReflect.Descriptor instead.
 func (*EventSubscribeV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{19}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *EventSubscribeV1) GetTypes() []string {
@@ -1673,7 +1758,7 @@ type EventV1 struct {
 
 func (x *EventV1) Reset() {
 	*x = EventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[20]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1685,7 +1770,7 @@ func (x *EventV1) String() string {
 func (*EventV1) ProtoMessage() {}
 
 func (x *EventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[20]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1698,7 +1783,7 @@ func (x *EventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventV1.ProtoReflect.Descriptor instead.
 func (*EventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{20}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *EventV1) GetType() string {
@@ -1969,7 +2054,7 @@ type CommandPreEventV1 struct {
 
 func (x *CommandPreEventV1) Reset() {
 	*x = CommandPreEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[21]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1981,7 +2066,7 @@ func (x *CommandPreEventV1) String() string {
 func (*CommandPreEventV1) ProtoMessage() {}
 
 func (x *CommandPreEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[21]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1994,7 +2079,7 @@ func (x *CommandPreEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommandPreEventV1.ProtoReflect.Descriptor instead.
 func (*CommandPreEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{21}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *CommandPreEventV1) GetCommand() string {
@@ -2032,7 +2117,7 @@ type CommandPostEventV1 struct {
 
 func (x *CommandPostEventV1) Reset() {
 	*x = CommandPostEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[22]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2129,7 @@ func (x *CommandPostEventV1) String() string {
 func (*CommandPostEventV1) ProtoMessage() {}
 
 func (x *CommandPostEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[22]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2142,7 @@ func (x *CommandPostEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommandPostEventV1.ProtoReflect.Descriptor instead.
 func (*CommandPostEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{22}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CommandPostEventV1) GetCommand() string {
@@ -2111,7 +2196,7 @@ type ConnectionOpenEventV1 struct {
 
 func (x *ConnectionOpenEventV1) Reset() {
 	*x = ConnectionOpenEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[23]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2123,7 +2208,7 @@ func (x *ConnectionOpenEventV1) String() string {
 func (*ConnectionOpenEventV1) ProtoMessage() {}
 
 func (x *ConnectionOpenEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[23]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2136,7 +2221,7 @@ func (x *ConnectionOpenEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectionOpenEventV1.ProtoReflect.Descriptor instead.
 func (*ConnectionOpenEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{23}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ConnectionOpenEventV1) GetRemoteAddr() string {
@@ -2156,7 +2241,7 @@ type ConnectionCloseEventV1 struct {
 
 func (x *ConnectionCloseEventV1) Reset() {
 	*x = ConnectionCloseEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[24]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2168,7 +2253,7 @@ func (x *ConnectionCloseEventV1) String() string {
 func (*ConnectionCloseEventV1) ProtoMessage() {}
 
 func (x *ConnectionCloseEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[24]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2181,7 +2266,7 @@ func (x *ConnectionCloseEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectionCloseEventV1.ProtoReflect.Descriptor instead.
 func (*ConnectionCloseEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{24}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ConnectionCloseEventV1) GetRemoteAddr() string {
@@ -2208,7 +2293,7 @@ type ServerStartEventV1 struct {
 
 func (x *ServerStartEventV1) Reset() {
 	*x = ServerStartEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[25]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2220,7 +2305,7 @@ func (x *ServerStartEventV1) String() string {
 func (*ServerStartEventV1) ProtoMessage() {}
 
 func (x *ServerStartEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[25]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2233,7 +2318,7 @@ func (x *ServerStartEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerStartEventV1.ProtoReflect.Descriptor instead.
 func (*ServerStartEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{25}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ServerStartEventV1) GetAddr() string {
@@ -2259,7 +2344,7 @@ type ServerShutdownEventV1 struct {
 
 func (x *ServerShutdownEventV1) Reset() {
 	*x = ServerShutdownEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[26]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2271,7 +2356,7 @@ func (x *ServerShutdownEventV1) String() string {
 func (*ServerShutdownEventV1) ProtoMessage() {}
 
 func (x *ServerShutdownEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[26]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2284,7 +2369,7 @@ func (x *ServerShutdownEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerShutdownEventV1.ProtoReflect.Descriptor instead.
 func (*ServerShutdownEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{26}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ServerShutdownEventV1) GetReason() string {
@@ -2305,7 +2390,7 @@ type PluginRegisteredEventV1 struct {
 
 func (x *PluginRegisteredEventV1) Reset() {
 	*x = PluginRegisteredEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[27]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2317,7 +2402,7 @@ func (x *PluginRegisteredEventV1) String() string {
 func (*PluginRegisteredEventV1) ProtoMessage() {}
 
 func (x *PluginRegisteredEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[27]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2330,7 +2415,7 @@ func (x *PluginRegisteredEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRegisteredEventV1.ProtoReflect.Descriptor instead.
 func (*PluginRegisteredEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{27}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *PluginRegisteredEventV1) GetName() string {
@@ -2365,7 +2450,7 @@ type PluginCrashedEventV1 struct {
 
 func (x *PluginCrashedEventV1) Reset() {
 	*x = PluginCrashedEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[28]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2377,7 +2462,7 @@ func (x *PluginCrashedEventV1) String() string {
 func (*PluginCrashedEventV1) ProtoMessage() {}
 
 func (x *PluginCrashedEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[28]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2390,7 +2475,7 @@ func (x *PluginCrashedEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginCrashedEventV1.ProtoReflect.Descriptor instead.
 func (*PluginCrashedEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{28}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *PluginCrashedEventV1) GetName() string {
@@ -2425,7 +2510,7 @@ type PluginRestartedEventV1 struct {
 
 func (x *PluginRestartedEventV1) Reset() {
 	*x = PluginRestartedEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[29]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2437,7 +2522,7 @@ func (x *PluginRestartedEventV1) String() string {
 func (*PluginRestartedEventV1) ProtoMessage() {}
 
 func (x *PluginRestartedEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[29]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2450,7 +2535,7 @@ func (x *PluginRestartedEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRestartedEventV1.ProtoReflect.Descriptor instead.
 func (*PluginRestartedEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{29}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PluginRestartedEventV1) GetName() string {
@@ -2483,7 +2568,7 @@ type ConfigReloadedEventV1 struct {
 
 func (x *ConfigReloadedEventV1) Reset() {
 	*x = ConfigReloadedEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[30]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2495,7 +2580,7 @@ func (x *ConfigReloadedEventV1) String() string {
 func (*ConfigReloadedEventV1) ProtoMessage() {}
 
 func (x *ConfigReloadedEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[30]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2508,7 +2593,7 @@ func (x *ConfigReloadedEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfigReloadedEventV1.ProtoReflect.Descriptor instead.
 func (*ConfigReloadedEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{30}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ConfigReloadedEventV1) GetFile() string {
@@ -2528,7 +2613,7 @@ type AuthFailedEventV1 struct {
 
 func (x *AuthFailedEventV1) Reset() {
 	*x = AuthFailedEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[31]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2540,7 +2625,7 @@ func (x *AuthFailedEventV1) String() string {
 func (*AuthFailedEventV1) ProtoMessage() {}
 
 func (x *AuthFailedEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[31]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2553,7 +2638,7 @@ func (x *AuthFailedEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthFailedEventV1.ProtoReflect.Descriptor instead.
 func (*AuthFailedEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{31}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *AuthFailedEventV1) GetRemoteAddr() string {
@@ -2580,7 +2665,7 @@ type CacheEvictionEventV1 struct {
 
 func (x *CacheEvictionEventV1) Reset() {
 	*x = CacheEvictionEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[32]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2592,7 +2677,7 @@ func (x *CacheEvictionEventV1) String() string {
 func (*CacheEvictionEventV1) ProtoMessage() {}
 
 func (x *CacheEvictionEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[32]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2605,7 +2690,7 @@ func (x *CacheEvictionEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheEvictionEventV1.ProtoReflect.Descriptor instead.
 func (*CacheEvictionEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{32}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *CacheEvictionEventV1) GetKey() string {
@@ -2634,7 +2719,7 @@ type LogEntryEventV1 struct {
 
 func (x *LogEntryEventV1) Reset() {
 	*x = LogEntryEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[33]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2646,7 +2731,7 @@ func (x *LogEntryEventV1) String() string {
 func (*LogEntryEventV1) ProtoMessage() {}
 
 func (x *LogEntryEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[33]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2659,7 +2744,7 @@ func (x *LogEntryEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntryEventV1.ProtoReflect.Descriptor instead.
 func (*LogEntryEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{33}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *LogEntryEventV1) GetLevel() string {
@@ -2702,7 +2787,7 @@ type OperationStartEventV1 struct {
 
 func (x *OperationStartEventV1) Reset() {
 	*x = OperationStartEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[34]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2714,7 +2799,7 @@ func (x *OperationStartEventV1) String() string {
 func (*OperationStartEventV1) ProtoMessage() {}
 
 func (x *OperationStartEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[34]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2727,7 +2812,7 @@ func (x *OperationStartEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStartEventV1.ProtoReflect.Descriptor instead.
 func (*OperationStartEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{34}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *OperationStartEventV1) GetId() string {
@@ -2772,7 +2857,7 @@ type OperationCompleteEventV1 struct {
 
 func (x *OperationCompleteEventV1) Reset() {
 	*x = OperationCompleteEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2784,7 +2869,7 @@ func (x *OperationCompleteEventV1) String() string {
 func (*OperationCompleteEventV1) ProtoMessage() {}
 
 func (x *OperationCompleteEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2797,7 +2882,7 @@ func (x *OperationCompleteEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationCompleteEventV1.ProtoReflect.Descriptor instead.
 func (*OperationCompleteEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{35}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *OperationCompleteEventV1) GetId() string {
@@ -2853,7 +2938,7 @@ type OperationHookDeclV1 struct {
 
 func (x *OperationHookDeclV1) Reset() {
 	*x = OperationHookDeclV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2865,7 +2950,7 @@ func (x *OperationHookDeclV1) String() string {
 func (*OperationHookDeclV1) ProtoMessage() {}
 
 func (x *OperationHookDeclV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2878,7 +2963,7 @@ func (x *OperationHookDeclV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookDeclV1.ProtoReflect.Descriptor instead.
 func (*OperationHookDeclV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{36}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *OperationHookDeclV1) GetType() string {
@@ -2920,7 +3005,7 @@ type OperationHookRequestV1 struct {
 
 func (x *OperationHookRequestV1) Reset() {
 	*x = OperationHookRequestV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2932,7 +3017,7 @@ func (x *OperationHookRequestV1) String() string {
 func (*OperationHookRequestV1) ProtoMessage() {}
 
 func (x *OperationHookRequestV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2945,7 +3030,7 @@ func (x *OperationHookRequestV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookRequestV1.ProtoReflect.Descriptor instead.
 func (*OperationHookRequestV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{37}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *OperationHookRequestV1) GetRequestId() string {
@@ -3015,7 +3100,7 @@ type OperationHookResponseV1 struct {
 
 func (x *OperationHookResponseV1) Reset() {
 	*x = OperationHookResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3027,7 +3112,7 @@ func (x *OperationHookResponseV1) String() string {
 func (*OperationHookResponseV1) ProtoMessage() {}
 
 func (x *OperationHookResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3040,7 +3125,7 @@ func (x *OperationHookResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookResponseV1.ProtoReflect.Descriptor instead.
 func (*OperationHookResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{38}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *OperationHookResponseV1) GetRequestId() string {
@@ -3061,7 +3146,7 @@ var File_api_gcpc_v1_gcpc_proto protoreflect.FileDescriptor
 
 const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\n" +
-	"\x16api/gcpc/v1/gcpc.proto\x12\agcpc.v1\"\xe8\b\n" +
+	"\x16api/gcpc/v1/gcpc.proto\x12\agcpc.v1\"\xa8\t\n" +
 	"\n" +
 	"EnvelopeV1\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\x0e\n" +
@@ -3082,7 +3167,8 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\x0fevent_subscribe\x18F \x01(\v2\x19.gcpc.v1.EventSubscribeV1H\x00R\x0eeventSubscribe\x12(\n" +
 	"\x05event\x18G \x01(\v2\x10.gcpc.v1.EventV1H\x00R\x05event\x12W\n" +
 	"\x16operation_hook_request\x18P \x01(\v2\x1f.gcpc.v1.OperationHookRequestV1H\x00R\x14operationHookRequest\x12Z\n" +
-	"\x17operation_hook_response\x18Q \x01(\v2 .gcpc.v1.OperationHookResponseV1H\x00R\x15operationHookResponseB\t\n" +
+	"\x17operation_hook_response\x18Q \x01(\v2 .gcpc.v1.OperationHookResponseV1H\x00R\x15operationHookResponse\x12>\n" +
+	"\rconfig_update\x18Z \x01(\v2\x17.gcpc.v1.PluginConfigV1H\x00R\fconfigUpdateB\t\n" +
 	"\apayload\"\xc3\x02\n" +
 	"\n" +
 	"RegisterV1\x12\x12\n" +
@@ -3105,11 +3191,20 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\n" +
 	"HookDeclV1\x12\x18\n" +
 	"\apattern\x18\x01 \x01(\tR\apattern\x12*\n" +
-	"\x05phase\x18\x02 \x01(\x0e2\x14.gcpc.v1.HookPhaseV1R\x05phase\"j\n" +
+	"\x05phase\x18\x02 \x01(\x0e2\x14.gcpc.v1.HookPhaseV1R\x05phase\"\xe1\x01\n" +
 	"\rRegisterAckV1\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12%\n" +
-	"\x0egranted_scopes\x18\x03 \x03(\tR\rgrantedScopes\"-\n" +
+	"\x0egranted_scopes\x18\x03 \x03(\tR\rgrantedScopes\x12:\n" +
+	"\x06config\x18\x04 \x03(\v2\".gcpc.v1.RegisterAckV1.ConfigEntryR\x06config\x1a9\n" +
+	"\vConfigEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8c\x01\n" +
+	"\x0ePluginConfigV1\x12>\n" +
+	"\aentries\x18\x01 \x03(\v2$.gcpc.v1.PluginConfigV1.EntriesEntryR\aentries\x1a:\n" +
+	"\fEntriesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"-\n" +
 	"\rHealthCheckV1\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x04R\ttimestamp\":\n" +
 	"\x10HealthResponseV1\x12\x0e\n" +
@@ -3119,14 +3214,18 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"ShutdownV1\x12\x1f\n" +
 	"\vdeadline_ns\x18\x01 \x01(\x04R\n" +
 	"deadlineNs\"\x0f\n" +
-	"\rShutdownAckV1\"\xe1\x01\n" +
+	"\rShutdownAckV1\"\xdf\x02\n" +
 	"\x10CommandRequestV1\x12\x18\n" +
 	"\acommand\x18\x01 \x01(\tR\acommand\x12\x12\n" +
 	"\x04args\x18\x02 \x03(\tR\x04args\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x03 \x01(\tR\trequestId\x12C\n" +
-	"\bmetadata\x18\x04 \x03(\v2'.gcpc.v1.CommandRequestV1.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x04 \x03(\v2'.gcpc.v1.CommandRequestV1.MetadataEntryR\bmetadata\x12@\n" +
+	"\acontext\x18\x05 \x03(\v2&.gcpc.v1.CommandRequestV1.ContextEntryR\acontext\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
+	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"]\n" +
 	"\x11CommandResponseV1\x12\x1d\n" +
@@ -3177,11 +3276,15 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\aentries\x18\x01 \x03(\v2\x16.gcpc.v1.ResultEntryV1R\aentries\"J\n" +
 	"\rResultEntryV1\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12'\n" +
-	"\x05value\x18\x02 \x01(\v2\x11.gcpc.v1.ResultV1R\x05value\"D\n" +
+	"\x05value\x18\x02 \x01(\v2\x11.gcpc.v1.ResultV1R\x05value\"\xbb\x01\n" +
 	"\rServerQueryV1\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12\x14\n" +
-	"\x05topic\x18\x02 \x01(\tR\x05topic\"\xc3\x01\n" +
+	"\x05topic\x18\x02 \x01(\tR\x05topic\x12:\n" +
+	"\x06params\x18\x03 \x03(\v2\".gcpc.v1.ServerQueryV1.ParamsEntryR\x06params\x1a9\n" +
+	"\vParamsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc3\x01\n" +
 	"\x15ServerQueryResponseV1\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12<\n" +
@@ -3336,7 +3439,7 @@ func file_api_gcpc_v1_gcpc_proto_rawDescGZIP() []byte {
 }
 
 var file_api_gcpc_v1_gcpc_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_gcpc_v1_gcpc_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_api_gcpc_v1_gcpc_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
 var file_api_gcpc_v1_gcpc_proto_goTypes = []any{
 	(HookPhaseV1)(0),                 // 0: gcpc.v1.HookPhaseV1
 	(*EnvelopeV1)(nil),               // 1: gcpc.v1.EnvelopeV1
@@ -3344,113 +3447,123 @@ var file_api_gcpc_v1_gcpc_proto_goTypes = []any{
 	(*CommandDeclV1)(nil),            // 3: gcpc.v1.CommandDeclV1
 	(*HookDeclV1)(nil),               // 4: gcpc.v1.HookDeclV1
 	(*RegisterAckV1)(nil),            // 5: gcpc.v1.RegisterAckV1
-	(*HealthCheckV1)(nil),            // 6: gcpc.v1.HealthCheckV1
-	(*HealthResponseV1)(nil),         // 7: gcpc.v1.HealthResponseV1
-	(*ShutdownV1)(nil),               // 8: gcpc.v1.ShutdownV1
-	(*ShutdownAckV1)(nil),            // 9: gcpc.v1.ShutdownAckV1
-	(*CommandRequestV1)(nil),         // 10: gcpc.v1.CommandRequestV1
-	(*CommandResponseV1)(nil),        // 11: gcpc.v1.CommandResponseV1
-	(*HookRequestV1)(nil),            // 12: gcpc.v1.HookRequestV1
-	(*HookResponseV1)(nil),           // 13: gcpc.v1.HookResponseV1
-	(*ResultV1)(nil),                 // 14: gcpc.v1.ResultV1
-	(*ResultArrayV1)(nil),            // 15: gcpc.v1.ResultArrayV1
-	(*ResultMapV1)(nil),              // 16: gcpc.v1.ResultMapV1
-	(*ResultEntryV1)(nil),            // 17: gcpc.v1.ResultEntryV1
-	(*ServerQueryV1)(nil),            // 18: gcpc.v1.ServerQueryV1
-	(*ServerQueryResponseV1)(nil),    // 19: gcpc.v1.ServerQueryResponseV1
-	(*EventSubscribeV1)(nil),         // 20: gcpc.v1.EventSubscribeV1
-	(*EventV1)(nil),                  // 21: gcpc.v1.EventV1
-	(*CommandPreEventV1)(nil),        // 22: gcpc.v1.CommandPreEventV1
-	(*CommandPostEventV1)(nil),       // 23: gcpc.v1.CommandPostEventV1
-	(*ConnectionOpenEventV1)(nil),    // 24: gcpc.v1.ConnectionOpenEventV1
-	(*ConnectionCloseEventV1)(nil),   // 25: gcpc.v1.ConnectionCloseEventV1
-	(*ServerStartEventV1)(nil),       // 26: gcpc.v1.ServerStartEventV1
-	(*ServerShutdownEventV1)(nil),    // 27: gcpc.v1.ServerShutdownEventV1
-	(*PluginRegisteredEventV1)(nil),  // 28: gcpc.v1.PluginRegisteredEventV1
-	(*PluginCrashedEventV1)(nil),     // 29: gcpc.v1.PluginCrashedEventV1
-	(*PluginRestartedEventV1)(nil),   // 30: gcpc.v1.PluginRestartedEventV1
-	(*ConfigReloadedEventV1)(nil),    // 31: gcpc.v1.ConfigReloadedEventV1
-	(*AuthFailedEventV1)(nil),        // 32: gcpc.v1.AuthFailedEventV1
-	(*CacheEvictionEventV1)(nil),     // 33: gcpc.v1.CacheEvictionEventV1
-	(*LogEntryEventV1)(nil),          // 34: gcpc.v1.LogEntryEventV1
-	(*OperationStartEventV1)(nil),    // 35: gcpc.v1.OperationStartEventV1
-	(*OperationCompleteEventV1)(nil), // 36: gcpc.v1.OperationCompleteEventV1
-	(*OperationHookDeclV1)(nil),      // 37: gcpc.v1.OperationHookDeclV1
-	(*OperationHookRequestV1)(nil),   // 38: gcpc.v1.OperationHookRequestV1
-	(*OperationHookResponseV1)(nil),  // 39: gcpc.v1.OperationHookResponseV1
-	nil,                              // 40: gcpc.v1.CommandRequestV1.MetadataEntry
-	nil,                              // 41: gcpc.v1.HookRequestV1.ContextEntry
-	nil,                              // 42: gcpc.v1.HookRequestV1.MetadataEntry
-	nil,                              // 43: gcpc.v1.HookResponseV1.ContextValuesEntry
-	nil,                              // 44: gcpc.v1.ServerQueryResponseV1.DataEntry
-	nil,                              // 45: gcpc.v1.CommandPreEventV1.MetadataEntry
-	nil,                              // 46: gcpc.v1.CommandPostEventV1.MetadataEntry
-	nil,                              // 47: gcpc.v1.LogEntryEventV1.FieldsEntry
-	nil,                              // 48: gcpc.v1.OperationStartEventV1.ContextEntry
-	nil,                              // 49: gcpc.v1.OperationCompleteEventV1.ContextEntry
-	nil,                              // 50: gcpc.v1.OperationHookRequestV1.ContextEntry
-	nil,                              // 51: gcpc.v1.OperationHookResponseV1.ContextValuesEntry
+	(*PluginConfigV1)(nil),           // 6: gcpc.v1.PluginConfigV1
+	(*HealthCheckV1)(nil),            // 7: gcpc.v1.HealthCheckV1
+	(*HealthResponseV1)(nil),         // 8: gcpc.v1.HealthResponseV1
+	(*ShutdownV1)(nil),               // 9: gcpc.v1.ShutdownV1
+	(*ShutdownAckV1)(nil),            // 10: gcpc.v1.ShutdownAckV1
+	(*CommandRequestV1)(nil),         // 11: gcpc.v1.CommandRequestV1
+	(*CommandResponseV1)(nil),        // 12: gcpc.v1.CommandResponseV1
+	(*HookRequestV1)(nil),            // 13: gcpc.v1.HookRequestV1
+	(*HookResponseV1)(nil),           // 14: gcpc.v1.HookResponseV1
+	(*ResultV1)(nil),                 // 15: gcpc.v1.ResultV1
+	(*ResultArrayV1)(nil),            // 16: gcpc.v1.ResultArrayV1
+	(*ResultMapV1)(nil),              // 17: gcpc.v1.ResultMapV1
+	(*ResultEntryV1)(nil),            // 18: gcpc.v1.ResultEntryV1
+	(*ServerQueryV1)(nil),            // 19: gcpc.v1.ServerQueryV1
+	(*ServerQueryResponseV1)(nil),    // 20: gcpc.v1.ServerQueryResponseV1
+	(*EventSubscribeV1)(nil),         // 21: gcpc.v1.EventSubscribeV1
+	(*EventV1)(nil),                  // 22: gcpc.v1.EventV1
+	(*CommandPreEventV1)(nil),        // 23: gcpc.v1.CommandPreEventV1
+	(*CommandPostEventV1)(nil),       // 24: gcpc.v1.CommandPostEventV1
+	(*ConnectionOpenEventV1)(nil),    // 25: gcpc.v1.ConnectionOpenEventV1
+	(*ConnectionCloseEventV1)(nil),   // 26: gcpc.v1.ConnectionCloseEventV1
+	(*ServerStartEventV1)(nil),       // 27: gcpc.v1.ServerStartEventV1
+	(*ServerShutdownEventV1)(nil),    // 28: gcpc.v1.ServerShutdownEventV1
+	(*PluginRegisteredEventV1)(nil),  // 29: gcpc.v1.PluginRegisteredEventV1
+	(*PluginCrashedEventV1)(nil),     // 30: gcpc.v1.PluginCrashedEventV1
+	(*PluginRestartedEventV1)(nil),   // 31: gcpc.v1.PluginRestartedEventV1
+	(*ConfigReloadedEventV1)(nil),    // 32: gcpc.v1.ConfigReloadedEventV1
+	(*AuthFailedEventV1)(nil),        // 33: gcpc.v1.AuthFailedEventV1
+	(*CacheEvictionEventV1)(nil),     // 34: gcpc.v1.CacheEvictionEventV1
+	(*LogEntryEventV1)(nil),          // 35: gcpc.v1.LogEntryEventV1
+	(*OperationStartEventV1)(nil),    // 36: gcpc.v1.OperationStartEventV1
+	(*OperationCompleteEventV1)(nil), // 37: gcpc.v1.OperationCompleteEventV1
+	(*OperationHookDeclV1)(nil),      // 38: gcpc.v1.OperationHookDeclV1
+	(*OperationHookRequestV1)(nil),   // 39: gcpc.v1.OperationHookRequestV1
+	(*OperationHookResponseV1)(nil),  // 40: gcpc.v1.OperationHookResponseV1
+	nil,                              // 41: gcpc.v1.RegisterAckV1.ConfigEntry
+	nil,                              // 42: gcpc.v1.PluginConfigV1.EntriesEntry
+	nil,                              // 43: gcpc.v1.CommandRequestV1.MetadataEntry
+	nil,                              // 44: gcpc.v1.CommandRequestV1.ContextEntry
+	nil,                              // 45: gcpc.v1.HookRequestV1.ContextEntry
+	nil,                              // 46: gcpc.v1.HookRequestV1.MetadataEntry
+	nil,                              // 47: gcpc.v1.HookResponseV1.ContextValuesEntry
+	nil,                              // 48: gcpc.v1.ServerQueryV1.ParamsEntry
+	nil,                              // 49: gcpc.v1.ServerQueryResponseV1.DataEntry
+	nil,                              // 50: gcpc.v1.CommandPreEventV1.MetadataEntry
+	nil,                              // 51: gcpc.v1.CommandPostEventV1.MetadataEntry
+	nil,                              // 52: gcpc.v1.LogEntryEventV1.FieldsEntry
+	nil,                              // 53: gcpc.v1.OperationStartEventV1.ContextEntry
+	nil,                              // 54: gcpc.v1.OperationCompleteEventV1.ContextEntry
+	nil,                              // 55: gcpc.v1.OperationHookRequestV1.ContextEntry
+	nil,                              // 56: gcpc.v1.OperationHookResponseV1.ContextValuesEntry
 }
 var file_api_gcpc_v1_gcpc_proto_depIdxs = []int32{
 	2,  // 0: gcpc.v1.EnvelopeV1.register:type_name -> gcpc.v1.RegisterV1
 	5,  // 1: gcpc.v1.EnvelopeV1.register_ack:type_name -> gcpc.v1.RegisterAckV1
-	6,  // 2: gcpc.v1.EnvelopeV1.health_check:type_name -> gcpc.v1.HealthCheckV1
-	7,  // 3: gcpc.v1.EnvelopeV1.health_response:type_name -> gcpc.v1.HealthResponseV1
-	8,  // 4: gcpc.v1.EnvelopeV1.shutdown:type_name -> gcpc.v1.ShutdownV1
-	9,  // 5: gcpc.v1.EnvelopeV1.shutdown_ack:type_name -> gcpc.v1.ShutdownAckV1
-	10, // 6: gcpc.v1.EnvelopeV1.command_request:type_name -> gcpc.v1.CommandRequestV1
-	11, // 7: gcpc.v1.EnvelopeV1.command_response:type_name -> gcpc.v1.CommandResponseV1
-	12, // 8: gcpc.v1.EnvelopeV1.hook_request:type_name -> gcpc.v1.HookRequestV1
-	13, // 9: gcpc.v1.EnvelopeV1.hook_response:type_name -> gcpc.v1.HookResponseV1
-	18, // 10: gcpc.v1.EnvelopeV1.server_query:type_name -> gcpc.v1.ServerQueryV1
-	19, // 11: gcpc.v1.EnvelopeV1.server_query_response:type_name -> gcpc.v1.ServerQueryResponseV1
-	20, // 12: gcpc.v1.EnvelopeV1.event_subscribe:type_name -> gcpc.v1.EventSubscribeV1
-	21, // 13: gcpc.v1.EnvelopeV1.event:type_name -> gcpc.v1.EventV1
-	38, // 14: gcpc.v1.EnvelopeV1.operation_hook_request:type_name -> gcpc.v1.OperationHookRequestV1
-	39, // 15: gcpc.v1.EnvelopeV1.operation_hook_response:type_name -> gcpc.v1.OperationHookResponseV1
-	3,  // 16: gcpc.v1.RegisterV1.commands:type_name -> gcpc.v1.CommandDeclV1
-	4,  // 17: gcpc.v1.RegisterV1.hooks:type_name -> gcpc.v1.HookDeclV1
-	37, // 18: gcpc.v1.RegisterV1.operation_hooks:type_name -> gcpc.v1.OperationHookDeclV1
-	0,  // 19: gcpc.v1.HookDeclV1.phase:type_name -> gcpc.v1.HookPhaseV1
-	40, // 20: gcpc.v1.CommandRequestV1.metadata:type_name -> gcpc.v1.CommandRequestV1.MetadataEntry
-	14, // 21: gcpc.v1.CommandResponseV1.result:type_name -> gcpc.v1.ResultV1
-	0,  // 22: gcpc.v1.HookRequestV1.phase:type_name -> gcpc.v1.HookPhaseV1
-	41, // 23: gcpc.v1.HookRequestV1.context:type_name -> gcpc.v1.HookRequestV1.ContextEntry
-	42, // 24: gcpc.v1.HookRequestV1.metadata:type_name -> gcpc.v1.HookRequestV1.MetadataEntry
-	43, // 25: gcpc.v1.HookResponseV1.context_values:type_name -> gcpc.v1.HookResponseV1.ContextValuesEntry
-	15, // 26: gcpc.v1.ResultV1.array:type_name -> gcpc.v1.ResultArrayV1
-	16, // 27: gcpc.v1.ResultV1.map_val:type_name -> gcpc.v1.ResultMapV1
-	14, // 28: gcpc.v1.ResultArrayV1.elements:type_name -> gcpc.v1.ResultV1
-	17, // 29: gcpc.v1.ResultMapV1.entries:type_name -> gcpc.v1.ResultEntryV1
-	14, // 30: gcpc.v1.ResultEntryV1.value:type_name -> gcpc.v1.ResultV1
-	44, // 31: gcpc.v1.ServerQueryResponseV1.data:type_name -> gcpc.v1.ServerQueryResponseV1.DataEntry
-	22, // 32: gcpc.v1.EventV1.command_pre:type_name -> gcpc.v1.CommandPreEventV1
-	23, // 33: gcpc.v1.EventV1.command_post:type_name -> gcpc.v1.CommandPostEventV1
-	24, // 34: gcpc.v1.EventV1.connection_open:type_name -> gcpc.v1.ConnectionOpenEventV1
-	25, // 35: gcpc.v1.EventV1.connection_close:type_name -> gcpc.v1.ConnectionCloseEventV1
-	26, // 36: gcpc.v1.EventV1.server_start:type_name -> gcpc.v1.ServerStartEventV1
-	27, // 37: gcpc.v1.EventV1.server_shutdown:type_name -> gcpc.v1.ServerShutdownEventV1
-	28, // 38: gcpc.v1.EventV1.plugin_registered:type_name -> gcpc.v1.PluginRegisteredEventV1
-	29, // 39: gcpc.v1.EventV1.plugin_crashed:type_name -> gcpc.v1.PluginCrashedEventV1
-	30, // 40: gcpc.v1.EventV1.plugin_restarted:type_name -> gcpc.v1.PluginRestartedEventV1
-	31, // 41: gcpc.v1.EventV1.config_reloaded:type_name -> gcpc.v1.ConfigReloadedEventV1
-	32, // 42: gcpc.v1.EventV1.auth_failed:type_name -> gcpc.v1.AuthFailedEventV1
-	33, // 43: gcpc.v1.EventV1.cache_eviction:type_name -> gcpc.v1.CacheEvictionEventV1
-	34, // 44: gcpc.v1.EventV1.log_entry:type_name -> gcpc.v1.LogEntryEventV1
-	35, // 45: gcpc.v1.EventV1.operation_start:type_name -> gcpc.v1.OperationStartEventV1
-	36, // 46: gcpc.v1.EventV1.operation_complete:type_name -> gcpc.v1.OperationCompleteEventV1
-	45, // 47: gcpc.v1.CommandPreEventV1.metadata:type_name -> gcpc.v1.CommandPreEventV1.MetadataEntry
-	46, // 48: gcpc.v1.CommandPostEventV1.metadata:type_name -> gcpc.v1.CommandPostEventV1.MetadataEntry
-	47, // 49: gcpc.v1.LogEntryEventV1.fields:type_name -> gcpc.v1.LogEntryEventV1.FieldsEntry
-	48, // 50: gcpc.v1.OperationStartEventV1.context:type_name -> gcpc.v1.OperationStartEventV1.ContextEntry
-	49, // 51: gcpc.v1.OperationCompleteEventV1.context:type_name -> gcpc.v1.OperationCompleteEventV1.ContextEntry
-	50, // 52: gcpc.v1.OperationHookRequestV1.context:type_name -> gcpc.v1.OperationHookRequestV1.ContextEntry
-	51, // 53: gcpc.v1.OperationHookResponseV1.context_values:type_name -> gcpc.v1.OperationHookResponseV1.ContextValuesEntry
-	54, // [54:54] is the sub-list for method output_type
-	54, // [54:54] is the sub-list for method input_type
-	54, // [54:54] is the sub-list for extension type_name
-	54, // [54:54] is the sub-list for extension extendee
-	0,  // [0:54] is the sub-list for field type_name
+	7,  // 2: gcpc.v1.EnvelopeV1.health_check:type_name -> gcpc.v1.HealthCheckV1
+	8,  // 3: gcpc.v1.EnvelopeV1.health_response:type_name -> gcpc.v1.HealthResponseV1
+	9,  // 4: gcpc.v1.EnvelopeV1.shutdown:type_name -> gcpc.v1.ShutdownV1
+	10, // 5: gcpc.v1.EnvelopeV1.shutdown_ack:type_name -> gcpc.v1.ShutdownAckV1
+	11, // 6: gcpc.v1.EnvelopeV1.command_request:type_name -> gcpc.v1.CommandRequestV1
+	12, // 7: gcpc.v1.EnvelopeV1.command_response:type_name -> gcpc.v1.CommandResponseV1
+	13, // 8: gcpc.v1.EnvelopeV1.hook_request:type_name -> gcpc.v1.HookRequestV1
+	14, // 9: gcpc.v1.EnvelopeV1.hook_response:type_name -> gcpc.v1.HookResponseV1
+	19, // 10: gcpc.v1.EnvelopeV1.server_query:type_name -> gcpc.v1.ServerQueryV1
+	20, // 11: gcpc.v1.EnvelopeV1.server_query_response:type_name -> gcpc.v1.ServerQueryResponseV1
+	21, // 12: gcpc.v1.EnvelopeV1.event_subscribe:type_name -> gcpc.v1.EventSubscribeV1
+	22, // 13: gcpc.v1.EnvelopeV1.event:type_name -> gcpc.v1.EventV1
+	39, // 14: gcpc.v1.EnvelopeV1.operation_hook_request:type_name -> gcpc.v1.OperationHookRequestV1
+	40, // 15: gcpc.v1.EnvelopeV1.operation_hook_response:type_name -> gcpc.v1.OperationHookResponseV1
+	6,  // 16: gcpc.v1.EnvelopeV1.config_update:type_name -> gcpc.v1.PluginConfigV1
+	3,  // 17: gcpc.v1.RegisterV1.commands:type_name -> gcpc.v1.CommandDeclV1
+	4,  // 18: gcpc.v1.RegisterV1.hooks:type_name -> gcpc.v1.HookDeclV1
+	38, // 19: gcpc.v1.RegisterV1.operation_hooks:type_name -> gcpc.v1.OperationHookDeclV1
+	0,  // 20: gcpc.v1.HookDeclV1.phase:type_name -> gcpc.v1.HookPhaseV1
+	41, // 21: gcpc.v1.RegisterAckV1.config:type_name -> gcpc.v1.RegisterAckV1.ConfigEntry
+	42, // 22: gcpc.v1.PluginConfigV1.entries:type_name -> gcpc.v1.PluginConfigV1.EntriesEntry
+	43, // 23: gcpc.v1.CommandRequestV1.metadata:type_name -> gcpc.v1.CommandRequestV1.MetadataEntry
+	44, // 24: gcpc.v1.CommandRequestV1.context:type_name -> gcpc.v1.CommandRequestV1.ContextEntry
+	15, // 25: gcpc.v1.CommandResponseV1.result:type_name -> gcpc.v1.ResultV1
+	0,  // 26: gcpc.v1.HookRequestV1.phase:type_name -> gcpc.v1.HookPhaseV1
+	45, // 27: gcpc.v1.HookRequestV1.context:type_name -> gcpc.v1.HookRequestV1.ContextEntry
+	46, // 28: gcpc.v1.HookRequestV1.metadata:type_name -> gcpc.v1.HookRequestV1.MetadataEntry
+	47, // 29: gcpc.v1.HookResponseV1.context_values:type_name -> gcpc.v1.HookResponseV1.ContextValuesEntry
+	16, // 30: gcpc.v1.ResultV1.array:type_name -> gcpc.v1.ResultArrayV1
+	17, // 31: gcpc.v1.ResultV1.map_val:type_name -> gcpc.v1.ResultMapV1
+	15, // 32: gcpc.v1.ResultArrayV1.elements:type_name -> gcpc.v1.ResultV1
+	18, // 33: gcpc.v1.ResultMapV1.entries:type_name -> gcpc.v1.ResultEntryV1
+	15, // 34: gcpc.v1.ResultEntryV1.value:type_name -> gcpc.v1.ResultV1
+	48, // 35: gcpc.v1.ServerQueryV1.params:type_name -> gcpc.v1.ServerQueryV1.ParamsEntry
+	49, // 36: gcpc.v1.ServerQueryResponseV1.data:type_name -> gcpc.v1.ServerQueryResponseV1.DataEntry
+	23, // 37: gcpc.v1.EventV1.command_pre:type_name -> gcpc.v1.CommandPreEventV1
+	24, // 38: gcpc.v1.EventV1.command_post:type_name -> gcpc.v1.CommandPostEventV1
+	25, // 39: gcpc.v1.EventV1.connection_open:type_name -> gcpc.v1.ConnectionOpenEventV1
+	26, // 40: gcpc.v1.EventV1.connection_close:type_name -> gcpc.v1.ConnectionCloseEventV1
+	27, // 41: gcpc.v1.EventV1.server_start:type_name -> gcpc.v1.ServerStartEventV1
+	28, // 42: gcpc.v1.EventV1.server_shutdown:type_name -> gcpc.v1.ServerShutdownEventV1
+	29, // 43: gcpc.v1.EventV1.plugin_registered:type_name -> gcpc.v1.PluginRegisteredEventV1
+	30, // 44: gcpc.v1.EventV1.plugin_crashed:type_name -> gcpc.v1.PluginCrashedEventV1
+	31, // 45: gcpc.v1.EventV1.plugin_restarted:type_name -> gcpc.v1.PluginRestartedEventV1
+	32, // 46: gcpc.v1.EventV1.config_reloaded:type_name -> gcpc.v1.ConfigReloadedEventV1
+	33, // 47: gcpc.v1.EventV1.auth_failed:type_name -> gcpc.v1.AuthFailedEventV1
+	34, // 48: gcpc.v1.EventV1.cache_eviction:type_name -> gcpc.v1.CacheEvictionEventV1
+	35, // 49: gcpc.v1.EventV1.log_entry:type_name -> gcpc.v1.LogEntryEventV1
+	36, // 50: gcpc.v1.EventV1.operation_start:type_name -> gcpc.v1.OperationStartEventV1
+	37, // 51: gcpc.v1.EventV1.operation_complete:type_name -> gcpc.v1.OperationCompleteEventV1
+	50, // 52: gcpc.v1.CommandPreEventV1.metadata:type_name -> gcpc.v1.CommandPreEventV1.MetadataEntry
+	51, // 53: gcpc.v1.CommandPostEventV1.metadata:type_name -> gcpc.v1.CommandPostEventV1.MetadataEntry
+	52, // 54: gcpc.v1.LogEntryEventV1.fields:type_name -> gcpc.v1.LogEntryEventV1.FieldsEntry
+	53, // 55: gcpc.v1.OperationStartEventV1.context:type_name -> gcpc.v1.OperationStartEventV1.ContextEntry
+	54, // 56: gcpc.v1.OperationCompleteEventV1.context:type_name -> gcpc.v1.OperationCompleteEventV1.ContextEntry
+	55, // 57: gcpc.v1.OperationHookRequestV1.context:type_name -> gcpc.v1.OperationHookRequestV1.ContextEntry
+	56, // 58: gcpc.v1.OperationHookResponseV1.context_values:type_name -> gcpc.v1.OperationHookResponseV1.ContextValuesEntry
+	59, // [59:59] is the sub-list for method output_type
+	59, // [59:59] is the sub-list for method input_type
+	59, // [59:59] is the sub-list for extension type_name
+	59, // [59:59] is the sub-list for extension extendee
+	0,  // [0:59] is the sub-list for field type_name
 }
 
 func init() { file_api_gcpc_v1_gcpc_proto_init() }
@@ -3475,8 +3588,9 @@ func file_api_gcpc_v1_gcpc_proto_init() {
 		(*EnvelopeV1_Event)(nil),
 		(*EnvelopeV1_OperationHookRequest)(nil),
 		(*EnvelopeV1_OperationHookResponse)(nil),
+		(*EnvelopeV1_ConfigUpdate)(nil),
 	}
-	file_api_gcpc_v1_gcpc_proto_msgTypes[13].OneofWrappers = []any{
+	file_api_gcpc_v1_gcpc_proto_msgTypes[14].OneofWrappers = []any{
 		(*ResultV1_SimpleString)(nil),
 		(*ResultV1_Error)(nil),
 		(*ResultV1_Integer)(nil),
@@ -3486,7 +3600,7 @@ func file_api_gcpc_v1_gcpc_proto_init() {
 		(*ResultV1_Array)(nil),
 		(*ResultV1_MapVal)(nil),
 	}
-	file_api_gcpc_v1_gcpc_proto_msgTypes[20].OneofWrappers = []any{
+	file_api_gcpc_v1_gcpc_proto_msgTypes[21].OneofWrappers = []any{
 		(*EventV1_CommandPre)(nil),
 		(*EventV1_CommandPost)(nil),
 		(*EventV1_ConnectionOpen)(nil),
@@ -3509,7 +3623,7 @@ func file_api_gcpc_v1_gcpc_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_gcpc_v1_gcpc_proto_rawDesc), len(file_api_gcpc_v1_gcpc_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   51,
+			NumMessages:   56,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gcpc/v1/gcpc.proto
+++ b/api/gcpc/v1/gcpc.proto
@@ -24,6 +24,7 @@ message EnvelopeV1 {
     EventV1               event                 = 71;
     OperationHookRequestV1  operation_hook_request  = 80;
     OperationHookResponseV1 operation_hook_response = 81;
+    PluginConfigV1          config_update           = 90;
   }
 }
 
@@ -66,6 +67,12 @@ message RegisterAckV1 {
   bool   accepted = 1;
   string reason   = 2;
   repeated string granted_scopes = 3; // scopes actually granted (intersection of requested and allowed)
+  map<string, string> config = 4;     // plugin's YAML config section (flat keys)
+}
+
+// PluginConfigV1 is sent by the server to push config updates on hot reload.
+message PluginConfigV1 {
+  map<string, string> entries = 1;
 }
 
 // HealthCheckV1 is sent by the server periodically to verify plugin liveness.
@@ -93,6 +100,7 @@ message CommandRequestV1 {
   repeated string args       = 2; // command arguments as strings
   string          request_id = 3; // correlation ID for multiplexed responses
   map<string, string> metadata = 4; // REX metadata (bare keys, no shared.rex. prefix)
+  map<string, string> context  = 5; // operation context (filtered for plugin visibility)
 }
 
 // CommandResponseV1 is the plugin's response to a CommandRequestV1.
@@ -154,8 +162,9 @@ message ResultEntryV1 {
 
 // ServerQueryV1 is sent by a plugin to query server state.
 message ServerQueryV1 {
-  string request_id = 1; // correlation ID for response matching
-  string topic      = 2; // query topic: "health", "plugins", "stats"
+  string              request_id = 1; // correlation ID for response matching
+  string              topic      = 2; // query topic: "health", "plugins", "stats"
+  map<string, string> params     = 3; // topic-specific parameters
 }
 
 // ServerQueryResponseV1 is the server's response to a ServerQueryV1.

--- a/api/gcpc/v1/helpers.go
+++ b/api/gcpc/v1/helpers.go
@@ -30,7 +30,7 @@ func NewRegister(name, version string, critical bool, commands []*CommandDeclV1,
 	}
 }
 
-func NewRegisterAck(accepted bool, reason string, grantedScopes []string) *EnvelopeV1 {
+func NewRegisterAck(accepted bool, reason string, grantedScopes []string, cfg map[string]string) *EnvelopeV1 {
 	return &EnvelopeV1{
 		Version: ProtocolVersion,
 		Id:      envelopeID(),
@@ -39,6 +39,19 @@ func NewRegisterAck(accepted bool, reason string, grantedScopes []string) *Envel
 				Accepted:      accepted,
 				Reason:        reason,
 				GrantedScopes: grantedScopes,
+				Config:        cfg,
+			},
+		},
+	}
+}
+
+func NewConfigUpdate(entries map[string]string) *EnvelopeV1 {
+	return &EnvelopeV1{
+		Version: ProtocolVersion,
+		Id:      envelopeID(),
+		Payload: &EnvelopeV1_ConfigUpdate{
+			ConfigUpdate: &PluginConfigV1{
+				Entries: entries,
 			},
 		},
 	}
@@ -125,7 +138,7 @@ func NewHookResponse(requestID string, deny bool, denyReason string, contextValu
 	}
 }
 
-func NewCommandRequest(command string, args []string, requestID string, metadata map[string]string) *EnvelopeV1 {
+func NewCommandRequest(command string, args []string, requestID string, metadata, opContext map[string]string) *EnvelopeV1 {
 	return &EnvelopeV1{
 		Version: ProtocolVersion,
 		Id:      envelopeID(),
@@ -135,6 +148,7 @@ func NewCommandRequest(command string, args []string, requestID string, metadata
 				Args:      args,
 				RequestId: requestID,
 				Metadata:  metadata,
+				Context:   opContext,
 			},
 		},
 	}
@@ -153,7 +167,7 @@ func NewCommandResponse(requestID string, result *ResultV1) *EnvelopeV1 {
 	}
 }
 
-func NewServerQuery(requestID, topic string) *EnvelopeV1 {
+func NewServerQuery(requestID, topic string, params map[string]string) *EnvelopeV1 {
 	return &EnvelopeV1{
 		Version: ProtocolVersion,
 		Id:      envelopeID(),
@@ -161,6 +175,7 @@ func NewServerQuery(requestID, topic string) *EnvelopeV1 {
 			ServerQuery: &ServerQueryV1{
 				RequestId: requestID,
 				Topic:     topic,
+				Params:    params,
 			},
 		},
 	}

--- a/api/operations/operations.go
+++ b/api/operations/operations.go
@@ -9,6 +9,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -103,6 +104,18 @@ func New(opType Type, parentID string) *Operation {
 		Status:    StatusRunning,
 		Context:   opctx.NewContext(),
 	}
+}
+
+// Begin creates a running operation parented to any operation in ctx,
+// and returns a new context carrying it. Convenience wrapper for embedded
+// plugins starting their own operations.
+func Begin(ctx context.Context, opType Type) (context.Context, *Operation) {
+	var parentID string
+	if parent := FromContext(ctx); parent != nil {
+		parentID = parent.ID
+	}
+	op := New(opType, parentID)
+	return WithContext(ctx, op), op
 }
 
 // Enrich adds a single key-value to the context. Thread-safe.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -146,8 +146,16 @@ func main() {
 	// ShutdownAll immediately so it fires on normal exit AND during a panic
 	// unwind — giving exporters a final flush even if main() crashes.
 	_ = bootstate.Write(bootStateFile, stageEmbeddedBoot)
-	embedded.BootAll(ctx)
-	defer embedded.ShutdownAll(ctx)
+	embBootOp := ops.New(ops.TypeStartup, "")
+	embBootOp.Enrich("_boot_stage", "embedded_boot")
+	embedded.BootAll(ops.WithContext(ctx, embBootOp))
+	embBootOp.Complete()
+	defer func() {
+		embShutOp := ops.New(ops.TypeShutdown, "")
+		embShutOp.Enrich("_scope", "embedded_plugins")
+		embedded.ShutdownAll(ops.WithContext(ctx, embShutOp))
+		embShutOp.Complete()
+	}()
 
 	// Load configuration: CLI flags > env vars (GOCACHE_*) > config file > defaults
 	_ = bootstate.Write(bootStateFile, stageConfigLoad)
@@ -177,7 +185,10 @@ func main() {
 
 	// Hand the parsed config to embedded plugins so they can upgrade
 	// env-var-only defaults with YAML-backed values (e.g. OTLP endpoint).
-	embedded.ConfigLoadedAll(ctx, cfg)
+	cfgOp := ops.New(ops.TypeConfigReload, "")
+	cfgOp.Enrich("_boot_stage", "config_loaded")
+	embedded.ConfigLoadedAll(ops.WithContext(ctx, cfgOp), cfg)
+	cfgOp.Complete()
 
 	logger.InfoNoCtx().Str("version", version.String()).Msg("starting gocache server")
 	if n := embedded.Count(); n > 0 {
@@ -228,6 +239,7 @@ func main() {
 		pluginManager = pluginmgr.NewManager(cfg.Plugins, srv.CoreCommandNames(), srv)
 		pluginManager.SetLogCollector(logCollector)
 		pluginManager.SetTracker(tracker)
+		pluginmgr.RegisterOperationHandlers(pluginManager.QueryRegistry(), tracker)
 		if err := pluginManager.Start(ctx); err != nil {
 			logger.FatalNoCtx().Err(err).Msg("failed to start plugin manager")
 		}

--- a/docs/adr/0019-unified-plugin-config-delivery.md
+++ b/docs/adr/0019-unified-plugin-config-delivery.md
@@ -1,0 +1,130 @@
+---
+title: ADR-0019 Unified plugin config delivery
+description: Framework injects PluginConfig into every plugin type — embedded and IPC — so plugins never self-fetch config
+status: proposed
+date: 2026-05-25
+deciders: [witherxse]
+related:
+  - ADR-0008
+  - ADR-0018
+  - Plugins
+---
+
+# ADR-0019: Unified plugin config delivery
+
+## Context
+
+GoCache has three plugin types, each consuming configuration differently:
+
+| Plugin type | Example | Config delivery |
+|---|---|---|
+| Persistence (embedded) | AOF, Snapshot | `PluginConfig` injected via `Provider.Build(cfg, store)` |
+| Embedded lifecycle | Crashdump, OTLP | Self-fetch via `config.PluginConfigFor(name)` in `ConfigLoaded` |
+| IPC (external process) | Gobservability | `os.Getenv()` only — no access to server YAML |
+
+This inconsistency has three costs:
+
+1. **Embedded plugins call `config.PluginConfigFor` themselves.** The framework already knows the plugin's name — making the plugin repeat it is error-prone and violates inversion of control.
+2. **IPC plugins have no access to YAML config at all.** Operators must set env vars for every knob; there is no way to manage IPC plugin config in the central `gocache.yaml`.
+3. **No reload path for IPC plugins.** When the server hot-reloads config, embedded plugins see fresh values through their viper view, but IPC plugins remain on stale env vars until restarted.
+
+## Decision
+
+### Part 1: Embedded plugin injection
+
+Change the `embedded.Plugin` interface:
+
+```go
+// Before
+ConfigLoaded(ctx context.Context, cfg *config.Config) error
+
+// After
+ConfigLoaded(ctx context.Context, cfg *config.Config, pcfg config.PluginConfig) error
+```
+
+`ConfigLoadedAll` constructs the scoped view and injects it:
+
+```go
+func ConfigLoadedAll(ctx context.Context, cfg *config.Config) {
+    for _, r := range registry {
+        pcfg := config.PluginConfigFor(r.plugin.Name())
+        invoke(ctx, r, "config_loaded", func() error {
+            return r.plugin.ConfigLoaded(ctx, cfg, pcfg)
+        })
+    }
+}
+```
+
+Callers of `ConfigLoadedAll` are unchanged — the extra parameter is internal.
+
+### Part 2: IPC plugin config delivery via GCPC
+
+Add a `config` field to `RegisterAckV1` so the server delivers the plugin's YAML config section at registration time:
+
+```protobuf
+message RegisterAckV1 {
+    bool accepted = 1;
+    string reason = 2;
+    repeated string granted_scopes = 3;
+    map<string, string> config = 4;
+}
+```
+
+Add a `PluginConfigV1` message and envelope variant for hot-reload pushes:
+
+```protobuf
+message PluginConfigV1 {
+    map<string, string> entries = 1;
+}
+// In EnvelopeV1 oneof:
+PluginConfigV1 config_update = 90;
+```
+
+The SDK receives a `RemoteConfig` that implements `api/config.PluginConfig`, backed by the server-delivered map. Priority: `os.Getenv` (via `BindEnv`) > server values > local `SetDefault` values. Plugins that want to react to reload implement the new `ConfigPlugin` interface:
+
+```go
+type ConfigPlugin interface {
+    Plugin
+    OnConfigReload(cfg config.PluginConfig)
+}
+```
+
+Server-side: `pkg/config.FlatPluginConfig(name)` reads all keys under `plugins.config.<name>` from viper and returns them as `map[string]string`. The manager calls this at registration to populate the ack, and registers `OnPluginReload` to push updates.
+
+## Alternatives Considered
+
+### Alternative 1: Plugin-level viper instance per IPC plugin
+
+Ship the full viper serialization (JSON blob) over GCPC and deserialize into a local viper on the plugin side.
+
+- **Pros**: Full viper feature parity (nested keys, type coercion, AllSettings).
+- **Cons**: Pulls viper into the SDK (it's currently server-only). Couples the wire format to viper's serialization model. Over-engineering for what is typically 3-5 flat keys.
+- **Why not**: `map[string]string` with `strconv` is sufficient for the config surface IPC plugins actually need, and keeps the SDK dependency-light.
+
+### Alternative 2: Keep self-fetch for embedded plugins
+
+Only do Part 2 (IPC delivery), leave embedded plugins calling `config.PluginConfigFor` themselves.
+
+- **Pros**: Smaller diff for Part 1.
+- **Cons**: Inconsistent — persistence plugins get injection, embedded lifecycle plugins self-fetch. Two patterns for the same concept in the same process.
+- **Why not**: The interface change is mechanical (one parameter addition) and makes all in-process plugins consistent.
+
+## Consequences
+
+### Positive
+
+- One config pattern for all plugin types: the framework injects, the plugin receives.
+- IPC plugins gain access to server YAML config without env-var workarounds.
+- Hot-reload pushes to IPC plugins — no restart needed for config changes.
+- Embedded plugins no longer need to know their own registered name for config lookup.
+
+### Negative
+
+- `embedded.Plugin` interface breaks — all implementations must add the `pcfg` parameter. Mechanical but touches every embedded plugin.
+- GCPC protocol gains a new field (`config` on ack) and a new message type (`PluginConfigV1`). Wire-compatible (additive), but external plugins compiled against the old proto won't see config until recompiled.
+- `RemoteConfig` in the SDK is a new type to maintain.
+
+### Risks
+
+- **Risk**: `FlatPluginConfig` flattens nested YAML keys to dot-separated strings. Deep nesting (`a.b.c`) in plugin config could collide with the dot separator. **Mitigation**: Plugin config sections are conventionally flat (1 level deep). Document the flat-key convention.
+- **Risk**: Reload push races with in-flight command handling. **Mitigation**: `RemoteConfig.Replace` swaps the backing map atomically (sync.Mutex). Reads during swap see either old or new values, never partial.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0016](0016-aof-wire-and-file-format.md) | AOF wire and file format | accepted | 2026-05-21 |
 | [0017](0017-mutation-replay-execution-path.md) | Mutation replay execution path | accepted | 2026-05-21 |
 | [0018](0018-plugin-config-autonomy.md) | Plugin config autonomy (BindEnv + MergeFile) | proposed | 2026-05-24 |
+| [0019](0019-unified-plugin-config-delivery.md) | Unified plugin config delivery | proposed | 2026-05-25 |
 
 ## Writing a new ADR
 

--- a/pkg/config/handle.go
+++ b/pkg/config/handle.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -39,6 +40,31 @@ func PluginConfigFor(name string) apiconfig.PluginConfig {
 		return nopConfig{}
 	}
 	return pluginView{v: v, prefix: pluginKeyPrefix(name)}
+}
+
+// FlatPluginConfig returns all keys under plugins.config.<name> as a
+// flat string map. Used by the plugin manager to deliver config to IPC
+// plugins via GCPC. Returns nil if Load has not run or the plugin has
+// no config keys.
+func FlatPluginConfig(name string) map[string]string {
+	v := serverConfig.Load()
+	if v == nil {
+		return nil
+	}
+	prefix := pluginKeyPrefix(name)
+	sub := v.Sub(prefix)
+	if sub == nil {
+		return nil
+	}
+	all := sub.AllSettings()
+	if len(all) == 0 {
+		return nil
+	}
+	flat := make(map[string]string, len(all))
+	for k, val := range all {
+		flat[k] = fmt.Sprintf("%v", val)
+	}
+	return flat
 }
 
 // ConfigFileUsed returns the path to the configuration file that was

--- a/pkg/plugin/manager/it_gcpc_test.go
+++ b/pkg/plugin/manager/it_gcpc_test.go
@@ -366,7 +366,7 @@ func TestGCPC_ServerQuery(t *testing.T) {
 	}
 
 	// Query health topic.
-	p.send(gcpc.NewServerQuery("q-1", "health"))
+	p.send(gcpc.NewServerQuery("q-1", "health", nil))
 
 	env := p.recv()
 	queryResp := env.GetServerQueryResponse()
@@ -395,7 +395,7 @@ func TestGCPC_ServerQuery_DeniedScope(t *testing.T) {
 	}
 
 	// Query should be denied.
-	p.send(gcpc.NewServerQuery("q-2", "health"))
+	p.send(gcpc.NewServerQuery("q-2", "health", nil))
 
 	env := p.recv()
 	queryResp := env.GetServerQueryResponse()
@@ -417,7 +417,7 @@ func TestGCPC_ServerQuery_Plugins(t *testing.T) {
 	p.register("test-plugin", []string{"read", "server:query"}, nil, nil)
 
 	// Query plugins topic.
-	p.send(gcpc.NewServerQuery("q-3", "plugins"))
+	p.send(gcpc.NewServerQuery("q-3", "plugins", nil))
 
 	env := p.recv()
 	queryResp := env.GetServerQueryResponse()

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -11,19 +11,21 @@ import (
 	"time"
 
 	apicommand "gocache/api/command"
+	apiconfig "gocache/api/config"
 	opctx "gocache/api/context"
 	"gocache/api/events"
 	gcpcv1 "gocache/api/gcpc/v1"
 	"gocache/api/logger"
 	ops "gocache/api/operations"
 	apiplugin "gocache/api/plugin"
+	"gocache/api/scope"
 	"gocache/api/transport"
+	pkgconfig "gocache/pkg/config"
 	serverEvents "gocache/pkg/events"
 	serverOps "gocache/pkg/operations"
 	"gocache/pkg/plugin"
 	"gocache/pkg/plugin/cmdhooks"
 	"gocache/pkg/plugin/ophooks"
-	"gocache/api/scope"
 	"gocache/pkg/plugin/permissions"
 	"gocache/pkg/plugin/router"
 
@@ -408,7 +410,7 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	reg := env.GetRegister()
 	if reg == nil {
 		logger.ErrorNoCtx().Msg("first message was not Register")
-		_ = conn.Send(gcpcv1.NewRegisterAck(false, "expected Register message", nil))
+		_ = conn.Send(gcpcv1.NewRegisterAck(false, "expected Register message", nil, nil))
 		_ = conn.Close()
 		return
 	}
@@ -417,7 +419,7 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	inst, ok := m.registry.Get(reg.Name)
 	if !ok {
 		logger.WarnNoCtx().Str("name", reg.Name).Msg("unknown plugin tried to register")
-		_ = conn.Send(gcpcv1.NewRegisterAck(false, "unknown plugin", nil))
+		_ = conn.Send(gcpcv1.NewRegisterAck(false, "unknown plugin", nil, nil))
 		_ = conn.Close()
 		return
 	}
@@ -431,7 +433,7 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	grantedScopes, err := m.validateScopes(reg.Name, reg.RequestedScopes)
 	if err != nil {
 		logger.Error(pluginCtx).Str("plugin", reg.Name).Err(err).Msg("scope validation failed")
-		_ = conn.Send(gcpcv1.NewRegisterAck(false, "scope validation failed: "+err.Error(), nil))
+		_ = conn.Send(gcpcv1.NewRegisterAck(false, "scope validation failed: "+err.Error(), nil, nil))
 		_ = conn.Close()
 		return
 	}
@@ -447,7 +449,7 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 		if err := m.router.RegisterPlugin(reg.Name, conn, reg.Commands); err != nil {
 			logger.Error(pluginCtx).Str("plugin", reg.Name).Err(err).Msg("command registration failed")
 			m.scopeRegistry.Unregister(reg.Name)
-			_ = conn.Send(gcpcv1.NewRegisterAck(false, "command registration failed: "+err.Error(), nil))
+			_ = conn.Send(gcpcv1.NewRegisterAck(false, "command registration failed: "+err.Error(), nil, nil))
 			_ = conn.Close()
 			return
 		}
@@ -490,7 +492,8 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	inst.SetState(StateRegistered)
 
 	grantedStrings := scope.ScopeStrings(grantedScopes)
-	if err := conn.Send(gcpcv1.NewRegisterAck(true, "", grantedStrings)); err != nil {
+	pluginCfgMap := pkgconfig.FlatPluginConfig(reg.Name)
+	if err := conn.Send(gcpcv1.NewRegisterAck(true, "", grantedStrings, pluginCfgMap)); err != nil {
 		logger.Error(pluginCtx).Str("plugin", reg.Name).Err(err).Msg("failed to send register ack")
 		m.router.UnregisterPlugin(reg.Name)
 		m.scopeRegistry.Unregister(reg.Name)
@@ -499,6 +502,10 @@ func (m *Manager) handleConnection(ctx context.Context, conn *transport.Conn) {
 	}
 
 	inst.SetState(StateRunning)
+	pkgconfig.OnPluginReload(reg.Name, func(_ apiconfig.PluginConfig) {
+		updated := pkgconfig.FlatPluginConfig(reg.Name)
+		_ = conn.Send(gcpcv1.NewConfigUpdate(updated))
+	})
 	critical := inst.Critical()
 	logger.Info(pluginCtx).Str("plugin", reg.Name).Str("version", reg.Version).Bool("critical", critical).Int("commands", len(reg.Commands)).Strs("scopes", grantedStrings).Msg("plugin registered")
 
@@ -676,7 +683,7 @@ func (m *Manager) readLoop(ctx context.Context, inst *PluginInstance) {
 					fmt.Sprintf("permission denied: missing scope %q", requiredScope)))
 				continue
 			}
-			data, qErr := m.queryRegistry.Handle(query.Topic)
+			data, qErr := m.queryRegistry.Handle(query.Topic, query.Params)
 			errMsg := ""
 			if qErr != nil {
 				errMsg = qErr.Error()

--- a/pkg/plugin/manager/query.go
+++ b/pkg/plugin/manager/query.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	ops "gocache/api/operations"
 )
 
 // ServerStateProvider is the interface the plugin manager uses to query
@@ -20,7 +22,7 @@ type ServerStateProvider interface {
 }
 
 // QueryHandlerFunc handles a server query topic and returns key-value data.
-type QueryHandlerFunc func() (map[string]string, error)
+type QueryHandlerFunc func(params map[string]string) (map[string]string, error)
 
 // QueryRegistry maps query topics to handler functions.
 type QueryRegistry struct {
@@ -42,14 +44,14 @@ func (r *QueryRegistry) Register(topic string, handler QueryHandlerFunc) {
 }
 
 // Handle executes the handler for a topic and returns the result.
-func (r *QueryRegistry) Handle(topic string) (map[string]string, error) {
+func (r *QueryRegistry) Handle(topic string, params map[string]string) (map[string]string, error) {
 	r.mu.RLock()
 	h, ok := r.handlers[topic]
 	r.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("unknown query topic %q", topic)
 	}
-	return h()
+	return h(params)
 }
 
 // Topics returns the list of registered topic names.
@@ -73,7 +75,7 @@ func RegisterBuiltinHandlers(qr *QueryRegistry, registry *Registry, sp ServerSta
 }
 
 func healthHandler(sp ServerStateProvider) QueryHandlerFunc {
-	return func() (map[string]string, error) {
+	return func(_ map[string]string) (map[string]string, error) {
 		status := "ok"
 		if sp.IsShuttingDown() {
 			status = "shutting_down"
@@ -88,7 +90,7 @@ func healthHandler(sp ServerStateProvider) QueryHandlerFunc {
 }
 
 func statsHandler(sp ServerStateProvider) QueryHandlerFunc {
-	return func() (map[string]string, error) {
+	return func(_ map[string]string) (map[string]string, error) {
 		return map[string]string{
 			"keys":             strconv.Itoa(sp.CacheKeys()),
 			"memory_bytes":     strconv.FormatInt(sp.CacheUsedBytes(), 10),
@@ -98,7 +100,7 @@ func statsHandler(sp ServerStateProvider) QueryHandlerFunc {
 }
 
 func pluginsHandler(registry *Registry) QueryHandlerFunc {
-	return func() (map[string]string, error) {
+	return func(_ map[string]string) (map[string]string, error) {
 		plugins := registry.All()
 		data := make(map[string]string, len(plugins)*2)
 		for _, p := range plugins {
@@ -107,4 +109,33 @@ func pluginsHandler(registry *Registry) QueryHandlerFunc {
 		}
 		return data, nil
 	}
+}
+
+// OperationTracker is the subset of pkg/operations.Tracker needed by
+// plugin-initiated operation management queries.
+type OperationTracker interface {
+	Start(opType ops.Type, parentID string) *ops.Operation
+	Complete(id string)
+	Fail(id, reason string)
+}
+
+// RegisterOperationHandlers registers query topics for plugin-initiated
+// operation lifecycle management.
+func RegisterOperationHandlers(qr *QueryRegistry, tracker OperationTracker) {
+	qr.Register("operation.start", func(params map[string]string) (map[string]string, error) {
+		opType := ops.Type(params["type"])
+		if opType == "" {
+			opType = ops.TypeCommand
+		}
+		op := tracker.Start(opType, params["parent_id"])
+		return op.ContextSnapshot(false), nil
+	})
+	qr.Register("operation.complete", func(params map[string]string) (map[string]string, error) {
+		tracker.Complete(params["_operation_id"])
+		return nil, nil
+	})
+	qr.Register("operation.fail", func(params map[string]string) (map[string]string, error) {
+		tracker.Fail(params["_operation_id"], params["_fail_reason"])
+		return nil, nil
+	})
 }

--- a/pkg/plugin/manager/query_test.go
+++ b/pkg/plugin/manager/query_test.go
@@ -23,7 +23,7 @@ func (m *mockStateProvider) CacheMaxBytes() int64   { return m.maxBytes }
 
 func TestQueryRegistry_UnknownTopic(t *testing.T) {
 	qr := NewQueryRegistry()
-	_, err := qr.Handle("nonexistent")
+	_, err := qr.Handle("nonexistent", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown topic")
 	}
@@ -31,11 +31,11 @@ func TestQueryRegistry_UnknownTopic(t *testing.T) {
 
 func TestQueryRegistry_RegisterAndHandle(t *testing.T) {
 	qr := NewQueryRegistry()
-	qr.Register("test", func() (map[string]string, error) {
+	qr.Register("test", func(_ map[string]string) (map[string]string, error) {
 		return map[string]string{"key": "value"}, nil
 	})
 
-	data, err := qr.Handle("test")
+	data, err := qr.Handle("test", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,8 +46,8 @@ func TestQueryRegistry_RegisterAndHandle(t *testing.T) {
 
 func TestQueryRegistry_Topics(t *testing.T) {
 	qr := NewQueryRegistry()
-	qr.Register("a", func() (map[string]string, error) { return nil, nil })
-	qr.Register("b", func() (map[string]string, error) { return nil, nil })
+	qr.Register("a", func(_ map[string]string) (map[string]string, error) { return nil, nil })
+	qr.Register("b", func(_ map[string]string) (map[string]string, error) { return nil, nil })
 
 	topics := qr.Topics()
 	if len(topics) != 2 {
@@ -61,7 +61,7 @@ func TestHealthHandler_Ok(t *testing.T) {
 		connections: 5,
 	}
 	handler := healthHandler(sp)
-	data, err := handler()
+	data, err := handler(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestHealthHandler_ShuttingDown(t *testing.T) {
 		startTime:    time.Now(),
 	}
 	handler := healthHandler(sp)
-	data, err := handler()
+	data, err := handler(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestStatsHandler(t *testing.T) {
 		maxBytes:  10485760,
 	}
 	handler := statsHandler(sp)
-	data, err := handler()
+	data, err := handler(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestPluginsHandler(t *testing.T) {
 	reg.Add(metricsInst)
 
 	handler := pluginsHandler(reg)
-	data, err := handler()
+	data, err := handler(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -158,10 +158,10 @@ func TestRegisterBuiltinHandlers_NilStateProvider(t *testing.T) {
 	RegisterBuiltinHandlers(qr, reg, nil)
 
 	// Only "plugins" should be registered when state provider is nil.
-	if _, err := qr.Handle("plugins"); err != nil {
+	if _, err := qr.Handle("plugins", nil); err != nil {
 		t.Errorf("plugins handler should be registered: %v", err)
 	}
-	if _, err := qr.Handle("health"); err == nil {
+	if _, err := qr.Handle("health", nil); err == nil {
 		t.Error("health handler should NOT be registered without state provider")
 	}
 }

--- a/pkg/plugin/router/router.go
+++ b/pkg/plugin/router/router.go
@@ -10,6 +10,7 @@ import (
 
 	gcpc "gocache/api/gcpc/v1"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 	"gocache/api/transport"
 )
 
@@ -322,7 +323,11 @@ func (r *Router) Route(ctx context.Context, op string, args []string, metadata m
 	}
 
 	requestID := NextRequestID()
-	env := gcpc.NewCommandRequest(route.Command, args, requestID, metadata)
+	var opCtx map[string]string
+	if ctxOp := ops.FromContext(ctx); ctxOp != nil {
+		opCtx = ctxOp.FilteredContext(route.PluginName, false)
+	}
+	env := gcpc.NewCommandRequest(route.Command, args, requestID, metadata, opCtx)
 
 	respCh, err := pc.Send(ctx, env, requestID)
 	if err != nil {

--- a/plugins/aof/init.go
+++ b/plugins/aof/init.go
@@ -11,6 +11,7 @@ import (
 	apicommand "gocache/api/command"
 	apiconfig "gocache/api/config"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 	apipersistence "gocache/api/persistence"
 )
 
@@ -73,15 +74,19 @@ func (p *provider) commands(store apipersistence.CacheStore) []apipersistence.Co
 	return []apipersistence.Command{
 		{
 			Name: "BGREWRITEAOF",
-			Fn: func(_ context.Context, _ []string) (any, error) {
+			Fn: func(ctx context.Context, _ []string) (any, error) {
 				if !p.rewriting.TryLock() {
 					return "Background append only file rewriting already in progress", nil
+				}
+				bgCtx := context.Background()
+				if op := ops.FromContext(ctx); op != nil {
+					bgCtx = ops.WithContext(bgCtx, op)
 				}
 				aofPath := sink.FilePath()
 				go func() {
 					defer p.rewriting.Unlock()
-					if err := Rewrite(context.Background(), store, sink, aofPath); err != nil {
-						logger.ErrorNoCtx().Err(err).Msg("BGREWRITEAOF failed")
+					if err := Rewrite(bgCtx, store, sink, aofPath); err != nil {
+						logger.Error(bgCtx).Err(err).Msg("BGREWRITEAOF failed")
 					}
 				}()
 				return "Background append only file rewriting started", nil

--- a/plugins/aof/reader.go
+++ b/plugins/aof/reader.go
@@ -79,13 +79,13 @@ type aofIterator struct {
 	goodOffset int64
 }
 
-func (it *aofIterator) Next(_ context.Context) (apipersistence.Mutation, error) {
+func (it *aofIterator) Next(ctx context.Context) (apipersistence.Mutation, error) {
 	m, err := decodeRecord(it.br, it.br)
 	if err == io.EOF {
 		return apipersistence.Mutation{}, io.EOF
 	}
 	if err != nil {
-		logger.WarnNoCtx().Str("file", it.path).Int64("offset", it.goodOffset).
+		logger.Warn(ctx).Str("file", it.path).Int64("offset", it.goodOffset).
 			Err(err).Msg("aof: torn record detected, truncating")
 		it.truncate()
 		return apipersistence.Mutation{}, io.EOF

--- a/plugins/crashdump/crashdump.go
+++ b/plugins/crashdump/crashdump.go
@@ -44,15 +44,14 @@ func (p *plugin) Name() string { return "crashdump" }
 
 func (p *plugin) BootInit(_ context.Context) error { return nil }
 
-func (p *plugin) ConfigLoaded(ctx context.Context, _ *config.Config) error {
-	cfg := config.PluginConfigFor("crashdump")
-	cfg.SetDefault(keyDir, defaultDir)
-	cfg.SetDefault(keyDisabled, false)
-	cfg.BindEnv(keyDir, envDir)
-	cfg.BindEnv(keyDisabled, envDisabled)
+func (p *plugin) ConfigLoaded(ctx context.Context, _ *config.Config, pcfg config.PluginConfig) error {
+	pcfg.SetDefault(keyDir, defaultDir)
+	pcfg.SetDefault(keyDisabled, false)
+	pcfg.BindEnv(keyDir, envDir)
+	pcfg.BindEnv(keyDisabled, envDisabled)
 
-	p.dir = cfg.GetString(keyDir)
-	p.disabled = cfg.GetBool(keyDisabled)
+	p.dir = pcfg.GetString(keyDir)
+	p.disabled = pcfg.GetBool(keyDisabled)
 
 	if p.disabled {
 		return nil

--- a/plugins/gobservability/handler.go
+++ b/plugins/gobservability/handler.go
@@ -31,7 +31,7 @@ func healthzHandler(p *gobservabilityPlugin) http.Handler {
 			return
 		}
 
-		data, err := p.session.QueryServer(r.Context(), "health")
+		data, err := p.session.QueryServer(r.Context(), "health", nil)
 		if err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]string{
@@ -65,7 +65,7 @@ func readyzHandler(p *gobservabilityPlugin) http.Handler {
 			return
 		}
 
-		healthData, err := p.session.QueryServer(r.Context(), "health")
+		healthData, err := p.session.QueryServer(r.Context(), "health", nil)
 		if err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -76,7 +76,7 @@ func readyzHandler(p *gobservabilityPlugin) http.Handler {
 			return
 		}
 
-		pluginData, err := p.session.QueryServer(r.Context(), "plugins")
+		pluginData, err := p.session.QueryServer(r.Context(), "plugins", nil)
 		if err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]any{

--- a/plugins/gobservability/main.go
+++ b/plugins/gobservability/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"gocache/api/command"
+	apiconfig "gocache/api/config"
 	gcpc "gocache/api/gcpc/v1"
 	apilogger "gocache/api/logger"
 	apiplugin "gocache/api/plugin"
@@ -72,7 +73,7 @@ func (p *gobservabilityPlugin) Hooks() []pluginsdk.HookDecl {
 	}
 }
 
-func (p *gobservabilityPlugin) HandleHook(_ context.Context, req *pluginsdk.HookRequest) *pluginsdk.HookResponse {
+func (p *gobservabilityPlugin) HandleHook(ctx context.Context, req *pluginsdk.HookRequest) *pluginsdk.HookResponse {
 	if req.Phase != pluginsdk.HookPhasePost {
 		return nil
 	}
@@ -83,7 +84,7 @@ func (p *gobservabilityPlugin) HandleHook(_ context.Context, req *pluginsdk.Hook
 		if err != nil {
 			// Malformed ns value would silently record a zero-latency sample.
 			// Log and skip the record so the histogram isn't poisoned.
-			p.log.WarnNoCtx().Str("value", v).Err(err).Msg("invalid elapsed_ns in hook context; skipping metrics sample")
+			p.log.Warn(ctx).Str("value", v).Err(err).Msg("invalid elapsed_ns in hook context; skipping metrics sample")
 			return nil
 		}
 		elapsedNs = n
@@ -169,6 +170,12 @@ func (p *gobservabilityPlugin) HandleEvent(_ context.Context, evt *gcpc.EventV1)
 
 func (p *gobservabilityPlugin) SetSession(s *pluginsdk.Session) {
 	p.session = s
+}
+
+// ConfigPlugin interface.
+
+func (p *gobservabilityPlugin) OnConfigReload(cfg apiconfig.PluginConfig) {
+	p.log.InfoNoCtx().Msg("config reloaded")
 }
 
 // ScopePlugin interface.

--- a/plugins/otlp/otlp.go
+++ b/plugins/otlp/otlp.go
@@ -20,6 +20,7 @@ import (
 	"gocache/api/config"
 	"gocache/api/embedded"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 )
 
 const (
@@ -126,8 +127,7 @@ func (p *plugin) BootInit(ctx context.Context) error {
 	return nil
 }
 
-func (p *plugin) ConfigLoaded(ctx context.Context, cfg *config.Config) error {
-	pcfg := config.PluginConfigFor("otlp_embedded")
+func (p *plugin) ConfigLoaded(ctx context.Context, cfg *config.Config, pcfg config.PluginConfig) error {
 	pcfg.SetDefault(keyEndpoint, "")
 	pcfg.SetDefault(keyService, defaultService)
 	pcfg.SetDefault(keyTimeoutMs, int(defaultTimeout.Milliseconds()))
@@ -158,14 +158,17 @@ func (p *plugin) ConfigLoaded(ctx context.Context, cfg *config.Config) error {
 // Grafana without a restart: main()'s deferred chain runs this during
 // panic unwind, and ForceFlush pushes whatever's in the batcher out
 // before the process exits.
-func (p *plugin) ProcessShutdown(_ context.Context) error {
+func (p *plugin) ProcessShutdown(ctx context.Context) error {
 	if p.provider == nil {
 		return nil
 	}
 	// Use a fresh context with a tight timeout — the main ctx may already
 	// be cancelled, and we don't want a slow telemetry backend to delay
-	// process exit.
+	// process exit. Propagate the operation for log correlation.
 	flushCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+	if op := ops.FromContext(ctx); op != nil {
+		flushCtx = ops.WithContext(flushCtx, op)
+	}
 	defer cancel()
 
 	if p.processSpan != nil {

--- a/plugins/otlp/otlp_test.go
+++ b/plugins/otlp/otlp_test.go
@@ -23,7 +23,7 @@ func TestBootInit_DisabledNoEndpoint(t *testing.T) {
 		t.Errorf("provider should remain nil when endpoint is empty")
 	}
 	// Subsequent lifecycle calls must not panic.
-	if err := p.ConfigLoaded(context.Background(), config.DefaultConfig()); err != nil {
+	if err := p.ConfigLoaded(context.Background(), config.DefaultConfig(), config.NewMapConfig()); err != nil {
 		t.Errorf("ConfigLoaded unexpected error: %v", err)
 	}
 	if err := p.ProcessShutdown(context.Background()); err != nil {

--- a/plugins/snapshot/init.go
+++ b/plugins/snapshot/init.go
@@ -7,6 +7,7 @@ import (
 	apicommand "gocache/api/command"
 	apiconfig "gocache/api/config"
 	"gocache/api/logger"
+	ops "gocache/api/operations"
 	apipersistence "gocache/api/persistence"
 )
 
@@ -53,10 +54,14 @@ func (p *provider) commands(api apipersistence.PersistenceAPI) []apipersistence.
 		return "OK", nil
 	}
 
-	bgsave := func(_ context.Context, _ []string) (any, error) {
+	bgsave := func(ctx context.Context, _ []string) (any, error) {
+		bgCtx := context.Background()
+		if op := ops.FromContext(ctx); op != nil {
+			bgCtx = ops.WithContext(bgCtx, op)
+		}
 		go func() {
-			if err := api.Snapshot(context.Background()); err != nil {
-				logger.ErrorNoCtx().Err(err).Msg("BGSAVE failed")
+			if err := api.Snapshot(bgCtx); err != nil {
+				logger.Error(bgCtx).Err(err).Msg("BGSAVE failed")
 			}
 		}()
 		return "Background saving started", nil

--- a/sdk/pluginsdk/remote_config.go
+++ b/sdk/pluginsdk/remote_config.go
@@ -1,0 +1,162 @@
+package pluginsdk
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RemoteConfig implements api/config.PluginConfig for IPC plugins. It is
+// backed by the config map delivered in RegisterAckV1 and updated via
+// PluginConfigV1 pushes on hot reload.
+//
+// Priority (highest wins): os.Getenv via BindEnv > server values > SetDefault.
+type RemoteConfig struct {
+	mu       sync.RWMutex
+	server   map[string]string // from RegisterAckV1.Config / PluginConfigV1
+	defaults map[string]any
+	envBinds map[string][]string // key → env var names
+}
+
+// NewRemoteConfig creates a RemoteConfig seeded with the server-delivered map.
+func NewRemoteConfig(server map[string]string) *RemoteConfig {
+	if server == nil {
+		server = make(map[string]string)
+	}
+	return &RemoteConfig{
+		server:   server,
+		defaults: make(map[string]any),
+		envBinds: make(map[string][]string),
+	}
+}
+
+// Replace swaps the server-side config map atomically on hot reload.
+func (c *RemoteConfig) Replace(entries map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entries == nil {
+		entries = make(map[string]string)
+	}
+	c.server = entries
+}
+
+func (c *RemoteConfig) resolve(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if envVars, ok := c.envBinds[key]; ok {
+		for _, ev := range envVars {
+			if v := os.Getenv(ev); v != "" {
+				return v, true
+			}
+		}
+	}
+	if v, ok := c.server[key]; ok {
+		return v, true
+	}
+	if v, ok := c.defaults[key]; ok {
+		return stringify(v), true
+	}
+	return "", false
+}
+
+func (c *RemoteConfig) GetString(key string) string {
+	v, _ := c.resolve(key)
+	return v
+}
+
+func (c *RemoteConfig) GetInt(key string) int {
+	v, ok := c.resolve(key)
+	if !ok {
+		return 0
+	}
+	n, _ := strconv.Atoi(v)
+	return n
+}
+
+func (c *RemoteConfig) GetInt64(key string) int64 {
+	v, ok := c.resolve(key)
+	if !ok {
+		return 0
+	}
+	n, _ := strconv.ParseInt(v, 10, 64)
+	return n
+}
+
+func (c *RemoteConfig) GetBool(key string) bool {
+	v, ok := c.resolve(key)
+	if !ok {
+		return false
+	}
+	b, _ := strconv.ParseBool(v)
+	return b
+}
+
+func (c *RemoteConfig) GetDuration(key string) time.Duration {
+	v, ok := c.resolve(key)
+	if !ok {
+		return 0
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	if ms, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return time.Duration(ms) * time.Millisecond
+	}
+	return 0
+}
+
+func (c *RemoteConfig) GetStringSlice(key string) []string {
+	v, ok := c.resolve(key)
+	if !ok || v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func (c *RemoteConfig) IsSet(key string) bool {
+	_, ok := c.resolve(key)
+	return ok
+}
+
+func (c *RemoteConfig) SetDefault(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.defaults[key] = value
+}
+
+func (c *RemoteConfig) BindEnv(key string, envVars ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.envBinds[key] = envVars
+}
+
+func (c *RemoteConfig) MergeFile(string) error { return nil }
+
+func stringify(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case bool:
+		return strconv.FormatBool(val)
+	case int:
+		return strconv.Itoa(val)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case time.Duration:
+		return val.String()
+	default:
+		return ""
+	}
+}

--- a/sdk/pluginsdk/remote_config_test.go
+++ b/sdk/pluginsdk/remote_config_test.go
@@ -1,0 +1,117 @@
+package pluginsdk
+
+import (
+	"testing"
+	"time"
+
+	apiconfig "gocache/api/config"
+)
+
+var _ apiconfig.PluginConfig = (*RemoteConfig)(nil)
+
+func TestRemoteConfig_ServerValues(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{
+		"file":  "appendonly.aof",
+		"flush": "5s",
+		"count": "42",
+	})
+	if got := rc.GetString("file"); got != "appendonly.aof" {
+		t.Errorf("GetString = %q, want %q", got, "appendonly.aof")
+	}
+	if got := rc.GetInt("count"); got != 42 {
+		t.Errorf("GetInt = %d, want %d", got, 42)
+	}
+	if got := rc.GetDuration("flush"); got != 5*time.Second {
+		t.Errorf("GetDuration = %v, want %v", got, 5*time.Second)
+	}
+	if !rc.IsSet("file") {
+		t.Error("IsSet should return true for server key")
+	}
+	if rc.IsSet("missing") {
+		t.Error("IsSet should return false for missing key")
+	}
+}
+
+func TestRemoteConfig_SetDefault(t *testing.T) {
+	rc := NewRemoteConfig(nil)
+	rc.SetDefault("file", "default.aof")
+	if got := rc.GetString("file"); got != "default.aof" {
+		t.Errorf("SetDefault: got %q, want %q", got, "default.aof")
+	}
+}
+
+func TestRemoteConfig_ServerOverridesDefault(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"file": "server.aof"})
+	rc.SetDefault("file", "default.aof")
+	if got := rc.GetString("file"); got != "server.aof" {
+		t.Errorf("server should override default: got %q", got)
+	}
+}
+
+func TestRemoteConfig_BindEnvOverridesServer(t *testing.T) {
+	t.Setenv("GOCACHE_AOF_FILE", "env.aof")
+	rc := NewRemoteConfig(map[string]string{"file": "server.aof"})
+	rc.BindEnv("file", "GOCACHE_AOF_FILE")
+	if got := rc.GetString("file"); got != "env.aof" {
+		t.Errorf("env should override server: got %q", got)
+	}
+}
+
+func TestRemoteConfig_Replace(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"file": "old.aof"})
+	if got := rc.GetString("file"); got != "old.aof" {
+		t.Fatalf("before replace: got %q", got)
+	}
+	rc.Replace(map[string]string{"file": "new.aof", "extra": "val"})
+	if got := rc.GetString("file"); got != "new.aof" {
+		t.Errorf("after replace: got %q, want %q", got, "new.aof")
+	}
+	if got := rc.GetString("extra"); got != "val" {
+		t.Errorf("new key after replace: got %q, want %q", got, "val")
+	}
+}
+
+func TestRemoteConfig_GetBool(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"enabled": "true", "disabled": "false"})
+	if !rc.GetBool("enabled") {
+		t.Error("GetBool(enabled) should be true")
+	}
+	if rc.GetBool("disabled") {
+		t.Error("GetBool(disabled) should be false")
+	}
+	if rc.GetBool("missing") {
+		t.Error("GetBool(missing) should be false")
+	}
+}
+
+func TestRemoteConfig_GetInt64(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"big": "9999999999"})
+	if got := rc.GetInt64("big"); got != 9999999999 {
+		t.Errorf("GetInt64 = %d, want %d", got, 9999999999)
+	}
+}
+
+func TestRemoteConfig_GetStringSlice(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"tags": "a, b, c"})
+	got := rc.GetStringSlice("tags")
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("GetStringSlice = %v, want [a b c]", got)
+	}
+	if slice := rc.GetStringSlice("missing"); slice != nil {
+		t.Errorf("GetStringSlice(missing) = %v, want nil", slice)
+	}
+}
+
+func TestRemoteConfig_GetDuration_Milliseconds(t *testing.T) {
+	rc := NewRemoteConfig(map[string]string{"timeout": "3000"})
+	if got := rc.GetDuration("timeout"); got != 3*time.Second {
+		t.Errorf("numeric duration = %v, want 3s", got)
+	}
+}
+
+func TestRemoteConfig_MergeFile_Noop(t *testing.T) {
+	rc := NewRemoteConfig(nil)
+	if err := rc.MergeFile("/any/path"); err != nil {
+		t.Errorf("MergeFile should be no-op: %v", err)
+	}
+}

--- a/sdk/pluginsdk/sdk.go
+++ b/sdk/pluginsdk/sdk.go
@@ -9,8 +9,11 @@ import (
 	"sync"
 	"time"
 
+	"gocache/api/command"
+	apiconfig "gocache/api/config"
 	gcpc "gocache/api/gcpc/v1"
 	apilogger "gocache/api/logger"
+	ops "gocache/api/operations"
 	apiplugin "gocache/api/plugin"
 	"gocache/api/transport"
 )
@@ -85,6 +88,15 @@ type EventPlugin interface {
 	// The EventV1 proto carries strongly-typed data in a oneof field.
 	// Called concurrently — must be goroutine-safe.
 	HandleEvent(ctx context.Context, evt *gcpc.EventV1)
+}
+
+// ConfigPlugin is an optional interface for plugins that want to react
+// to server config reloads. OnConfigReload is called when the server
+// pushes a PluginConfigV1 update. The provided PluginConfig reflects
+// the latest server-side values.
+type ConfigPlugin interface {
+	Plugin
+	OnConfigReload(cfg apiconfig.PluginConfig)
 }
 
 // OperationHookPlugin extends Plugin with operation lifecycle hooks.
@@ -183,6 +195,17 @@ type HookResponse struct {
 	ContextValues map[string]string // pre-hook: values to add to command context
 }
 
+// ctxFromOpMap reconstructs a local operation from a context map containing
+// _operation_id. If no operation ID is present, returns ctx unchanged.
+func ctxFromOpMap(ctx context.Context, m map[string]string) context.Context {
+	if opID := m[command.OperationID]; opID != "" {
+		op := ops.New(ops.TypeCommand, "")
+		op.ID = opID
+		return ops.WithContext(ctx, op)
+	}
+	return ctx
+}
+
 // Run connects to the GoCache server's plugin socket, registers the plugin,
 // and enters the message loop. It blocks until shutdown or context cancellation.
 // If the plugin implements CommandPlugin, its commands are registered.
@@ -216,6 +239,7 @@ func Run(ctx context.Context, p Plugin) error {
 	qp, isQueryPlugin := p.(QueryPlugin)
 	ep, isEventPlugin := p.(EventPlugin)
 	ohp, isOperationHookPlugin := p.(OperationHookPlugin)
+	cfgp, isConfigPlugin := p.(ConfigPlugin)
 
 	// Build registration message.
 	var cmdDecls []*gcpc.CommandDeclV1
@@ -314,6 +338,9 @@ func Run(ctx context.Context, p Plugin) error {
 		}
 	}
 
+	// Build RemoteConfig from server-delivered config map.
+	remoteCfg := NewRemoteConfig(ack.Config)
+
 	// Set up session for server queries.
 	session := newSession(tc)
 	if isQueryPlugin {
@@ -345,7 +372,11 @@ func Run(ctx context.Context, p Plugin) error {
 
 		switch env.Payload.(type) {
 		case *gcpc.EnvelopeV1_HealthCheck:
-			hErr := p.OnHealthCheck(ctx)
+			hcOp := ops.New(ops.TypeCommand, "")
+			hcOp.Enrich("_type", "health_check")
+			hcCtx := ops.WithContext(ctx, hcOp)
+			hErr := p.OnHealthCheck(hcCtx)
+			hcOp.Complete()
 			ok := hErr == nil
 			status := ""
 			if hErr != nil {
@@ -358,8 +389,10 @@ func Run(ctx context.Context, p Plugin) error {
 		case *gcpc.EnvelopeV1_Shutdown:
 			sd := env.GetShutdown()
 			deadline := time.Unix(0, int64(sd.DeadlineNs))
-			sdCtx, cancel := context.WithDeadline(ctx, deadline)
+			shutOp := ops.New(ops.TypeShutdown, "")
+			sdCtx, cancel := context.WithDeadline(ops.WithContext(ctx, shutOp), deadline)
 			_ = p.OnShutdown(sdCtx)
+			shutOp.Complete()
 			cancel()
 
 			if err := tc.Send(gcpc.NewShutdownAck()); err != nil {
@@ -375,7 +408,8 @@ func Run(ctx context.Context, p Plugin) error {
 			handlerWg.Add(1)
 			go func() {
 				defer handlerWg.Done()
-				result := cp.HandleCommand(ctx, req.Command, req.Args, req.Metadata)
+				cmdCtx := ctxFromOpMap(ctx, req.Context)
+				result := cp.HandleCommand(cmdCtx, req.Command, req.Args, req.Metadata)
 				var protoResult *gcpc.ResultV1
 				if result != nil {
 					protoResult = gcpc.ResultFromInterface(result.Value)
@@ -402,10 +436,16 @@ func Run(ctx context.Context, p Plugin) error {
 				Replayed:          req.Replayed,
 				ReplayStartUnixNs: req.ReplayStartUnixNs,
 			}
+			ohCtx := ctx
+			if req.OperationId != "" {
+				ohOp := ops.New(ops.TypeCommand, "")
+				ohOp.ID = req.OperationId
+				ohCtx = ops.WithContext(ctx, ohOp)
+			}
 			switch {
 			case req.Phase == apiplugin.PhaseStart && !req.Replayed:
 				// Live start: synchronous — server is waiting for response.
-				result := ohp.HandleOperationHook(ctx, hookReq)
+				result := ohp.HandleOperationHook(ohCtx, hookReq)
 				var ctxValues map[string]string
 				if result != nil {
 					ctxValues = result.ContextValues
@@ -423,7 +463,7 @@ func Run(ctx context.Context, p Plugin) error {
 				handlerWg.Add(1)
 				go func() {
 					defer handlerWg.Done()
-					ohp.HandleOperationHook(ctx, hookReq)
+					ohp.HandleOperationHook(ohCtx, hookReq)
 				}()
 			}
 
@@ -458,7 +498,8 @@ func Run(ctx context.Context, p Plugin) error {
 					Context:     req.Context,
 					Metadata:    req.Metadata,
 				}
-				result := hp.HandleHook(ctx, hookReq)
+				hookCtx := ctxFromOpMap(ctx, req.Context)
+				result := hp.HandleHook(hookCtx, hookReq)
 				deny := false
 				denyReason := ""
 				var ctxValues map[string]string
@@ -472,6 +513,13 @@ func Run(ctx context.Context, p Plugin) error {
 					pluginLog.ErrorNoCtx().Err(err).Str("command", req.Command).Msg("failed to send hook response")
 				}
 			}()
+
+		case *gcpc.EnvelopeV1_ConfigUpdate:
+			cu := env.GetConfigUpdate()
+			remoteCfg.Replace(cu.Entries)
+			if isConfigPlugin {
+				cfgp.OnConfigReload(remoteCfg)
+			}
 		}
 	}
 }

--- a/sdk/pluginsdk/session.go
+++ b/sdk/pluginsdk/session.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"gocache/api/command"
 	gcpc "gocache/api/gcpc/v1"
+	ops "gocache/api/operations"
 	"gocache/api/transport"
 )
 
@@ -25,13 +27,13 @@ func newSession(conn *transport.Conn) *Session {
 
 // QueryServer sends a query to the server and waits for the response.
 // The topic maps to a registered server-side handler (e.g. "health", "plugins", "stats").
-func (s *Session) QueryServer(ctx context.Context, topic string) (map[string]string, error) {
+func (s *Session) QueryServer(ctx context.Context, topic string, params map[string]string) (map[string]string, error) {
 	id := fmt.Sprintf("q-%d", s.idSeq.Add(1))
 	ch := make(chan *gcpc.ServerQueryResponseV1, 1)
 	s.pending.Store(id, ch)
 	defer s.pending.Delete(id)
 
-	if err := s.conn.Send(gcpc.NewServerQuery(id, topic)); err != nil {
+	if err := s.conn.Send(gcpc.NewServerQuery(id, topic, params)); err != nil {
 		return nil, fmt.Errorf("send server query: %w", err)
 	}
 
@@ -44,6 +46,58 @@ func (s *Session) QueryServer(ctx context.Context, topic string) (map[string]str
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// StartOperation creates a server-tracked operation for plugin-initiated
+// async work. Returns an enriched context and a PluginOperation whose
+// Complete/Fail methods notify the server.
+func (s *Session) StartOperation(ctx context.Context, opType string) (context.Context, *PluginOperation, error) {
+	data, err := s.QueryServer(ctx, "operation.start", map[string]string{"type": opType})
+	if err != nil {
+		return ctx, nil, fmt.Errorf("start operation: %w", err)
+	}
+	op := ops.New(ops.Type(opType), "")
+	if id := data[command.OperationID]; id != "" {
+		op.ID = id
+	}
+	op.EnrichMany(data)
+	return ops.WithContext(ctx, op), &PluginOperation{session: s, op: op}, nil
+}
+
+func (s *Session) completeOperation(operationID string) error {
+	_, err := s.QueryServer(context.Background(), "operation.complete", map[string]string{
+		"_operation_id": operationID,
+	})
+	return err
+}
+
+func (s *Session) failOperation(operationID, reason string) error {
+	_, err := s.QueryServer(context.Background(), "operation.fail", map[string]string{
+		"_operation_id":  operationID,
+		"_fail_reason":   reason,
+	})
+	return err
+}
+
+// PluginOperation wraps a server-tracked operation started by the plugin.
+// Complete and Fail update both the local operation and notify the server.
+type PluginOperation struct {
+	session *Session
+	op      *ops.Operation
+}
+
+func (po *PluginOperation) Complete() {
+	po.op.Complete()
+	_ = po.session.completeOperation(po.op.ID)
+}
+
+func (po *PluginOperation) Fail(reason string) {
+	po.op.Fail(reason)
+	_ = po.session.failOperation(po.op.ID, reason)
+}
+
+func (po *PluginOperation) Enrich(key, value string) {
+	po.op.Enrich(key, value)
 }
 
 // dispatch routes a server query response to the waiting caller.

--- a/sdk/pluginsdk/session_test.go
+++ b/sdk/pluginsdk/session_test.go
@@ -56,7 +56,7 @@ func TestSession_QueryServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	data, err := session.QueryServer(ctx, "health")
+	data, err := session.QueryServer(ctx, "health", nil)
 	if err != nil {
 		t.Fatalf("QueryServer error: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestSession_QueryServer_Error(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := session.QueryServer(ctx, "health")
+	_, err := session.QueryServer(ctx, "health", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -123,7 +123,7 @@ func TestSession_QueryServer_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := session.QueryServer(ctx, "health")
+	_, err := session.QueryServer(ctx, "health", nil)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}


### PR DESCRIPTION
## Summary

- **ADR-0019 (Unified Plugin Config Delivery)**: One config pattern for all plugin types — the server injects `PluginConfig` via lifecycle methods, plugins never self-fetch. Adds `ConfigPlugin` interface for IPC hot-reload push via `PluginConfigV1`. SDK-side `RemoteConfig` implements `PluginConfig` backed by server-delivered map with env override and defaults.
- **Operation context propagation**: Embedded lifecycle methods create parent operations; `invoke()` wraps each plugin in a child operation for log correlation. IPC handlers forward filtered operation context to plugins via context maps. SDK reconstructs local operations for logger enrichment.
- **Plugin-initiated operations**: IPC plugins start server-tracked operations via `Session.StartOperation()`; embedded plugins use `ops.Begin()`. `ServerQueryV1` gains params; `operation.start/complete/fail` query handlers registered.
- **Logging bug fixes**: Fixes `NoCtx()` logging in gobservability, aof, snapshot, and otlp plugins where context was available but discarded.

## Test plan

- [x] `go build -tags "aof crashdump otlp" ./...`
- [x] `go test -tags "aof crashdump otlp" -race ./...`
- [x] `go vet ./...`
- [ ] `staticcheck ./...` (CI)
- [ ] Verify log output includes `operation_id` fields during plugin boot/shutdown
- [ ] Verify IPC plugin commands receive operation context in `req.Context`