### PR TITLE
feat: Pub/Sub IPC plugin with client push architecture

### DIFF
--- a/api/command/hookctx.go
+++ b/api/command/hookctx.go
@@ -26,8 +26,12 @@ const (
 	FileKey    = "_file"    // File path associated with the operation
 
 	// Connection enrichment keys.
-	RemoteAddrKey  = "_remote_addr" // Remote peer address for connection operations
-	PluginNameKey  = "_plugin"      // Plugin name for plugin-scoped operations
+	RemoteAddrKey   = "_remote_addr"   // Remote peer address for connection operations
+	ConnectionIDKey = "_connection_id" // Stable connection identifier (connOp.ID)
+	PluginNameKey   = "_plugin"        // Plugin name for plugin-scoped operations
+
+	// Command enrichment keys — readonly classification.
+	ReadOnlyKey = "_readonly" // "true" if the command does not mutate cache state
 
 	// Log collector field names.
 	CtxField = "_ctx" // Nested operation-context object in JSON log lines

--- a/api/command/types.go
+++ b/api/command/types.go
@@ -6,8 +6,9 @@ package command
 
 // Result holds the return value or error from a command handler.
 type Result struct {
-	Value any
-	Err   error
+	Value            any
+	Err              error
+	SuppressResponse bool
 }
 
 // Spec defines the minimum and maximum number of arguments a command

--- a/api/gcpc/v1/gcpc.pb.go
+++ b/api/gcpc/v1/gcpc.pb.go
@@ -96,6 +96,7 @@ type EnvelopeV1 struct {
 	//	*EnvelopeV1_OperationHookRequest
 	//	*EnvelopeV1_OperationHookResponse
 	//	*EnvelopeV1_ConfigUpdate
+	//	*EnvelopeV1_ClientPush
 	Payload       isEnvelopeV1_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -305,6 +306,15 @@ func (x *EnvelopeV1) GetConfigUpdate() *PluginConfigV1 {
 	return nil
 }
 
+func (x *EnvelopeV1) GetClientPush() *ClientPushV1 {
+	if x != nil {
+		if x, ok := x.Payload.(*EnvelopeV1_ClientPush); ok {
+			return x.ClientPush
+		}
+	}
+	return nil
+}
+
 type isEnvelopeV1_Payload interface {
 	isEnvelopeV1_Payload()
 }
@@ -377,6 +387,10 @@ type EnvelopeV1_ConfigUpdate struct {
 	ConfigUpdate *PluginConfigV1 `protobuf:"bytes,90,opt,name=config_update,json=configUpdate,proto3,oneof"`
 }
 
+type EnvelopeV1_ClientPush struct {
+	ClientPush *ClientPushV1 `protobuf:"bytes,100,opt,name=client_push,json=clientPush,proto3,oneof"`
+}
+
 func (*EnvelopeV1_Register) isEnvelopeV1_Payload() {}
 
 func (*EnvelopeV1_RegisterAck) isEnvelopeV1_Payload() {}
@@ -410,6 +424,8 @@ func (*EnvelopeV1_OperationHookRequest) isEnvelopeV1_Payload() {}
 func (*EnvelopeV1_OperationHookResponse) isEnvelopeV1_Payload() {}
 
 func (*EnvelopeV1_ConfigUpdate) isEnvelopeV1_Payload() {}
+
+func (*EnvelopeV1_ClientPush) isEnvelopeV1_Payload() {}
 
 // RegisterV1 is sent by the plugin after connecting to announce capabilities.
 type RegisterV1 struct {
@@ -518,8 +534,10 @@ type CommandDeclV1 struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`              // command name, e.g. "PUBLISH" or "QUERY"
 	Namespaced    bool                   `protobuf:"varint,2,opt,name=namespaced,proto3" json:"namespaced,omitempty"` // true = REX (PLUGIN:CMD), false = main namespace
 	MinArgs       int32                  `protobuf:"varint,3,opt,name=min_args,json=minArgs,proto3" json:"min_args,omitempty"`
-	MaxArgs       int32                  `protobuf:"varint,4,opt,name=max_args,json=maxArgs,proto3" json:"max_args,omitempty"` // -1 = unlimited
-	Readonly      bool                   `protobuf:"varint,5,opt,name=readonly,proto3" json:"readonly,omitempty"`              // hint: command does not mutate state
+	MaxArgs       int32                  `protobuf:"varint,4,opt,name=max_args,json=maxArgs,proto3" json:"max_args,omitempty"`               // -1 = unlimited
+	Readonly      bool                   `protobuf:"varint,5,opt,name=readonly,proto3" json:"readonly,omitempty"`                            // hint: command does not mutate state
+	KeyArgIndex   int32                  `protobuf:"varint,6,opt,name=key_arg_index,json=keyArgIndex,proto3" json:"key_arg_index,omitempty"` // -1 = keyless, 0+ = single-key at Args[N]
+	MultiKey      bool                   `protobuf:"varint,7,opt,name=multi_key,json=multiKey,proto3" json:"multi_key,omitempty"`            // command touches multiple keys
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -585,6 +603,20 @@ func (x *CommandDeclV1) GetMaxArgs() int32 {
 func (x *CommandDeclV1) GetReadonly() bool {
 	if x != nil {
 		return x.Readonly
+	}
+	return false
+}
+
+func (x *CommandDeclV1) GetKeyArgIndex() int32 {
+	if x != nil {
+		return x.KeyArgIndex
+	}
+	return 0
+}
+
+func (x *CommandDeclV1) GetMultiKey() bool {
+	if x != nil {
+		return x.MultiKey
 	}
 	return false
 }
@@ -1015,11 +1047,12 @@ func (x *CommandRequestV1) GetContext() map[string]string {
 
 // CommandResponseV1 is the plugin's response to a CommandRequestV1.
 type CommandResponseV1 struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	Result        *ResultV1              `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	RequestId        string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Result           *ResultV1              `protobuf:"bytes,2,opt,name=result,proto3" json:"result,omitempty"`
+	SuppressResponse bool                   `protobuf:"varint,3,opt,name=suppress_response,json=suppressResponse,proto3" json:"suppress_response,omitempty"` // when true, server skips writing the RESP response (plugin already pushed via ClientPushV1)
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *CommandResponseV1) Reset() {
@@ -1064,6 +1097,13 @@ func (x *CommandResponseV1) GetResult() *ResultV1 {
 		return x.Result
 	}
 	return nil
+}
+
+func (x *CommandResponseV1) GetSuppressResponse() bool {
+	if x != nil {
+		return x.SuppressResponse
+	}
+	return false
 }
 
 // HookRequestV1 is sent by the server when a hook fires.
@@ -2775,6 +2815,61 @@ func (x *LogEntryEventV1) GetFields() map[string]string {
 	return nil
 }
 
+// ClientPushV1 is sent by a plugin to push raw RESP data to a specific
+// client connection. The server writes the data verbatim to the connection's
+// writer. Fire-and-forget: no response is sent back to the plugin.
+type ClientPushV1 struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ConnectionId  string                 `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"` // target connection (connOp.ID, received as _connection_id in context)
+	Data          []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`                                     // pre-formatted RESP bytes
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClientPushV1) Reset() {
+	*x = ClientPushV1{}
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClientPushV1) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClientPushV1) ProtoMessage() {}
+
+func (x *ClientPushV1) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClientPushV1.ProtoReflect.Descriptor instead.
+func (*ClientPushV1) Descriptor() ([]byte, []int) {
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ClientPushV1) GetConnectionId() string {
+	if x != nil {
+		return x.ConnectionId
+	}
+	return ""
+}
+
+func (x *ClientPushV1) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 type OperationStartEventV1 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -2787,7 +2882,7 @@ type OperationStartEventV1 struct {
 
 func (x *OperationStartEventV1) Reset() {
 	*x = OperationStartEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2799,7 +2894,7 @@ func (x *OperationStartEventV1) String() string {
 func (*OperationStartEventV1) ProtoMessage() {}
 
 func (x *OperationStartEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[35]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2812,7 +2907,7 @@ func (x *OperationStartEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationStartEventV1.ProtoReflect.Descriptor instead.
 func (*OperationStartEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{35}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *OperationStartEventV1) GetId() string {
@@ -2857,7 +2952,7 @@ type OperationCompleteEventV1 struct {
 
 func (x *OperationCompleteEventV1) Reset() {
 	*x = OperationCompleteEventV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2869,7 +2964,7 @@ func (x *OperationCompleteEventV1) String() string {
 func (*OperationCompleteEventV1) ProtoMessage() {}
 
 func (x *OperationCompleteEventV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[36]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2882,7 +2977,7 @@ func (x *OperationCompleteEventV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationCompleteEventV1.ProtoReflect.Descriptor instead.
 func (*OperationCompleteEventV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{36}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *OperationCompleteEventV1) GetId() string {
@@ -2938,7 +3033,7 @@ type OperationHookDeclV1 struct {
 
 func (x *OperationHookDeclV1) Reset() {
 	*x = OperationHookDeclV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2950,7 +3045,7 @@ func (x *OperationHookDeclV1) String() string {
 func (*OperationHookDeclV1) ProtoMessage() {}
 
 func (x *OperationHookDeclV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[37]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2963,7 +3058,7 @@ func (x *OperationHookDeclV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookDeclV1.ProtoReflect.Descriptor instead.
 func (*OperationHookDeclV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{37}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *OperationHookDeclV1) GetType() string {
@@ -3005,7 +3100,7 @@ type OperationHookRequestV1 struct {
 
 func (x *OperationHookRequestV1) Reset() {
 	*x = OperationHookRequestV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3017,7 +3112,7 @@ func (x *OperationHookRequestV1) String() string {
 func (*OperationHookRequestV1) ProtoMessage() {}
 
 func (x *OperationHookRequestV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[38]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3030,7 +3125,7 @@ func (x *OperationHookRequestV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookRequestV1.ProtoReflect.Descriptor instead.
 func (*OperationHookRequestV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{38}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *OperationHookRequestV1) GetRequestId() string {
@@ -3100,7 +3195,7 @@ type OperationHookResponseV1 struct {
 
 func (x *OperationHookResponseV1) Reset() {
 	*x = OperationHookResponseV1{}
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3112,7 +3207,7 @@ func (x *OperationHookResponseV1) String() string {
 func (*OperationHookResponseV1) ProtoMessage() {}
 
 func (x *OperationHookResponseV1) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[39]
+	mi := &file_api_gcpc_v1_gcpc_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3125,7 +3220,7 @@ func (x *OperationHookResponseV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OperationHookResponseV1.ProtoReflect.Descriptor instead.
 func (*OperationHookResponseV1) Descriptor() ([]byte, []int) {
-	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{39}
+	return file_api_gcpc_v1_gcpc_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *OperationHookResponseV1) GetRequestId() string {
@@ -3146,7 +3241,7 @@ var File_api_gcpc_v1_gcpc_proto protoreflect.FileDescriptor
 
 const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\n" +
-	"\x16api/gcpc/v1/gcpc.proto\x12\agcpc.v1\"\xa8\t\n" +
+	"\x16api/gcpc/v1/gcpc.proto\x12\agcpc.v1\"\xe2\t\n" +
 	"\n" +
 	"EnvelopeV1\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\x0e\n" +
@@ -3168,7 +3263,9 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\x05event\x18G \x01(\v2\x10.gcpc.v1.EventV1H\x00R\x05event\x12W\n" +
 	"\x16operation_hook_request\x18P \x01(\v2\x1f.gcpc.v1.OperationHookRequestV1H\x00R\x14operationHookRequest\x12Z\n" +
 	"\x17operation_hook_response\x18Q \x01(\v2 .gcpc.v1.OperationHookResponseV1H\x00R\x15operationHookResponse\x12>\n" +
-	"\rconfig_update\x18Z \x01(\v2\x17.gcpc.v1.PluginConfigV1H\x00R\fconfigUpdateB\t\n" +
+	"\rconfig_update\x18Z \x01(\v2\x17.gcpc.v1.PluginConfigV1H\x00R\fconfigUpdate\x128\n" +
+	"\vclient_push\x18d \x01(\v2\x15.gcpc.v1.ClientPushV1H\x00R\n" +
+	"clientPushB\t\n" +
 	"\apayload\"\xc3\x02\n" +
 	"\n" +
 	"RegisterV1\x12\x12\n" +
@@ -3179,7 +3276,7 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\bpriority\x18\x05 \x01(\x05R\bpriority\x12)\n" +
 	"\x05hooks\x18\x06 \x03(\v2\x13.gcpc.v1.HookDeclV1R\x05hooks\x12)\n" +
 	"\x10requested_scopes\x18\a \x03(\tR\x0frequestedScopes\x12E\n" +
-	"\x0foperation_hooks\x18\b \x03(\v2\x1c.gcpc.v1.OperationHookDeclV1R\x0eoperationHooks\"\x95\x01\n" +
+	"\x0foperation_hooks\x18\b \x03(\v2\x1c.gcpc.v1.OperationHookDeclV1R\x0eoperationHooks\"\xd6\x01\n" +
 	"\rCommandDeclV1\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1e\n" +
 	"\n" +
@@ -3187,7 +3284,9 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"namespaced\x12\x19\n" +
 	"\bmin_args\x18\x03 \x01(\x05R\aminArgs\x12\x19\n" +
 	"\bmax_args\x18\x04 \x01(\x05R\amaxArgs\x12\x1a\n" +
-	"\breadonly\x18\x05 \x01(\bR\breadonly\"R\n" +
+	"\breadonly\x18\x05 \x01(\bR\breadonly\x12\"\n" +
+	"\rkey_arg_index\x18\x06 \x01(\x05R\vkeyArgIndex\x12\x1b\n" +
+	"\tmulti_key\x18\a \x01(\bR\bmultiKey\"R\n" +
 	"\n" +
 	"HookDeclV1\x12\x18\n" +
 	"\apattern\x18\x01 \x01(\tR\apattern\x12*\n" +
@@ -3227,11 +3326,12 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
 	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"]\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8a\x01\n" +
 	"\x11CommandResponseV1\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12)\n" +
-	"\x06result\x18\x02 \x01(\v2\x11.gcpc.v1.ResultV1R\x06result\"\xc8\x03\n" +
+	"\x06result\x18\x02 \x01(\v2\x11.gcpc.v1.ResultV1R\x06result\x12+\n" +
+	"\x11suppress_response\x18\x03 \x01(\bR\x10suppressResponse\"\xc8\x03\n" +
 	"\rHookRequestV1\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12*\n" +
@@ -3377,7 +3477,10 @@ const file_api_gcpc_v1_gcpc_proto_rawDesc = "" +
 	"\x06fields\x18\x04 \x03(\v2$.gcpc.v1.LogEntryEventV1.FieldsEntryR\x06fields\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdb\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
+	"\fClientPushV1\x12#\n" +
+	"\rconnection_id\x18\x01 \x01(\tR\fconnectionId\x12\x12\n" +
+	"\x04data\x18\x02 \x01(\fR\x04data\"\xdb\x01\n" +
 	"\x15OperationStartEventV1\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1b\n" +
@@ -3439,7 +3542,7 @@ func file_api_gcpc_v1_gcpc_proto_rawDescGZIP() []byte {
 }
 
 var file_api_gcpc_v1_gcpc_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_gcpc_v1_gcpc_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
+var file_api_gcpc_v1_gcpc_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_api_gcpc_v1_gcpc_proto_goTypes = []any{
 	(HookPhaseV1)(0),                 // 0: gcpc.v1.HookPhaseV1
 	(*EnvelopeV1)(nil),               // 1: gcpc.v1.EnvelopeV1
@@ -3477,27 +3580,28 @@ var file_api_gcpc_v1_gcpc_proto_goTypes = []any{
 	(*AuthFailedEventV1)(nil),        // 33: gcpc.v1.AuthFailedEventV1
 	(*CacheEvictionEventV1)(nil),     // 34: gcpc.v1.CacheEvictionEventV1
 	(*LogEntryEventV1)(nil),          // 35: gcpc.v1.LogEntryEventV1
-	(*OperationStartEventV1)(nil),    // 36: gcpc.v1.OperationStartEventV1
-	(*OperationCompleteEventV1)(nil), // 37: gcpc.v1.OperationCompleteEventV1
-	(*OperationHookDeclV1)(nil),      // 38: gcpc.v1.OperationHookDeclV1
-	(*OperationHookRequestV1)(nil),   // 39: gcpc.v1.OperationHookRequestV1
-	(*OperationHookResponseV1)(nil),  // 40: gcpc.v1.OperationHookResponseV1
-	nil,                              // 41: gcpc.v1.RegisterAckV1.ConfigEntry
-	nil,                              // 42: gcpc.v1.PluginConfigV1.EntriesEntry
-	nil,                              // 43: gcpc.v1.CommandRequestV1.MetadataEntry
-	nil,                              // 44: gcpc.v1.CommandRequestV1.ContextEntry
-	nil,                              // 45: gcpc.v1.HookRequestV1.ContextEntry
-	nil,                              // 46: gcpc.v1.HookRequestV1.MetadataEntry
-	nil,                              // 47: gcpc.v1.HookResponseV1.ContextValuesEntry
-	nil,                              // 48: gcpc.v1.ServerQueryV1.ParamsEntry
-	nil,                              // 49: gcpc.v1.ServerQueryResponseV1.DataEntry
-	nil,                              // 50: gcpc.v1.CommandPreEventV1.MetadataEntry
-	nil,                              // 51: gcpc.v1.CommandPostEventV1.MetadataEntry
-	nil,                              // 52: gcpc.v1.LogEntryEventV1.FieldsEntry
-	nil,                              // 53: gcpc.v1.OperationStartEventV1.ContextEntry
-	nil,                              // 54: gcpc.v1.OperationCompleteEventV1.ContextEntry
-	nil,                              // 55: gcpc.v1.OperationHookRequestV1.ContextEntry
-	nil,                              // 56: gcpc.v1.OperationHookResponseV1.ContextValuesEntry
+	(*ClientPushV1)(nil),             // 36: gcpc.v1.ClientPushV1
+	(*OperationStartEventV1)(nil),    // 37: gcpc.v1.OperationStartEventV1
+	(*OperationCompleteEventV1)(nil), // 38: gcpc.v1.OperationCompleteEventV1
+	(*OperationHookDeclV1)(nil),      // 39: gcpc.v1.OperationHookDeclV1
+	(*OperationHookRequestV1)(nil),   // 40: gcpc.v1.OperationHookRequestV1
+	(*OperationHookResponseV1)(nil),  // 41: gcpc.v1.OperationHookResponseV1
+	nil,                              // 42: gcpc.v1.RegisterAckV1.ConfigEntry
+	nil,                              // 43: gcpc.v1.PluginConfigV1.EntriesEntry
+	nil,                              // 44: gcpc.v1.CommandRequestV1.MetadataEntry
+	nil,                              // 45: gcpc.v1.CommandRequestV1.ContextEntry
+	nil,                              // 46: gcpc.v1.HookRequestV1.ContextEntry
+	nil,                              // 47: gcpc.v1.HookRequestV1.MetadataEntry
+	nil,                              // 48: gcpc.v1.HookResponseV1.ContextValuesEntry
+	nil,                              // 49: gcpc.v1.ServerQueryV1.ParamsEntry
+	nil,                              // 50: gcpc.v1.ServerQueryResponseV1.DataEntry
+	nil,                              // 51: gcpc.v1.CommandPreEventV1.MetadataEntry
+	nil,                              // 52: gcpc.v1.CommandPostEventV1.MetadataEntry
+	nil,                              // 53: gcpc.v1.LogEntryEventV1.FieldsEntry
+	nil,                              // 54: gcpc.v1.OperationStartEventV1.ContextEntry
+	nil,                              // 55: gcpc.v1.OperationCompleteEventV1.ContextEntry
+	nil,                              // 56: gcpc.v1.OperationHookRequestV1.ContextEntry
+	nil,                              // 57: gcpc.v1.OperationHookResponseV1.ContextValuesEntry
 }
 var file_api_gcpc_v1_gcpc_proto_depIdxs = []int32{
 	2,  // 0: gcpc.v1.EnvelopeV1.register:type_name -> gcpc.v1.RegisterV1
@@ -3514,56 +3618,57 @@ var file_api_gcpc_v1_gcpc_proto_depIdxs = []int32{
 	20, // 11: gcpc.v1.EnvelopeV1.server_query_response:type_name -> gcpc.v1.ServerQueryResponseV1
 	21, // 12: gcpc.v1.EnvelopeV1.event_subscribe:type_name -> gcpc.v1.EventSubscribeV1
 	22, // 13: gcpc.v1.EnvelopeV1.event:type_name -> gcpc.v1.EventV1
-	39, // 14: gcpc.v1.EnvelopeV1.operation_hook_request:type_name -> gcpc.v1.OperationHookRequestV1
-	40, // 15: gcpc.v1.EnvelopeV1.operation_hook_response:type_name -> gcpc.v1.OperationHookResponseV1
+	40, // 14: gcpc.v1.EnvelopeV1.operation_hook_request:type_name -> gcpc.v1.OperationHookRequestV1
+	41, // 15: gcpc.v1.EnvelopeV1.operation_hook_response:type_name -> gcpc.v1.OperationHookResponseV1
 	6,  // 16: gcpc.v1.EnvelopeV1.config_update:type_name -> gcpc.v1.PluginConfigV1
-	3,  // 17: gcpc.v1.RegisterV1.commands:type_name -> gcpc.v1.CommandDeclV1
-	4,  // 18: gcpc.v1.RegisterV1.hooks:type_name -> gcpc.v1.HookDeclV1
-	38, // 19: gcpc.v1.RegisterV1.operation_hooks:type_name -> gcpc.v1.OperationHookDeclV1
-	0,  // 20: gcpc.v1.HookDeclV1.phase:type_name -> gcpc.v1.HookPhaseV1
-	41, // 21: gcpc.v1.RegisterAckV1.config:type_name -> gcpc.v1.RegisterAckV1.ConfigEntry
-	42, // 22: gcpc.v1.PluginConfigV1.entries:type_name -> gcpc.v1.PluginConfigV1.EntriesEntry
-	43, // 23: gcpc.v1.CommandRequestV1.metadata:type_name -> gcpc.v1.CommandRequestV1.MetadataEntry
-	44, // 24: gcpc.v1.CommandRequestV1.context:type_name -> gcpc.v1.CommandRequestV1.ContextEntry
-	15, // 25: gcpc.v1.CommandResponseV1.result:type_name -> gcpc.v1.ResultV1
-	0,  // 26: gcpc.v1.HookRequestV1.phase:type_name -> gcpc.v1.HookPhaseV1
-	45, // 27: gcpc.v1.HookRequestV1.context:type_name -> gcpc.v1.HookRequestV1.ContextEntry
-	46, // 28: gcpc.v1.HookRequestV1.metadata:type_name -> gcpc.v1.HookRequestV1.MetadataEntry
-	47, // 29: gcpc.v1.HookResponseV1.context_values:type_name -> gcpc.v1.HookResponseV1.ContextValuesEntry
-	16, // 30: gcpc.v1.ResultV1.array:type_name -> gcpc.v1.ResultArrayV1
-	17, // 31: gcpc.v1.ResultV1.map_val:type_name -> gcpc.v1.ResultMapV1
-	15, // 32: gcpc.v1.ResultArrayV1.elements:type_name -> gcpc.v1.ResultV1
-	18, // 33: gcpc.v1.ResultMapV1.entries:type_name -> gcpc.v1.ResultEntryV1
-	15, // 34: gcpc.v1.ResultEntryV1.value:type_name -> gcpc.v1.ResultV1
-	48, // 35: gcpc.v1.ServerQueryV1.params:type_name -> gcpc.v1.ServerQueryV1.ParamsEntry
-	49, // 36: gcpc.v1.ServerQueryResponseV1.data:type_name -> gcpc.v1.ServerQueryResponseV1.DataEntry
-	23, // 37: gcpc.v1.EventV1.command_pre:type_name -> gcpc.v1.CommandPreEventV1
-	24, // 38: gcpc.v1.EventV1.command_post:type_name -> gcpc.v1.CommandPostEventV1
-	25, // 39: gcpc.v1.EventV1.connection_open:type_name -> gcpc.v1.ConnectionOpenEventV1
-	26, // 40: gcpc.v1.EventV1.connection_close:type_name -> gcpc.v1.ConnectionCloseEventV1
-	27, // 41: gcpc.v1.EventV1.server_start:type_name -> gcpc.v1.ServerStartEventV1
-	28, // 42: gcpc.v1.EventV1.server_shutdown:type_name -> gcpc.v1.ServerShutdownEventV1
-	29, // 43: gcpc.v1.EventV1.plugin_registered:type_name -> gcpc.v1.PluginRegisteredEventV1
-	30, // 44: gcpc.v1.EventV1.plugin_crashed:type_name -> gcpc.v1.PluginCrashedEventV1
-	31, // 45: gcpc.v1.EventV1.plugin_restarted:type_name -> gcpc.v1.PluginRestartedEventV1
-	32, // 46: gcpc.v1.EventV1.config_reloaded:type_name -> gcpc.v1.ConfigReloadedEventV1
-	33, // 47: gcpc.v1.EventV1.auth_failed:type_name -> gcpc.v1.AuthFailedEventV1
-	34, // 48: gcpc.v1.EventV1.cache_eviction:type_name -> gcpc.v1.CacheEvictionEventV1
-	35, // 49: gcpc.v1.EventV1.log_entry:type_name -> gcpc.v1.LogEntryEventV1
-	36, // 50: gcpc.v1.EventV1.operation_start:type_name -> gcpc.v1.OperationStartEventV1
-	37, // 51: gcpc.v1.EventV1.operation_complete:type_name -> gcpc.v1.OperationCompleteEventV1
-	50, // 52: gcpc.v1.CommandPreEventV1.metadata:type_name -> gcpc.v1.CommandPreEventV1.MetadataEntry
-	51, // 53: gcpc.v1.CommandPostEventV1.metadata:type_name -> gcpc.v1.CommandPostEventV1.MetadataEntry
-	52, // 54: gcpc.v1.LogEntryEventV1.fields:type_name -> gcpc.v1.LogEntryEventV1.FieldsEntry
-	53, // 55: gcpc.v1.OperationStartEventV1.context:type_name -> gcpc.v1.OperationStartEventV1.ContextEntry
-	54, // 56: gcpc.v1.OperationCompleteEventV1.context:type_name -> gcpc.v1.OperationCompleteEventV1.ContextEntry
-	55, // 57: gcpc.v1.OperationHookRequestV1.context:type_name -> gcpc.v1.OperationHookRequestV1.ContextEntry
-	56, // 58: gcpc.v1.OperationHookResponseV1.context_values:type_name -> gcpc.v1.OperationHookResponseV1.ContextValuesEntry
-	59, // [59:59] is the sub-list for method output_type
-	59, // [59:59] is the sub-list for method input_type
-	59, // [59:59] is the sub-list for extension type_name
-	59, // [59:59] is the sub-list for extension extendee
-	0,  // [0:59] is the sub-list for field type_name
+	36, // 17: gcpc.v1.EnvelopeV1.client_push:type_name -> gcpc.v1.ClientPushV1
+	3,  // 18: gcpc.v1.RegisterV1.commands:type_name -> gcpc.v1.CommandDeclV1
+	4,  // 19: gcpc.v1.RegisterV1.hooks:type_name -> gcpc.v1.HookDeclV1
+	39, // 20: gcpc.v1.RegisterV1.operation_hooks:type_name -> gcpc.v1.OperationHookDeclV1
+	0,  // 21: gcpc.v1.HookDeclV1.phase:type_name -> gcpc.v1.HookPhaseV1
+	42, // 22: gcpc.v1.RegisterAckV1.config:type_name -> gcpc.v1.RegisterAckV1.ConfigEntry
+	43, // 23: gcpc.v1.PluginConfigV1.entries:type_name -> gcpc.v1.PluginConfigV1.EntriesEntry
+	44, // 24: gcpc.v1.CommandRequestV1.metadata:type_name -> gcpc.v1.CommandRequestV1.MetadataEntry
+	45, // 25: gcpc.v1.CommandRequestV1.context:type_name -> gcpc.v1.CommandRequestV1.ContextEntry
+	15, // 26: gcpc.v1.CommandResponseV1.result:type_name -> gcpc.v1.ResultV1
+	0,  // 27: gcpc.v1.HookRequestV1.phase:type_name -> gcpc.v1.HookPhaseV1
+	46, // 28: gcpc.v1.HookRequestV1.context:type_name -> gcpc.v1.HookRequestV1.ContextEntry
+	47, // 29: gcpc.v1.HookRequestV1.metadata:type_name -> gcpc.v1.HookRequestV1.MetadataEntry
+	48, // 30: gcpc.v1.HookResponseV1.context_values:type_name -> gcpc.v1.HookResponseV1.ContextValuesEntry
+	16, // 31: gcpc.v1.ResultV1.array:type_name -> gcpc.v1.ResultArrayV1
+	17, // 32: gcpc.v1.ResultV1.map_val:type_name -> gcpc.v1.ResultMapV1
+	15, // 33: gcpc.v1.ResultArrayV1.elements:type_name -> gcpc.v1.ResultV1
+	18, // 34: gcpc.v1.ResultMapV1.entries:type_name -> gcpc.v1.ResultEntryV1
+	15, // 35: gcpc.v1.ResultEntryV1.value:type_name -> gcpc.v1.ResultV1
+	49, // 36: gcpc.v1.ServerQueryV1.params:type_name -> gcpc.v1.ServerQueryV1.ParamsEntry
+	50, // 37: gcpc.v1.ServerQueryResponseV1.data:type_name -> gcpc.v1.ServerQueryResponseV1.DataEntry
+	23, // 38: gcpc.v1.EventV1.command_pre:type_name -> gcpc.v1.CommandPreEventV1
+	24, // 39: gcpc.v1.EventV1.command_post:type_name -> gcpc.v1.CommandPostEventV1
+	25, // 40: gcpc.v1.EventV1.connection_open:type_name -> gcpc.v1.ConnectionOpenEventV1
+	26, // 41: gcpc.v1.EventV1.connection_close:type_name -> gcpc.v1.ConnectionCloseEventV1
+	27, // 42: gcpc.v1.EventV1.server_start:type_name -> gcpc.v1.ServerStartEventV1
+	28, // 43: gcpc.v1.EventV1.server_shutdown:type_name -> gcpc.v1.ServerShutdownEventV1
+	29, // 44: gcpc.v1.EventV1.plugin_registered:type_name -> gcpc.v1.PluginRegisteredEventV1
+	30, // 45: gcpc.v1.EventV1.plugin_crashed:type_name -> gcpc.v1.PluginCrashedEventV1
+	31, // 46: gcpc.v1.EventV1.plugin_restarted:type_name -> gcpc.v1.PluginRestartedEventV1
+	32, // 47: gcpc.v1.EventV1.config_reloaded:type_name -> gcpc.v1.ConfigReloadedEventV1
+	33, // 48: gcpc.v1.EventV1.auth_failed:type_name -> gcpc.v1.AuthFailedEventV1
+	34, // 49: gcpc.v1.EventV1.cache_eviction:type_name -> gcpc.v1.CacheEvictionEventV1
+	35, // 50: gcpc.v1.EventV1.log_entry:type_name -> gcpc.v1.LogEntryEventV1
+	37, // 51: gcpc.v1.EventV1.operation_start:type_name -> gcpc.v1.OperationStartEventV1
+	38, // 52: gcpc.v1.EventV1.operation_complete:type_name -> gcpc.v1.OperationCompleteEventV1
+	51, // 53: gcpc.v1.CommandPreEventV1.metadata:type_name -> gcpc.v1.CommandPreEventV1.MetadataEntry
+	52, // 54: gcpc.v1.CommandPostEventV1.metadata:type_name -> gcpc.v1.CommandPostEventV1.MetadataEntry
+	53, // 55: gcpc.v1.LogEntryEventV1.fields:type_name -> gcpc.v1.LogEntryEventV1.FieldsEntry
+	54, // 56: gcpc.v1.OperationStartEventV1.context:type_name -> gcpc.v1.OperationStartEventV1.ContextEntry
+	55, // 57: gcpc.v1.OperationCompleteEventV1.context:type_name -> gcpc.v1.OperationCompleteEventV1.ContextEntry
+	56, // 58: gcpc.v1.OperationHookRequestV1.context:type_name -> gcpc.v1.OperationHookRequestV1.ContextEntry
+	57, // 59: gcpc.v1.OperationHookResponseV1.context_values:type_name -> gcpc.v1.OperationHookResponseV1.ContextValuesEntry
+	60, // [60:60] is the sub-list for method output_type
+	60, // [60:60] is the sub-list for method input_type
+	60, // [60:60] is the sub-list for extension type_name
+	60, // [60:60] is the sub-list for extension extendee
+	0,  // [0:60] is the sub-list for field type_name
 }
 
 func init() { file_api_gcpc_v1_gcpc_proto_init() }
@@ -3589,6 +3694,7 @@ func file_api_gcpc_v1_gcpc_proto_init() {
 		(*EnvelopeV1_OperationHookRequest)(nil),
 		(*EnvelopeV1_OperationHookResponse)(nil),
 		(*EnvelopeV1_ConfigUpdate)(nil),
+		(*EnvelopeV1_ClientPush)(nil),
 	}
 	file_api_gcpc_v1_gcpc_proto_msgTypes[14].OneofWrappers = []any{
 		(*ResultV1_SimpleString)(nil),
@@ -3623,7 +3729,7 @@ func file_api_gcpc_v1_gcpc_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_gcpc_v1_gcpc_proto_rawDesc), len(file_api_gcpc_v1_gcpc_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   56,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gcpc/v1/gcpc.proto
+++ b/api/gcpc/v1/gcpc.proto
@@ -25,6 +25,7 @@ message EnvelopeV1 {
     OperationHookRequestV1  operation_hook_request  = 80;
     OperationHookResponseV1 operation_hook_response = 81;
     PluginConfigV1          config_update           = 90;
+    ClientPushV1            client_push             = 100;
   }
 }
 
@@ -42,11 +43,13 @@ message RegisterV1 {
 
 // CommandDeclV1 declares a single command a plugin can handle.
 message CommandDeclV1 {
-  string name       = 1; // command name, e.g. "PUBLISH" or "QUERY"
-  bool   namespaced = 2; // true = REX (PLUGIN:CMD), false = main namespace
-  int32  min_args   = 3;
-  int32  max_args   = 4; // -1 = unlimited
-  bool   readonly   = 5; // hint: command does not mutate state
+  string name          = 1; // command name, e.g. "PUBLISH" or "QUERY"
+  bool   namespaced    = 2; // true = REX (PLUGIN:CMD), false = main namespace
+  int32  min_args      = 3;
+  int32  max_args      = 4; // -1 = unlimited
+  bool   readonly      = 5; // hint: command does not mutate state
+  int32  key_arg_index = 6; // -1 = keyless, 0+ = single-key at Args[N]
+  bool   multi_key     = 7; // command touches multiple keys
 }
 
 // HookPhaseV1 specifies when a hook fires relative to command execution.
@@ -105,8 +108,9 @@ message CommandRequestV1 {
 
 // CommandResponseV1 is the plugin's response to a CommandRequestV1.
 message CommandResponseV1 {
-  string   request_id = 1;
-  ResultV1 result     = 2;
+  string   request_id        = 1;
+  ResultV1 result             = 2;
+  bool     suppress_response  = 3; // when true, server skips writing the RESP response (plugin already pushed via ClientPushV1)
 }
 
 // HookRequestV1 is sent by the server when a hook fires.
@@ -275,6 +279,16 @@ message LogEntryEventV1 {
   string              message = 2;
   string              caller  = 3; // source file:line
   map<string, string> fields  = 4; // structured log fields
+}
+
+// --- Client Push ---
+
+// ClientPushV1 is sent by a plugin to push raw RESP data to a specific
+// client connection. The server writes the data verbatim to the connection's
+// writer. Fire-and-forget: no response is sent back to the plugin.
+message ClientPushV1 {
+  string connection_id = 1; // target connection (connOp.ID, received as _connection_id in context)
+  bytes  data          = 2; // pre-formatted RESP bytes
 }
 
 // --- Operation Events ---

--- a/api/gcpc/v1/helpers.go
+++ b/api/gcpc/v1/helpers.go
@@ -154,14 +154,28 @@ func NewCommandRequest(command string, args []string, requestID string, metadata
 	}
 }
 
-func NewCommandResponse(requestID string, result *ResultV1) *EnvelopeV1 {
+func NewCommandResponse(requestID string, result *ResultV1, suppressResponse bool) *EnvelopeV1 {
 	return &EnvelopeV1{
 		Version: ProtocolVersion,
 		Id:      envelopeID(),
 		Payload: &EnvelopeV1_CommandResponse{
 			CommandResponse: &CommandResponseV1{
-				RequestId: requestID,
-				Result:    result,
+				RequestId:        requestID,
+				Result:           result,
+				SuppressResponse: suppressResponse,
+			},
+		},
+	}
+}
+
+func NewClientPush(connectionID string, data []byte) *EnvelopeV1 {
+	return &EnvelopeV1{
+		Version: ProtocolVersion,
+		Id:      envelopeID(),
+		Payload: &EnvelopeV1_ClientPush{
+			ClientPush: &ClientPushV1{
+				ConnectionId: connectionID,
+				Data:         data,
 			},
 		},
 	}

--- a/api/resp/encode.go
+++ b/api/resp/encode.go
@@ -1,0 +1,100 @@
+package resp
+
+import "strconv"
+
+const (
+	SimpleString = '+'
+	Error        = '-'
+	Integer      = ':'
+	BulkString   = '$'
+	Array        = '*'
+	Null         = '_'
+	Boolean      = '#'
+	Double       = ','
+	BulkError    = '!'
+	Map          = '%'
+	Set          = '~'
+)
+
+// --- Append-based API (zero-alloc hot path) ---
+
+func AppendBulkString(b []byte, s string) []byte {
+	b = append(b, BulkString)
+	b = strconv.AppendInt(b, int64(len(s)), 10)
+	b = append(b, '\r', '\n')
+	b = append(b, s...)
+	return append(b, '\r', '\n')
+}
+
+func AppendInteger(b []byte, n int64) []byte {
+	b = append(b, Integer)
+	b = strconv.AppendInt(b, n, 10)
+	return append(b, '\r', '\n')
+}
+
+func AppendSimpleString(b []byte, s string) []byte {
+	b = append(b, SimpleString)
+	b = append(b, s...)
+	return append(b, '\r', '\n')
+}
+
+func AppendError(b []byte, s string) []byte {
+	b = append(b, Error)
+	b = append(b, s...)
+	return append(b, '\r', '\n')
+}
+
+func AppendArrayHeader(b []byte, count int) []byte {
+	b = append(b, Array)
+	b = strconv.AppendInt(b, int64(count), 10)
+	return append(b, '\r', '\n')
+}
+
+func AppendNullBulk(b []byte) []byte {
+	return append(b, "$-1\r\n"...)
+}
+
+func AppendNullArray(b []byte) []byte {
+	return append(b, "*-1\r\n"...)
+}
+
+// --- Allocating convenience API ---
+
+func EncodeBulkString(s string) []byte {
+	return AppendBulkString(make([]byte, 0, 1+20+2+len(s)+2), s)
+}
+
+func EncodeInteger(n int64) []byte {
+	return AppendInteger(make([]byte, 0, 24), n)
+}
+
+func EncodeSimpleString(s string) []byte {
+	return AppendSimpleString(make([]byte, 0, 1+len(s)+2), s)
+}
+
+func EncodeError(s string) []byte {
+	return AppendError(make([]byte, 0, 1+len(s)+2), s)
+}
+
+func EncodeArray(elements ...[]byte) []byte {
+	total := 0
+	for _, e := range elements {
+		total += len(e)
+	}
+	b := make([]byte, 0, 1+20+2+total)
+	b = append(b, Array)
+	b = strconv.AppendInt(b, int64(len(elements)), 10)
+	b = append(b, '\r', '\n')
+	for _, e := range elements {
+		b = append(b, e...)
+	}
+	return b
+}
+
+func EncodeNullBulk() []byte {
+	return []byte("$-1\r\n")
+}
+
+func EncodeNullArray() []byte {
+	return []byte("*-1\r\n")
+}

--- a/api/resp/encode_test.go
+++ b/api/resp/encode_test.go
@@ -1,0 +1,123 @@
+package resp
+
+import "testing"
+
+func TestEncodeBulkString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "$5\r\nhello\r\n"},
+		{"", "$0\r\n\r\n"},
+		{"a b c", "$5\r\na b c\r\n"},
+	}
+	for _, tt := range tests {
+		got := string(EncodeBulkString(tt.input))
+		if got != tt.want {
+			t.Errorf("EncodeBulkString(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestEncodeInteger(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, ":0\r\n"},
+		{42, ":42\r\n"},
+		{-1, ":-1\r\n"},
+	}
+	for _, tt := range tests {
+		got := string(EncodeInteger(tt.input))
+		if got != tt.want {
+			t.Errorf("EncodeInteger(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestEncodeSimpleString(t *testing.T) {
+	got := string(EncodeSimpleString("OK"))
+	if got != "+OK\r\n" {
+		t.Errorf("EncodeSimpleString(OK) = %q, want %q", got, "+OK\r\n")
+	}
+}
+
+func TestEncodeError(t *testing.T) {
+	got := string(EncodeError("ERR bad"))
+	if got != "-ERR bad\r\n" {
+		t.Errorf("EncodeError = %q, want %q", got, "-ERR bad\r\n")
+	}
+}
+
+func TestEncodeArray(t *testing.T) {
+	got := string(EncodeArray(
+		EncodeBulkString("message"),
+		EncodeBulkString("ch1"),
+		EncodeBulkString("hello"),
+	))
+	want := "*3\r\n$7\r\nmessage\r\n$3\r\nch1\r\n$5\r\nhello\r\n"
+	if got != want {
+		t.Errorf("EncodeArray = %q, want %q", got, want)
+	}
+}
+
+func TestAppendEquivalence(t *testing.T) {
+	s := "test"
+	alloc := EncodeBulkString(s)
+	appended := AppendBulkString(nil, s)
+	if string(alloc) != string(appended) {
+		t.Errorf("Append/Encode mismatch: %q vs %q", appended, alloc)
+	}
+
+	allocInt := EncodeInteger(99)
+	appendedInt := AppendInteger(nil, 99)
+	if string(allocInt) != string(appendedInt) {
+		t.Errorf("AppendInteger mismatch: %q vs %q", appendedInt, allocInt)
+	}
+}
+
+func TestEncodeNulls(t *testing.T) {
+	if got := string(EncodeNullBulk()); got != "$-1\r\n" {
+		t.Errorf("EncodeNullBulk = %q", got)
+	}
+	if got := string(EncodeNullArray()); got != "*-1\r\n" {
+		t.Errorf("EncodeNullArray = %q", got)
+	}
+}
+
+func BenchmarkEncodeBulkString(b *testing.B) {
+	b.Run("alloc", func(b *testing.B) {
+		for b.Loop() {
+			_ = EncodeBulkString("hello world")
+		}
+	})
+	b.Run("append", func(b *testing.B) {
+		buf := make([]byte, 0, 64)
+		for b.Loop() {
+			buf = AppendBulkString(buf[:0], "hello world")
+		}
+	})
+}
+
+func BenchmarkEncodeMessage(b *testing.B) {
+	b.Run("alloc", func(b *testing.B) {
+		for b.Loop() {
+			_ = EncodeArray(
+				EncodeBulkString("message"),
+				EncodeBulkString("mychannel"),
+				EncodeBulkString("hello world payload"),
+			)
+		}
+	})
+	b.Run("append", func(b *testing.B) {
+		buf := make([]byte, 0, 128)
+		for b.Loop() {
+			buf = buf[:0]
+			buf = AppendArrayHeader(buf, 3)
+			buf = AppendBulkString(buf, "message")
+			buf = AppendBulkString(buf, "mychannel")
+			buf = AppendBulkString(buf, "hello world payload")
+		}
+	})
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -239,6 +239,7 @@ func main() {
 		pluginManager = pluginmgr.NewManager(cfg.Plugins, srv.CoreCommandNames(), srv)
 		pluginManager.SetLogCollector(logCollector)
 		pluginManager.SetTracker(tracker)
+		pluginManager.SetClientPusher(srv.ConnRegistry())
 		pluginmgr.RegisterOperationHandlers(pluginManager.QueryRegistry(), tracker)
 		if err := pluginManager.Start(ctx); err != nil {
 			logger.FatalNoCtx().Err(err).Msg("failed to start plugin manager")

--- a/docs/adr/0020-client-push-via-gcpc.md
+++ b/docs/adr/0020-client-push-via-gcpc.md
@@ -1,0 +1,83 @@
+---
+title: ADR-0020 Client Push via GCPC
+description: Generic mechanism for IPC plugins to push RESP data to client connections
+status: accepted
+date: 2026-05-26
+deciders: [witherxse]
+related:
+  - 0006-builtin-vs-third-party-transport
+  - 0008-plugin-config-and-reload-contract
+---
+
+# ADR-0020: Client Push via GCPC
+
+## Context
+
+GCPC v1 is strictly request-response: the server sends a `CommandRequestV1`, the plugin replies with one `CommandResponseV1`. This works for commands where the server waits for a single answer (PUBLISH returning a subscriber count, QUERY returning data), but it cannot support push semantics where a plugin needs to send unsolicited data to specific client TCP connections.
+
+Redis Pub/Sub is the motivating case: when a client calls SUBSCRIBE, the plugin must push `["subscribe", channel, count]` confirmation messages. When another client PUBLISHes, the plugin must fan out `["message", channel, data]` to every subscribed connection. Neither fits the one-request-one-response model.
+
+This is not a Pub/Sub-specific problem. Any future plugin with push needs — WebSocket relay, streaming queries, replication — hits the same wall. The solution must be generic.
+
+Constraints:
+- `resp.Writer` is stack-scoped inside `handleConnection` (server.go:264) — not accessible outside that goroutine
+- Each connection's write path must be serialized — concurrent writes to the same TCP connection produce corrupt RESP output
+- The mechanism must work within GCPC v1 without breaking existing plugins
+
+## Decision
+
+We add three generic primitives to GCPC and the server:
+
+1. **`ClientPushV1` message** (plugin → server): carries a `connection_id` and raw RESP `bytes`. The Manager's `readLoop` receives it and writes the bytes to the identified connection.
+
+2. **`ConnectionRegistry`** (server component): maps connection IDs to `ConnHandle` objects. Each `ConnHandle` wraps a `resp.Writer` and a `sync.Mutex`. All writes to a connection — both normal command responses and plugin pushes — go through the handle's mutex, preventing interleaved output.
+
+3. **`suppress_response` flag on `CommandResponseV1`**: when a plugin sets this to `true`, the server skips writing the normal RESP response for that command. The plugin has already sent all necessary data via `ClientPushV1`. This handles commands like SUBSCRIBE that send multiple push messages instead of a single response.
+
+Connections are identified by `connOp.ID` (the connection operation ID), exposed to plugins as `_connection_id` in the context map.
+
+## Alternatives Considered
+
+### Alternative 1: Dedicated push socket per connection
+
+Each client connection gets a second Unix socket shared with interested plugins. Plugins write RESP directly to this socket; the server splices it into the client's TCP stream.
+
+- **Pros**: Zero-copy potential; no protobuf overhead for push data
+- **Cons**: One extra socket per connection × number of push-interested plugins; complex lifecycle management (who creates, who closes); splice is Linux-specific
+- **Why not**: The socket-per-connection overhead scales poorly and adds significant complexity for a problem that ClientPushV1 solves with a single message type.
+
+### Alternative 2: Poll-based approach (plugin stores, client fetches)
+
+Plugin buffers messages internally. Server polls the plugin periodically or the client sends a FETCH command to retrieve pending messages.
+
+- **Pros**: No new GCPC message types; no ConnectionRegistry
+- **Cons**: Adds latency proportional to poll interval; FETCH is not Redis-compatible; requires client-side changes; fundamentally changes the push model to pull
+- **Why not**: Incompatible with Redis Pub/Sub semantics where messages arrive as unsolicited pushes.
+
+### Alternative 3: Server-side message queue per connection
+
+Server maintains an internal queue per connection. Plugin posts messages to the queue via GCPC. Server drains the queue into the connection's writer.
+
+- **Pros**: Decouples push rate from connection write rate; natural backpressure
+- **Cons**: Unbounded memory growth if subscribers are slow; queue management complexity (max size, eviction policy, per-connection or global limits); adds latency vs direct write
+- **Why not**: Over-engineered for the common case. ClientPushV1 with direct write is simpler and matches Redis's behavior (slow subscribers get disconnected, not buffered). If backpressure becomes a problem, it can be added to the ConnectionRegistry later without protocol changes.
+
+## Consequences
+
+### Positive
+
+- Any IPC plugin can push data to any client connection — Pub/Sub, streaming, notifications
+- The server remains ignorant of specific plugin semantics — it just writes bytes where told
+- Per-connection mutex serialization is the same model Redis uses in multi-threaded I/O mode
+- `suppress_response` is additive (field 3 on CommandResponseV1) — existing plugins ignore it
+
+### Negative
+
+- Per-connection mutex adds a lock acquisition to every command response write, even for connections with no active push consumers
+- Raw RESP encoding responsibility shifts to the plugin (must format valid RESP bytes)
+- `ClientPushV1` is fire-and-forget — no acknowledgement if the connection is gone (plugin learns via `connection.close` events asynchronously)
+
+### Risks
+
+- **Risk**: Malicious or buggy plugin pushes corrupt RESP to a connection. **Mitigation**: The push data is raw bytes — the server trusts the plugin to send valid RESP. Scope checking (`write` scope required) limits which plugins can push. Future work could validate RESP framing in the push handler.
+- **Risk**: Per-connection mutex contention under high push + command rate. **Mitigation**: Contention is per-connection, not global. A connection receiving 10k pushes/sec while also processing 10k commands/sec is an extreme case; benchmarking will quantify the real impact.

--- a/docs/server/design/component/components_client_push.puml
+++ b/docs/server/design/component/components_client_push.puml
@@ -1,0 +1,49 @@
+@startuml components_client_push
+!include ../../../design/theme.iuml
+
+mainframe **component** Client Push Architecture
+
+package "Server Process" {
+    component "handleConnection\n(per-goroutine)" as HC
+    component "ConnectionRegistry" as CR
+    component "ConnHandle\n(mutex + resp.Writer)" as CH
+    component "Manager.readLoop" as MRL
+
+    HC --> CR : Register(connID, writer)
+    CR --> CH : creates per-connection
+    HC --> CH : WriteValue / Flush\n(normal command responses)
+    MRL --> CH : Push(connID, data)\n(plugin-initiated)
+}
+
+package "Plugin Process (IPC)" {
+    component "PubSub Plugin" as PS
+    component "Session.PushToClient" as SPC
+    component "SubscriptionManager" as SM
+
+    PS --> SM : Subscribe/Publish
+    PS --> SPC : PushToClient(connID, respBytes)
+}
+
+cloud "GCPC (Unix Socket)" as GCPC
+
+SPC --> GCPC : ClientPushV1{connID, data}
+GCPC --> MRL : ClientPushV1
+
+note bottom of CH
+  ConnHandle serializes concurrent access:
+  - Normal writes from handleConnection goroutine
+  - Push writes from Manager.readLoop goroutine
+  Both acquire the per-connection mutex before writing.
+end note
+
+note bottom of CR
+  Registry lifecycle:
+  1. Register() after resp.NewWriter() in handleConnection
+  2. Unregister() in deferred cleanup before conn.Close()
+  Push() after Unregister returns ErrConnNotFound
+end note
+
+actor "Client" as C
+CH --> C : TCP write\n(mutex-serialized)
+
+@enduml

--- a/docs/server/design/sequence/sequence_pubsub.puml
+++ b/docs/server/design/sequence/sequence_pubsub.puml
@@ -1,0 +1,70 @@
+@startuml sequence_pubsub
+!include ../../../design/theme.iuml
+
+mainframe **sd** Pub/Sub Message Flow (IPC Plugin)
+
+actor "Client A\n(subscriber)" as SubClient
+actor "Client B\n(publisher)" as PubClient
+participant "Server\n(handleConnection)" as Server
+participant "ConnHandle\n(per-connection mutex)" as ConnHandle
+participant "Pipeline\n(routeToPlugin)" as Pipeline
+participant "Plugin Router" as Router
+participant "Manager\n(readLoop)" as Manager
+participant "PubSub Plugin\n(IPC process)" as Plugin
+participant "SubscriptionManager\n(in-plugin)" as SubMgr
+
+== SUBSCRIBE ==
+
+SubClient -> Server : SUBSCRIBE mychannel
+Server -> Pipeline : Evaluate("SUBSCRIBE", ["mychannel"])
+Pipeline -> Router : Route(ctx, "SUBSCRIBE", ...)
+Router -> Plugin : GCPC CommandRequestV1
+Plugin -> SubMgr : Subscribe(connID, "mychannel")
+Plugin -> Plugin : encode ["subscribe", "mychannel", 1]
+Plugin -> Manager : ClientPushV1(connID, respBytes)
+Manager -> ConnHandle : Push(connID, data)
+ConnHandle -> SubClient : raw RESP push
+Plugin -> Router : CommandResponseV1(suppress=true)
+Router -> Pipeline : (nil, true, nil)
+note right: SuppressResponse=true\nskips normal write
+
+== PUBLISH ==
+
+PubClient -> Server : PUBLISH mychannel "hello"
+Server -> Pipeline : Evaluate("PUBLISH", ["mychannel", "hello"])
+Pipeline -> Router : Route(ctx, "PUBLISH", ...)
+Router -> Plugin : GCPC CommandRequestV1
+Plugin -> SubMgr : Publish("mychannel")
+SubMgr --> Plugin : [{connID: A}]
+Plugin -> Plugin : encode ["message", "mychannel", "hello"]
+Plugin -> Manager : ClientPushV1(connA, respBytes)
+Manager -> ConnHandle : Push(connA, data)
+ConnHandle -> SubClient : *3\r\n$7\r\nmessage\r\n...
+Plugin -> Router : CommandResponseV1(result=1, suppress=false)
+Router -> Pipeline : (1, false, nil)
+Pipeline -> Server : Result{Value: "1"}
+Server -> PubClient : :1\r\n
+
+== UNSUBSCRIBE ==
+
+SubClient -> Server : UNSUBSCRIBE mychannel
+Server -> Pipeline : Evaluate("UNSUBSCRIBE", ["mychannel"])
+Pipeline -> Router : Route(ctx, "UNSUBSCRIBE", ...)
+Router -> Plugin : GCPC CommandRequestV1
+Plugin -> SubMgr : Unsubscribe(connID, "mychannel")
+Plugin -> Plugin : encode ["unsubscribe", "mychannel", 0]
+Plugin -> Manager : ClientPushV1(connID, respBytes)
+Manager -> ConnHandle : Push(connID, data)
+ConnHandle -> SubClient : raw RESP push
+Plugin -> Router : CommandResponseV1(suppress=true)
+
+== Connection Close (cleanup) ==
+
+SubClient ->x Server : TCP disconnect
+Server -> Server : connRegistry.Unregister(connID)
+Server -> Server : emit connection.close event
+Server -> Manager : EventV1{type: "connection.close"}
+Manager -> Plugin : forward EventV1
+Plugin -> SubMgr : RemoveConnection(connID)
+
+@enduml

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -277,6 +277,9 @@ func (b *Pipeline) evaluateCore(parentCtx context.Context, ctx *clientctx.Client
 	cmdOp.Enrich(apicommand.OperationID, cmdOp.ID)
 	cmdOp.Enrich(apicommand.CommandKey, op)
 	cmdOp.Enrich(apicommand.ArgCountKey, strconv.Itoa(len(args)))
+	if hasSpec && spec.ReadOnly {
+		cmdOp.Enrich(apicommand.ReadOnlyKey, "true")
+	}
 
 	// Inject REX metadata into operation context.
 	if ctx.RexMeta != nil || len(ctx.CmdMeta) > 0 {
@@ -434,10 +437,19 @@ func (b *Pipeline) routeToPlugin(parentCtx context.Context, client *clientctx.Cl
 	ctx, cancel := context.WithTimeout(parentCtx, pluginCommandTimeout)
 	defer cancel()
 
-	val, err := b.pluginRouter.Route(ctx, op, args, metadata)
+	if b.hasAnySink() {
+		cmdOp := b.tracker.Start(ops.TypeCommand, client.OperationID)
+		cmdOp.Enrich(apicommand.CommandKey, op)
+		cmdOp.Enrich(apicommand.ArgCountKey, strconv.Itoa(len(args)))
+		if meta := b.pluginRouter.LookupMeta(op); meta != nil && meta.ReadOnly {
+			cmdOp.Enrich(apicommand.ReadOnlyKey, "true")
+		}
+		ctx = ops.WithContext(ctx, cmdOp)
+		defer func() { cmdOp.Complete(); b.tracker.Complete(cmdOp.ID) }()
+	}
+
+	val, suppress, err := b.pluginRouter.Route(ctx, op, args, metadata)
 	if err != nil {
-		// Known sentinels produce stable wire messages; the mapToResp pipeline
-		// formats the default "ERR <msg>" for anything else via Result.Err.
 		if errors.Is(err, router.ErrPluginTimeout) {
 			return apicommand.Result{Value: resp.MarshalError("ERR plugin timeout")}
 		}
@@ -449,7 +461,7 @@ func (b *Pipeline) routeToPlugin(parentCtx context.Context, client *clientctx.Cl
 	if e, ok := val.(error); ok {
 		return apicommand.Result{Err: e}
 	}
-	return apicommand.Result{Value: val}
+	return apicommand.Result{Value: val, SuppressResponse: suppress}
 }
 
 func resultToHookStrings(r apicommand.Result) (string, string) {

--- a/pkg/plugin/manager/manager.go
+++ b/pkg/plugin/manager/manager.go
@@ -39,6 +39,11 @@ type LogCollector interface {
 	AddSource(name string, r io.Reader)
 }
 
+// ClientPusher pushes raw RESP data to a specific client connection.
+type ClientPusher interface {
+	Push(connectionID string, data []byte) error
+}
+
 // Manager handles plugin lifecycle: discovery, fork/exec, registration,
 // health monitoring, restart, and graceful shutdown.
 //
@@ -58,6 +63,7 @@ type Manager struct {
 	eventBus       *serverEvents.Bus
 	logCollector   LogCollector
 	tracker        *serverOps.Tracker
+	clientPusher   ClientPusher
 
 	// cancel terminates the lifecycle context derived inside Start.
 	// nil before Start; reset to nil by Shutdown.
@@ -125,6 +131,12 @@ func (m *Manager) SetLogCollector(lc LogCollector) {
 // goroutines fall back to NoCtx logging just as before.
 func (m *Manager) SetTracker(t *serverOps.Tracker) {
 	m.tracker = t
+}
+
+// SetClientPusher wires the connection push interface so plugins can send
+// unsolicited data to client connections (e.g. Pub/Sub messages).
+func (m *Manager) SetClientPusher(p ClientPusher) {
+	m.clientPusher = p
 }
 
 // startPluginLifecycleOp creates the lifecycle operation for a plugin instance
@@ -689,6 +701,19 @@ func (m *Manager) readLoop(ctx context.Context, inst *PluginInstance) {
 				errMsg = qErr.Error()
 			}
 			_ = conn.Send(gcpcv1.NewServerQueryResponse(query.RequestId, data, errMsg))
+		case *gcpcv1.EnvelopeV1_ClientPush:
+			push := env.GetClientPush()
+			if m.clientPusher == nil {
+				logger.Warn(loopCtx).Str("plugin", inst.Name).Msg("client push received but no pusher configured")
+				continue
+			}
+			if !m.scopeRegistry.HasScope(inst.Name, scope.ScopeWrite) {
+				logger.Warn(loopCtx).Str("plugin", inst.Name).Msg("client push denied: missing 'write' scope")
+				continue
+			}
+			if err := m.clientPusher.Push(push.ConnectionId, push.Data); err != nil {
+				logger.Debug(loopCtx).Str("plugin", inst.Name).Err(err).Msg("client push failed")
+			}
 		default:
 			logger.Debug(loopCtx).Str("plugin", inst.Name).Msg("unexpected message from plugin")
 		}

--- a/pkg/plugin/router/router.go
+++ b/pkg/plugin/router/router.go
@@ -42,6 +42,12 @@ type PluginRoute struct {
 	ReadOnly   bool
 }
 
+// RouteMeta is a lightweight snapshot of a registered command's metadata,
+// returned by LookupMeta for callers that need classification without routing.
+type RouteMeta struct {
+	ReadOnly bool
+}
+
 // PluginConn wraps a transport.Conn with request/response multiplexing.
 // Multiple goroutines can send requests concurrently; responses are
 // correlated by request_id. Used by both the command router and hook executor.
@@ -304,22 +310,35 @@ func (r *Router) HasCommand(op string) bool {
 	return found
 }
 
+// LookupMeta returns classification metadata for a registered plugin command
+// without acquiring the full route connection. Returns nil if the command is
+// not registered.
+func (r *Router) LookupMeta(op string) *RouteMeta {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	route, _, found := r.lookup(op)
+	if !found {
+		return nil
+	}
+	return &RouteMeta{ReadOnly: route.ReadOnly}
+}
+
 // Route dispatches a command to the owning plugin and waits for the response.
 // Returns the result as an any compatible with evaluator.Result.Value.
 // metadata carries REX metadata with bare keys (no shared.rex. prefix).
-func (r *Router) Route(ctx context.Context, op string, args []string, metadata map[string]string) (any, error) {
+func (r *Router) Route(ctx context.Context, op string, args []string, metadata map[string]string) (any, bool, error) {
 	r.mu.RLock()
 	route, pc, found := r.lookup(op)
 	r.mu.RUnlock()
 
 	if !found {
-		return nil, ErrCommandNotFound
+		return nil, false, ErrCommandNotFound
 	}
 
 	// Arg count validation.
 	n := len(args)
 	if n < route.MinArgs || (route.MaxArgs >= 0 && n > route.MaxArgs) {
-		return nil, fmt.Errorf("ERR wrong number of arguments for '%s' command", strings.ToLower(op))
+		return nil, false, fmt.Errorf("ERR wrong number of arguments for '%s' command", strings.ToLower(op))
 	}
 
 	requestID := NextRequestID()
@@ -332,24 +351,24 @@ func (r *Router) Route(ctx context.Context, op string, args []string, metadata m
 	respCh, err := pc.Send(ctx, env, requestID)
 	if err != nil {
 		if ctx.Err() != nil {
-			return nil, ErrPluginTimeout
+			return nil, false, ErrPluginTimeout
 		}
-		return nil, fmt.Errorf("%w: %s", ErrPluginDown, err.Error())
+		return nil, false, fmt.Errorf("%w: %s", ErrPluginDown, err.Error())
 	}
 
 	select {
 	case resp, ok := <-respCh:
 		if !ok {
-			return nil, ErrPluginDown
+			return nil, false, ErrPluginDown
 		}
 		cmdResp := resp.GetCommandResponse()
 		if cmdResp == nil {
-			return nil, ErrPluginDown
+			return nil, false, ErrPluginDown
 		}
-		return gcpc.InterfaceFromResult(cmdResp.Result), nil
+		return gcpc.InterfaceFromResult(cmdResp.Result), cmdResp.SuppressResponse, nil
 	case <-ctx.Done():
 		pc.pending.Delete(requestID)
-		return nil, ErrPluginTimeout
+		return nil, false, ErrPluginTimeout
 	}
 }
 

--- a/pkg/plugin/router/router_test.go
+++ b/pkg/plugin/router/router_test.go
@@ -205,7 +205,7 @@ func TestRouteSuccess(t *testing.T) {
 		}
 		// Send response.
 		result := &gcpc.ResultV1{Value: &gcpc.ResultV1_BulkString{BulkString: "hello"}}
-		resp := gcpc.NewCommandResponse(req.RequestId, result)
+		resp := gcpc.NewCommandResponse(req.RequestId, result, false)
 		if err := clientConn.Send(resp); err != nil {
 			t.Errorf("plugin send: %v", err)
 		}
@@ -214,7 +214,7 @@ func TestRouteSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	val, err := r.Route(ctx, "ECHO", []string{"hello"}, nil)
+	val, _, err := r.Route(ctx, "ECHO", []string{"hello"}, nil)
 	if err != nil {
 		t.Fatalf("Route error: %v", err)
 	}
@@ -240,13 +240,13 @@ func TestRouteArgValidation(t *testing.T) {
 	ctx := context.Background()
 
 	// Too few args.
-	_, err := r.Route(ctx, "EXACT", []string{"one"}, nil)
+	_, _, err := r.Route(ctx, "EXACT", []string{"one"}, nil)
 	if err == nil {
 		t.Error("expected arg validation error for too few args")
 	}
 
 	// Too many args.
-	_, err = r.Route(ctx, "EXACT", []string{"one", "two", "three"}, nil)
+	_, _, err = r.Route(ctx, "EXACT", []string{"one", "two", "three"}, nil)
 	if err == nil {
 		t.Error("expected arg validation error for too many args")
 	}
@@ -267,7 +267,7 @@ func TestRouteTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	_, err := r.Route(ctx, "SLOW", nil, nil)
+	_, _, err := r.Route(ctx, "SLOW", nil, nil)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -298,7 +298,7 @@ func TestRouteConcurrent(t *testing.T) {
 				continue
 			}
 			result := &gcpc.ResultV1{Value: &gcpc.ResultV1_BulkString{BulkString: req.RequestId}}
-			_ = clientConn.Send(gcpc.NewCommandResponse(req.RequestId, result))
+			_ = clientConn.Send(gcpc.NewCommandResponse(req.RequestId, result, false))
 		}
 	}()
 
@@ -312,7 +312,7 @@ func TestRouteConcurrent(t *testing.T) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			_, err := r.Route(ctx, "PING", nil, nil)
+			_, _, err := r.Route(ctx, "PING", nil, nil)
 			if err != nil {
 				errs <- err
 			}
@@ -368,7 +368,7 @@ func TestRouteMetadataForwarded(t *testing.T) {
 			}
 		}
 		result := &gcpc.ResultV1{Value: &gcpc.ResultV1_BulkString{BulkString: "hello"}}
-		resp := gcpc.NewCommandResponse(req.RequestId, result)
+		resp := gcpc.NewCommandResponse(req.RequestId, result, false)
 		_ = clientConn.Send(resp)
 	}()
 
@@ -379,7 +379,7 @@ func TestRouteMetadataForwarded(t *testing.T) {
 		"traceparent": "00-abc-def-01",
 		"tenant":      "acme",
 	}
-	val, err := r.Route(ctx, "ECHO", []string{"hello"}, metadata)
+	val, _, err := r.Route(ctx, "ECHO", []string{"hello"}, metadata)
 	if err != nil {
 		t.Fatalf("Route error: %v", err)
 	}
@@ -418,13 +418,13 @@ func TestRouteNilMetadata(t *testing.T) {
 			t.Errorf("expected empty metadata, got %v", req.Metadata)
 		}
 		result := &gcpc.ResultV1{Value: &gcpc.ResultV1_BulkString{BulkString: "hello"}}
-		_ = clientConn.Send(gcpc.NewCommandResponse(req.RequestId, result))
+		_ = clientConn.Send(gcpc.NewCommandResponse(req.RequestId, result, false))
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, err := r.Route(ctx, "ECHO", []string{"hello"}, nil)
+	_, _, err := r.Route(ctx, "ECHO", []string{"hello"}, nil)
 	if err != nil {
 		t.Fatalf("Route error: %v", err)
 	}

--- a/pkg/resp/resp.go
+++ b/pkg/resp/resp.go
@@ -346,6 +346,11 @@ func (w *Writer) Flush() error {
 	return w.writer.Flush()
 }
 
+func (w *Writer) WriteRaw(data []byte) error {
+	_, err := w.writer.Write(data)
+	return err
+}
+
 func (w *Writer) Write(v Value) error {
 	bufp := getScratch()
 	// Reset + release after every exit path. The buffer is fully consumed by

--- a/pkg/server/connregistry.go
+++ b/pkg/server/connregistry.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"errors"
+	"sync"
+
+	"gocache/pkg/resp"
+)
+
+var ErrConnNotFound = errors.New("connection not found")
+
+type ConnHandle struct {
+	mu     sync.Mutex
+	writer *resp.Writer
+	closed bool
+}
+
+func (h *ConnHandle) WriteValue(v resp.Value) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return ErrConnNotFound
+	}
+	return h.writer.Write(v)
+}
+
+func (h *ConnHandle) WriteRaw(data []byte) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return ErrConnNotFound
+	}
+	return h.writer.WriteRaw(data)
+}
+
+func (h *ConnHandle) Flush() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return ErrConnNotFound
+	}
+	return h.writer.Flush()
+}
+
+type ConnectionRegistry struct {
+	mu    sync.RWMutex
+	conns map[string]*ConnHandle
+}
+
+func NewConnectionRegistry() *ConnectionRegistry {
+	return &ConnectionRegistry{
+		conns: make(map[string]*ConnHandle),
+	}
+}
+
+func (r *ConnectionRegistry) Register(id string, w *resp.Writer) *ConnHandle {
+	h := &ConnHandle{writer: w}
+	r.mu.Lock()
+	r.conns[id] = h
+	r.mu.Unlock()
+	return h
+}
+
+func (r *ConnectionRegistry) Unregister(id string) {
+	r.mu.Lock()
+	if h, ok := r.conns[id]; ok {
+		h.mu.Lock()
+		h.closed = true
+		h.mu.Unlock()
+		delete(r.conns, id)
+	}
+	r.mu.Unlock()
+}
+
+func (r *ConnectionRegistry) Push(connectionID string, data []byte) error {
+	r.mu.RLock()
+	h, ok := r.conns[connectionID]
+	r.mu.RUnlock()
+	if !ok {
+		return ErrConnNotFound
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return ErrConnNotFound
+	}
+	if err := h.writer.WriteRaw(data); err != nil {
+		return err
+	}
+	return h.writer.Flush()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,6 +65,7 @@ type Server struct {
 	emitter          events.Emitter
 	tracker          *serverOps.Tracker
 	opHookExecutor   pipeline.OpHookExecutor
+	connRegistry     *ConnectionRegistry
 }
 
 func New(addr string, c *cache.Cache, e *engine.Engine, requirePass string, br *blocking.Registry, wm *watch.Manager) *Server {
@@ -83,7 +84,13 @@ func New(addr string, c *cache.Cache, e *engine.Engine, requirePass string, br *
 		startTime:        time.Now(),
 		emitter:          events.NoopEmitter{},
 		tracker:          tracker,
+		connRegistry:     NewConnectionRegistry(),
 	}
+}
+
+// ConnRegistry returns the connection registry for plugin push access.
+func (srv *Server) ConnRegistry() *ConnectionRegistry {
+	return srv.connRegistry
 }
 
 // CoreCommandNames returns the list of core command names for plugin shadow checking.
@@ -237,6 +244,7 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 	// Create connection operation and derive a connection-scoped ctx.
 	connOp := srv.tracker.Start(ops.TypeConnection, "")
 	connOp.Enrich(apicommand.RemoteAddrKey, remoteAddr)
+	connOp.Enrich(apicommand.ConnectionIDKey, connOp.ID)
 	connCtx := ops.WithContext(serverCtx, connOp)
 	if srv.opHookExecutor != nil {
 		srv.opHookExecutor.RunStartHooks(connCtx, connOp)
@@ -247,6 +255,7 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 	ctx.OperationID = connOp.ID
 
 	defer func() {
+		srv.connRegistry.Unregister(connOp.ID)
 		if srv.watchManager != nil {
 			srv.watchManager.Unwatch(ctx)
 		}
@@ -262,8 +271,9 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 
 	reader := resp.NewReader(conn)
 	writer := resp.NewWriter(conn)
+	connHandle := srv.connRegistry.Register(connOp.ID, writer)
 	defer func() {
-		if err := writer.Flush(); err != nil {
+		if err := connHandle.Flush(); err != nil {
 			logger.Debug(connCtx).Err(err).Msg("final flush on connection close")
 		}
 	}()
@@ -275,7 +285,7 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 
 	for {
 		if srv.isShuttingDown.Load() {
-			if err := writer.Write(resp.MarshalError("ERR Server is shutting down")); err != nil {
+			if err := connHandle.WriteValue(resp.MarshalError("ERR Server is shutting down")); err != nil {
 				logger.Debug(connCtx).Err(err).Msg("write shutdown notice failed")
 			}
 			return
@@ -298,11 +308,11 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 			}
 
 			if val.Type != resp.Array {
-				if err := writer.Write(resp.MarshalError("ERR Protocol error: expected array")); err != nil {
+				if err := connHandle.WriteValue(resp.MarshalError("ERR Protocol error: expected array")); err != nil {
 					return
 				}
 				if reader.Buffered() == 0 {
-					if err := writer.Flush(); err != nil {
+					if err := connHandle.Flush(); err != nil {
 						return
 					}
 				}
@@ -327,11 +337,11 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 		if ctx.RexVersion > 0 && op == resp.CmdMeta {
 			key, value, err := rex.ParseMeta(args)
 			if err != nil {
-				if writeErr := writer.Write(resp.MarshalError("ERR " + err.Error())); writeErr != nil {
+				if writeErr := connHandle.WriteValue(resp.MarshalError("ERR " + err.Error())); writeErr != nil {
 					return
 				}
 				if reader.Buffered() == 0 {
-					if flushErr := writer.Flush(); flushErr != nil {
+					if flushErr := connHandle.Flush(); flushErr != nil {
 						return
 					}
 				}
@@ -342,11 +352,11 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 				cmdMeta = make(map[string]string)
 			}
 			cmdMeta[key] = value
-			if writeErr := writer.Write(resp.OK()); writeErr != nil {
+			if writeErr := connHandle.WriteValue(resp.OK()); writeErr != nil {
 				return
 			}
 			if reader.Buffered() == 0 {
-				if flushErr := writer.Flush(); flushErr != nil {
+				if flushErr := connHandle.Flush(); flushErr != nil {
 					return
 				}
 			}
@@ -354,7 +364,7 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 		}
 
 		if op == "QUIT" {
-			if err := writer.Write(resp.OK()); err != nil {
+			if err := connHandle.WriteValue(resp.OK()); err != nil {
 				logger.Debug(connCtx).Err(err).Msg("write QUIT ack failed")
 			}
 			return
@@ -364,11 +374,11 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 		if srv.requirePass != "" && !ctx.Authenticated {
 			if op != "AUTH" && op != "HELLO" {
 				srv.emitter.Emit(events.NewAuthFailed(remoteAddr, op).WithOperationID(ctx.OperationID))
-				if err := writer.Write(resp.MarshalError("NOAUTH Authentication required.")); err != nil {
+				if err := connHandle.WriteValue(resp.MarshalError("NOAUTH Authentication required.")); err != nil {
 					return
 				}
 				if reader.Buffered() == 0 {
-					if err := writer.Flush(); err != nil {
+					if err := connHandle.Flush(); err != nil {
 						return
 					}
 				}
@@ -378,20 +388,22 @@ func (srv *Server) handleConnection(serverCtx context.Context, conn net.Conn) {
 		}
 
 		if reader.Buffered() > 0 && srv.canBatch(ctx, op, args) {
-			pending = srv.runBatch(connCtx, ctx, reader, writer, op, args, cmdMeta)
+			pending = srv.runBatch(connCtx, ctx, reader, connHandle, op, args, cmdMeta)
 			cmdMeta = nil
 		} else {
 			ctx.CmdMeta = cmdMeta
 			res := srv.pipeline.Evaluate(connCtx, ctx, op, args)
 			ctx.CmdMeta = nil
 			cmdMeta = nil
-			if err := writer.Write(srv.mapToResp(ctx, res)); err != nil {
-				return
+			if !res.SuppressResponse {
+				if err := connHandle.WriteValue(srv.mapToResp(ctx, res)); err != nil {
+					return
+				}
 			}
 		}
 
 		if reader.Buffered() == 0 && pending == nil {
-			if err := writer.Flush(); err != nil {
+			if err := connHandle.Flush(); err != nil {
 				return
 			}
 		}
@@ -421,7 +433,7 @@ func (srv *Server) runBatch(
 	connCtx context.Context,
 	ctx *clientctx.ClientContext,
 	reader *resp.Reader,
-	writer *resp.Writer,
+	handle *ConnHandle,
 	firstOp string,
 	firstArgs []string,
 	cmdMeta map[string]string,
@@ -443,7 +455,7 @@ func (srv *Server) runBatch(
 			break
 		}
 		if val.Type != resp.Array || len(val.Array) == 0 {
-			_ = writer.Write(resp.MarshalError("ERR Protocol error: expected array"))
+			_ = handle.WriteValue(resp.MarshalError("ERR Protocol error: expected array"))
 			continue
 		}
 		parts := make([]string, len(val.Array))
@@ -505,7 +517,9 @@ func (srv *Server) runBatch(
 	}
 
 	for _, r := range results {
-		_ = writer.Write(srv.mapToResp(ctx, r))
+		if !r.SuppressResponse {
+			_ = handle.WriteValue(srv.mapToResp(ctx, r))
+		}
 	}
 
 	return overflow

--- a/plugins/dummy/main.go
+++ b/plugins/dummy/main.go
@@ -10,12 +10,17 @@ import (
 	"gocache/sdk/pluginsdk"
 )
 
+const (
+	pluginName    = "dummy"
+	pluginVersion = "0.1.0"
+)
+
 type dummyPlugin struct {
 	log *apilogger.Logger
 }
 
-func (d *dummyPlugin) Name() string    { return "dummy" }
-func (d *dummyPlugin) Version() string { return "0.1.0" }
+func (d *dummyPlugin) Name() string    { return pluginName }
+func (d *dummyPlugin) Version() string { return pluginVersion }
 func (d *dummyPlugin) Critical() bool  { return false }
 
 func (d *dummyPlugin) OnHealthCheck(_ context.Context) error {

--- a/plugins/pubsub/main.go
+++ b/plugins/pubsub/main.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"gocache/api/command"
+	"gocache/api/events"
+	gcpc "gocache/api/gcpc/v1"
+	apiResp "gocache/api/resp"
+	"gocache/sdk/pluginsdk"
+)
+
+const (
+	pluginName    = "pubsub"
+	pluginVersion = "0.1.0"
+)
+
+// Compile-time interface checks.
+var (
+	_ pluginsdk.CommandPlugin = (*PubSub)(nil)
+	_ pluginsdk.HookPlugin   = (*PubSub)(nil)
+	_ pluginsdk.EventPlugin  = (*PubSub)(nil)
+	_ pluginsdk.ScopePlugin  = (*PubSub)(nil)
+	_ pluginsdk.QueryPlugin  = (*PubSub)(nil)
+)
+
+type PubSub struct {
+	manager *SubscriptionManager
+	session *pluginsdk.Session
+}
+
+func (p *PubSub) SetSession(s *pluginsdk.Session) {
+	p.session = s
+}
+
+func (p *PubSub) Name() string    { return pluginName }
+func (p *PubSub) Version() string { return pluginVersion }
+func (p *PubSub) Critical() bool  { return false }
+
+func (p *PubSub) OnHealthCheck(context.Context) error { return nil }
+func (p *PubSub) OnShutdown(context.Context) error    { return nil }
+
+func (p *PubSub) Commands() []pluginsdk.CommandDecl {
+	return []pluginsdk.CommandDecl{
+		{Name: "SUBSCRIBE", MinArgs: 1, MaxArgs: -1, ReadOnly: true, KeyArgIndex: -1},
+		{Name: "UNSUBSCRIBE", MinArgs: 0, MaxArgs: -1, ReadOnly: true, KeyArgIndex: -1},
+		{Name: "PSUBSCRIBE", MinArgs: 1, MaxArgs: -1, ReadOnly: true, KeyArgIndex: -1},
+		{Name: "PUNSUBSCRIBE", MinArgs: 0, MaxArgs: -1, ReadOnly: true, KeyArgIndex: -1},
+		{Name: "PUBLISH", MinArgs: 2, MaxArgs: 2, ReadOnly: true, KeyArgIndex: -1},
+	}
+}
+
+func (p *PubSub) HandleCommand(ctx context.Context, cmd string, args []string, _ map[string]string) *pluginsdk.CommandResult {
+	connID := pluginsdk.ConnectionID(ctx)
+	if connID == "" {
+		return &pluginsdk.CommandResult{Value: fmt.Errorf("ERR no connection context")}
+	}
+
+	switch cmd {
+	case "SUBSCRIBE":
+		return p.handleSubscribe(connID, args)
+	case "UNSUBSCRIBE":
+		return p.handleUnsubscribe(connID, args)
+	case "PSUBSCRIBE":
+		return p.handlePSubscribe(connID, args)
+	case "PUNSUBSCRIBE":
+		return p.handlePUnsubscribe(connID, args)
+	case "PUBLISH":
+		return p.handlePublish(connID, args[0], args[1])
+	default:
+		return &pluginsdk.CommandResult{Value: fmt.Errorf("ERR unknown command '%s'", cmd)}
+	}
+}
+
+func (p *PubSub) handleSubscribe(connID string, channels []string) *pluginsdk.CommandResult {
+	for _, ch := range channels {
+		p.manager.Subscribe(connID, ch)
+		count := p.manager.SubscriptionCount(connID)
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("subscribe"),
+			apiResp.EncodeBulkString(ch),
+			apiResp.EncodeInteger(int64(count)),
+		)
+		_ = p.session.PushToClient(connID, msg)
+	}
+	return &pluginsdk.CommandResult{SuppressResponse: true}
+}
+
+func (p *PubSub) handleUnsubscribe(connID string, channels []string) *pluginsdk.CommandResult {
+	if len(channels) == 0 {
+		channels = p.manager.Channels(connID)
+	}
+	if len(channels) == 0 {
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("unsubscribe"),
+			apiResp.EncodeNullBulk(),
+			apiResp.EncodeInteger(0),
+		)
+		_ = p.session.PushToClient(connID, msg)
+		return &pluginsdk.CommandResult{SuppressResponse: true}
+	}
+	for _, ch := range channels {
+		p.manager.Unsubscribe(connID, ch)
+		count := p.manager.SubscriptionCount(connID)
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("unsubscribe"),
+			apiResp.EncodeBulkString(ch),
+			apiResp.EncodeInteger(int64(count)),
+		)
+		_ = p.session.PushToClient(connID, msg)
+	}
+	return &pluginsdk.CommandResult{SuppressResponse: true}
+}
+
+func (p *PubSub) handlePSubscribe(connID string, patterns []string) *pluginsdk.CommandResult {
+	for _, pat := range patterns {
+		p.manager.PSubscribe(connID, pat)
+		count := p.manager.SubscriptionCount(connID)
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("psubscribe"),
+			apiResp.EncodeBulkString(pat),
+			apiResp.EncodeInteger(int64(count)),
+		)
+		_ = p.session.PushToClient(connID, msg)
+	}
+	return &pluginsdk.CommandResult{SuppressResponse: true}
+}
+
+func (p *PubSub) handlePUnsubscribe(connID string, patterns []string) *pluginsdk.CommandResult {
+	if len(patterns) == 0 {
+		patterns = p.manager.Patterns(connID)
+	}
+	if len(patterns) == 0 {
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("punsubscribe"),
+			apiResp.EncodeNullBulk(),
+			apiResp.EncodeInteger(0),
+		)
+		_ = p.session.PushToClient(connID, msg)
+		return &pluginsdk.CommandResult{SuppressResponse: true}
+	}
+	for _, pat := range patterns {
+		p.manager.PUnsubscribe(connID, pat)
+		count := p.manager.SubscriptionCount(connID)
+		msg := apiResp.EncodeArray(
+			apiResp.EncodeBulkString("punsubscribe"),
+			apiResp.EncodeBulkString(pat),
+			apiResp.EncodeInteger(int64(count)),
+		)
+		_ = p.session.PushToClient(connID, msg)
+	}
+	return &pluginsdk.CommandResult{SuppressResponse: true}
+}
+
+func (p *PubSub) handlePublish(connID, channel, message string) *pluginsdk.CommandResult {
+	matches := p.manager.Publish(channel)
+
+	// Pre-encode the channel message once for exact-match subscribers.
+	// Pattern matches need per-pattern encoding so those are built inline.
+	var channelMsg []byte
+	hasChannel := false
+	for _, m := range matches {
+		if m.Pattern == "" {
+			hasChannel = true
+			break
+		}
+	}
+	if hasChannel {
+		b := make([]byte, 0, 64+len(channel)+len(message))
+		b = apiResp.AppendArrayHeader(b, 3)
+		b = apiResp.AppendBulkString(b, "message")
+		b = apiResp.AppendBulkString(b, channel)
+		b = apiResp.AppendBulkString(b, message)
+		channelMsg = b
+	}
+
+	for _, m := range matches {
+		if m.Pattern == "" {
+			_ = p.session.PushToClient(m.ConnID, channelMsg)
+		} else {
+			b := make([]byte, 0, 64+len(m.Pattern)+len(channel)+len(message))
+			b = apiResp.AppendArrayHeader(b, 4)
+			b = apiResp.AppendBulkString(b, "pmessage")
+			b = apiResp.AppendBulkString(b, m.Pattern)
+			b = apiResp.AppendBulkString(b, channel)
+			b = apiResp.AppendBulkString(b, message)
+			_ = p.session.PushToClient(m.ConnID, b)
+		}
+	}
+
+	return &pluginsdk.CommandResult{Value: strconv.Itoa(len(matches))}
+}
+
+// Hooks returns the hook declarations for subscription mode enforcement.
+func (p *PubSub) Hooks() []pluginsdk.HookDecl {
+	return []pluginsdk.HookDecl{
+		{Pattern: "*", Phase: pluginsdk.HookPhasePre},
+	}
+}
+
+// HandleHook enforces subscription mode: when a connection has active
+// subscriptions, only subscription-related commands are allowed.
+func (p *PubSub) HandleHook(ctx context.Context, req *pluginsdk.HookRequest) *pluginsdk.HookResponse {
+	if req.Phase != pluginsdk.HookPhasePre {
+		return nil
+	}
+	connID := req.Context[command.ConnectionIDKey]
+	if connID == "" || !p.manager.IsSubscribed(connID) {
+		return nil
+	}
+	switch req.Command {
+	case "SUBSCRIBE", "UNSUBSCRIBE", "PSUBSCRIBE", "PUNSUBSCRIBE", "PING", "RESET", "QUIT":
+		return nil
+	default:
+		return &pluginsdk.HookResponse{
+			Deny:       true,
+			DenyReason: "ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT / RESET are allowed in subscribed state",
+		}
+	}
+}
+
+// EventTypes returns the event types this plugin subscribes to.
+func (p *PubSub) EventTypes() []string {
+	return []string{string(events.ConnectionClose)}
+}
+
+// HandleEvent cleans up subscriptions when a connection disconnects.
+func (p *PubSub) HandleEvent(_ context.Context, evt *gcpc.EventV1) {
+	if evt.Type == string(events.ConnectionClose) {
+		if connID := evt.OperationId; connID != "" {
+			p.manager.RemoveConnection(connID)
+		}
+	}
+}
+
+// Scopes returns the permission scopes this plugin requires.
+func (p *PubSub) Scopes() []string {
+	return []string{"write", "hook:pre", "events"}
+}
+
+func main() {
+	plugin := &PubSub{
+		manager: NewSubscriptionManager(),
+	}
+	pluginsdk.Run(context.Background(), plugin)
+}

--- a/plugins/pubsub/manager.go
+++ b/plugins/pubsub/manager.go
@@ -1,0 +1,150 @@
+package main
+
+import "sync"
+
+type SubscriptionManager struct {
+	mu           sync.RWMutex
+	channels     map[string]map[string]struct{} // channel → connID set
+	patterns     map[string]map[string]struct{} // pattern → connID set
+	connChannels map[string]map[string]struct{} // connID → channel set
+	connPatterns map[string]map[string]struct{} // connID → pattern set
+}
+
+func NewSubscriptionManager() *SubscriptionManager {
+	return &SubscriptionManager{
+		channels:     make(map[string]map[string]struct{}),
+		patterns:     make(map[string]map[string]struct{}),
+		connChannels: make(map[string]map[string]struct{}),
+		connPatterns: make(map[string]map[string]struct{}),
+	}
+}
+
+func (m *SubscriptionManager) Subscribe(connID, channel string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	addToSet(m.channels, channel, connID)
+	addToSet(m.connChannels, connID, channel)
+}
+
+func (m *SubscriptionManager) Unsubscribe(connID, channel string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	removeFromSet(m.channels, channel, connID)
+	removeFromSet(m.connChannels, connID, channel)
+}
+
+func (m *SubscriptionManager) PSubscribe(connID, pattern string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	addToSet(m.patterns, pattern, connID)
+	addToSet(m.connPatterns, connID, pattern)
+}
+
+func (m *SubscriptionManager) PUnsubscribe(connID, pattern string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	removeFromSet(m.patterns, pattern, connID)
+	removeFromSet(m.connPatterns, connID, pattern)
+}
+
+// Channels returns a copy of the channels the connection is subscribed to.
+func (m *SubscriptionManager) Channels(connID string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return setKeys(m.connChannels[connID])
+}
+
+// Patterns returns a copy of the patterns the connection is subscribed to.
+func (m *SubscriptionManager) Patterns(connID string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return setKeys(m.connPatterns[connID])
+}
+
+type PublishMatch struct {
+	ConnID  string
+	Pattern string // non-empty for pattern matches
+}
+
+// Publish returns all connections that should receive a message on channel:
+// exact channel subscribers + pattern subscribers whose pattern matches.
+func (m *SubscriptionManager) Publish(channel string) []PublishMatch {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var matches []PublishMatch
+
+	for connID := range m.channels[channel] {
+		matches = append(matches, PublishMatch{ConnID: connID})
+	}
+
+	for pattern, conns := range m.patterns {
+		if matchPattern(pattern, channel) {
+			for connID := range conns {
+				matches = append(matches, PublishMatch{ConnID: connID, Pattern: pattern})
+			}
+		}
+	}
+
+	return matches
+}
+
+func (m *SubscriptionManager) IsSubscribed(connID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.connChannels[connID]) > 0 || len(m.connPatterns[connID]) > 0
+}
+
+// SubscriptionCount returns the total number of subscriptions for a connection.
+func (m *SubscriptionManager) SubscriptionCount(connID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.connChannels[connID]) + len(m.connPatterns[connID])
+}
+
+// RemoveConnection removes all subscriptions for a connection.
+func (m *SubscriptionManager) RemoveConnection(connID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for ch := range m.connChannels[connID] {
+		removeFromSet(m.channels, ch, connID)
+	}
+	delete(m.connChannels, connID)
+
+	for pat := range m.connPatterns[connID] {
+		removeFromSet(m.patterns, pat, connID)
+	}
+	delete(m.connPatterns, connID)
+}
+
+func addToSet(m map[string]map[string]struct{}, key, val string) {
+	s, ok := m[key]
+	if !ok {
+		s = make(map[string]struct{})
+		m[key] = s
+	}
+	s[val] = struct{}{}
+}
+
+func removeFromSet(m map[string]map[string]struct{}, key, val string) {
+	s, ok := m[key]
+	if !ok {
+		return
+	}
+	delete(s, val)
+	if len(s) == 0 {
+		delete(m, key)
+	}
+}
+
+func setKeys(s map[string]struct{}) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(s))
+	for k := range s {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/plugins/pubsub/manager_test.go
+++ b/plugins/pubsub/manager_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSubscribeUnsubscribe(t *testing.T) {
+	m := NewSubscriptionManager()
+
+	m.Subscribe("conn1", "news")
+	m.Subscribe("conn1", "sports")
+	m.Subscribe("conn2", "news")
+
+	if !m.IsSubscribed("conn1") {
+		t.Error("conn1 should be subscribed")
+	}
+	if m.SubscriptionCount("conn1") != 2 {
+		t.Errorf("conn1 count = %d, want 2", m.SubscriptionCount("conn1"))
+	}
+
+	channels := m.Channels("conn1")
+	sort.Strings(channels)
+	if len(channels) != 2 || channels[0] != "news" || channels[1] != "sports" {
+		t.Errorf("conn1 channels = %v, want [news sports]", channels)
+	}
+
+	m.Unsubscribe("conn1", "news")
+	if m.SubscriptionCount("conn1") != 1 {
+		t.Errorf("conn1 count after unsub = %d, want 1", m.SubscriptionCount("conn1"))
+	}
+
+	m.Unsubscribe("conn1", "sports")
+	if m.IsSubscribed("conn1") {
+		t.Error("conn1 should not be subscribed after full unsub")
+	}
+}
+
+func TestPSubscribe(t *testing.T) {
+	m := NewSubscriptionManager()
+
+	m.PSubscribe("conn1", "news.*")
+	m.Subscribe("conn2", "news.art")
+
+	matches := m.Publish("news.art")
+	if len(matches) != 2 {
+		t.Fatalf("publish matches = %d, want 2", len(matches))
+	}
+
+	var channelMatch, patternMatch bool
+	for _, match := range matches {
+		if match.ConnID == "conn2" && match.Pattern == "" {
+			channelMatch = true
+		}
+		if match.ConnID == "conn1" && match.Pattern == "news.*" {
+			patternMatch = true
+		}
+	}
+	if !channelMatch {
+		t.Error("missing channel match for conn2")
+	}
+	if !patternMatch {
+		t.Error("missing pattern match for conn1")
+	}
+}
+
+func TestPublishNoSubscribers(t *testing.T) {
+	m := NewSubscriptionManager()
+	matches := m.Publish("empty")
+	if len(matches) != 0 {
+		t.Errorf("publish to empty channel = %d matches, want 0", len(matches))
+	}
+}
+
+func TestRemoveConnection(t *testing.T) {
+	m := NewSubscriptionManager()
+
+	m.Subscribe("conn1", "a")
+	m.Subscribe("conn1", "b")
+	m.PSubscribe("conn1", "c.*")
+	m.Subscribe("conn2", "a")
+
+	m.RemoveConnection("conn1")
+
+	if m.IsSubscribed("conn1") {
+		t.Error("conn1 should not be subscribed after removal")
+	}
+
+	matches := m.Publish("a")
+	if len(matches) != 1 || matches[0].ConnID != "conn2" {
+		t.Errorf("after removal, publish to 'a' = %v, want [conn2]", matches)
+	}
+
+	matches = m.Publish("c.test")
+	if len(matches) != 0 {
+		t.Error("pattern subscription should be removed")
+	}
+}
+
+func TestRemoveConnectionIdempotent(t *testing.T) {
+	m := NewSubscriptionManager()
+	m.RemoveConnection("nonexistent")
+}
+
+func TestSubscriptionCount(t *testing.T) {
+	m := NewSubscriptionManager()
+
+	m.Subscribe("conn1", "a")
+	m.PSubscribe("conn1", "b.*")
+	if m.SubscriptionCount("conn1") != 2 {
+		t.Errorf("count = %d, want 2", m.SubscriptionCount("conn1"))
+	}
+
+	if m.SubscriptionCount("nonexistent") != 0 {
+		t.Error("nonexistent connection should have 0 subscriptions")
+	}
+}
+
+func TestDuplicateSubscribe(t *testing.T) {
+	m := NewSubscriptionManager()
+	m.Subscribe("conn1", "ch")
+	m.Subscribe("conn1", "ch")
+	if m.SubscriptionCount("conn1") != 1 {
+		t.Errorf("duplicate subscribe should not increase count, got %d", m.SubscriptionCount("conn1"))
+	}
+}

--- a/plugins/pubsub/pattern.go
+++ b/plugins/pubsub/pattern.go
@@ -1,0 +1,110 @@
+package main
+
+// matchPattern implements Redis-compatible glob matching.
+//
+// Supported syntax:
+//   - *      matches any sequence of characters (including empty)
+//   - ?      matches exactly one character
+//   - [abc]  matches one character in the set
+//   - [a-z]  matches one character in the range
+//   - [^a]   matches one character NOT in the set
+//   - \x     matches literal x (escape)
+func matchPattern(pattern, str string) bool {
+	return match([]byte(pattern), []byte(str))
+}
+
+func match(pattern, str []byte) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			pattern = trimStars(pattern)
+			if len(pattern) == 0 {
+				return true
+			}
+			for i := 0; i <= len(str); i++ {
+				if match(pattern, str[i:]) {
+					return true
+				}
+			}
+			return false
+
+		case '?':
+			if len(str) == 0 {
+				return false
+			}
+			pattern = pattern[1:]
+			str = str[1:]
+
+		case '[':
+			if len(str) == 0 {
+				return false
+			}
+			matched, rest, ok := matchCharClass(pattern, str[0])
+			if !ok || !matched {
+				return false
+			}
+			pattern = rest
+			str = str[1:]
+
+		case '\\':
+			pattern = pattern[1:]
+			if len(pattern) == 0 || len(str) == 0 || pattern[0] != str[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			str = str[1:]
+
+		default:
+			if len(str) == 0 || pattern[0] != str[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			str = str[1:]
+		}
+	}
+	return len(str) == 0
+}
+
+func trimStars(pattern []byte) []byte {
+	for len(pattern) > 0 && pattern[0] == '*' {
+		pattern = pattern[1:]
+	}
+	return pattern
+}
+
+// matchCharClass parses a [...] class starting at pattern[0]=='[' and
+// tests whether ch is in the class. Returns (matched, restOfPattern, valid).
+func matchCharClass(pattern []byte, ch byte) (bool, []byte, bool) {
+	pattern = pattern[1:] // skip '['
+	negate := false
+	if len(pattern) > 0 && pattern[0] == '^' {
+		negate = true
+		pattern = pattern[1:]
+	}
+
+	matched := false
+	for len(pattern) > 0 && pattern[0] != ']' {
+		lo := pattern[0]
+		pattern = pattern[1:]
+
+		if len(pattern) >= 2 && pattern[0] == '-' {
+			hi := pattern[1]
+			pattern = pattern[2:]
+			if ch >= lo && ch <= hi {
+				matched = true
+			}
+		} else if ch == lo {
+			matched = true
+		}
+	}
+
+	if len(pattern) == 0 {
+		return false, nil, false
+	}
+	pattern = pattern[1:] // skip ']'
+
+	if negate {
+		matched = !matched
+	}
+	return matched, pattern, true
+}

--- a/plugins/pubsub/pattern_test.go
+++ b/plugins/pubsub/pattern_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		str     string
+		want    bool
+	}{
+		{"*", "", true},
+		{"*", "hello", true},
+		{"*", "hello.world", true},
+		{"h?llo", "hello", true},
+		{"h?llo", "hallo", true},
+		{"h?llo", "hllo", false},
+		{"h[ae]llo", "hello", true},
+		{"h[ae]llo", "hallo", true},
+		{"h[ae]llo", "hillo", false},
+		{"h[a-e]llo", "hcllo", true},
+		{"h[a-e]llo", "hfllo", false},
+		{"h[^e]llo", "hallo", true},
+		{"h[^e]llo", "hello", false},
+		{"hello", "hello", true},
+		{"hello", "world", false},
+		{"hello.*", "hello.world", true},
+		{"hello.*", "hello.", true},
+		{"hello.*", "hello", false},
+		{"*.world", "hello.world", true},
+		{"*.world", "world", false},
+		{"news.*", "news.art.figurative", true},
+		{"news.*", "news.", true},
+		{"news.*", "news", false},
+		{"\\*special", "*special", true},
+		{"\\*special", "xspecial", false},
+		{"\\?mark", "?mark", true},
+		{"a*b*c", "abc", true},
+		{"a*b*c", "aXXbYYc", true},
+		{"a*b*c", "aXXbYY", false},
+		{"", "", true},
+		{"", "a", false},
+		{"a", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.str, func(t *testing.T) {
+			got := matchPattern(tt.pattern, tt.str)
+			if got != tt.want {
+				t.Errorf("matchPattern(%q, %q) = %v, want %v", tt.pattern, tt.str, got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/pluginsdk/sdk.go
+++ b/sdk/pluginsdk/sdk.go
@@ -157,18 +157,21 @@ const (
 
 // CommandDecl declares a command a plugin can handle.
 type CommandDecl struct {
-	Name       string // command name (e.g. "PUBLISH" or "QUERY")
-	Namespaced bool   // true = REX (PLUGIN:CMD), false = main namespace
-	MinArgs    int
-	MaxArgs    int  // -1 = unlimited
-	ReadOnly   bool // hint: command does not mutate state
+	Name        string // command name (e.g. "PUBLISH" or "QUERY")
+	Namespaced  bool   // true = REX (PLUGIN:CMD), false = main namespace
+	MinArgs     int
+	MaxArgs     int  // -1 = unlimited
+	ReadOnly    bool // hint: command does not mutate state
+	KeyArgIndex int  // -1 = keyless (default), 0+ = single-key at Args[N]
+	MultiKey    bool // command touches multiple keys
 }
 
 // CommandResult holds the result of a plugin command execution.
 type CommandResult struct {
 	// Value can be: string, int, int64, float64, nil, error,
 	// []any, []string, map[string]string, map[string]any.
-	Value any
+	Value            any
+	SuppressResponse bool
 }
 
 // HookDecl declares a hook a plugin wants to intercept.
@@ -195,12 +198,23 @@ type HookResponse struct {
 	ContextValues map[string]string // pre-hook: values to add to command context
 }
 
+// ConnectionID extracts the stable connection identifier from the operation
+// context. Returns "" if no operation or connection ID is available.
+func ConnectionID(ctx context.Context) string {
+	if op := ops.FromContext(ctx); op != nil {
+		snap := op.ContextSnapshot(false)
+		return snap[command.ConnectionIDKey]
+	}
+	return ""
+}
+
 // ctxFromOpMap reconstructs a local operation from a context map containing
 // _operation_id. If no operation ID is present, returns ctx unchanged.
 func ctxFromOpMap(ctx context.Context, m map[string]string) context.Context {
 	if opID := m[command.OperationID]; opID != "" {
 		op := ops.New(ops.TypeCommand, "")
 		op.ID = opID
+		op.EnrichMany(m)
 		return ops.WithContext(ctx, op)
 	}
 	return ctx
@@ -248,11 +262,13 @@ func Run(ctx context.Context, p Plugin) error {
 		cmdDecls = make([]*gcpc.CommandDeclV1, len(decls))
 		for i, d := range decls {
 			cmdDecls[i] = &gcpc.CommandDeclV1{
-				Name:       d.Name,
-				Namespaced: d.Namespaced,
-				MinArgs:    int32(d.MinArgs),
-				MaxArgs:    int32(d.MaxArgs),
-				Readonly:   d.ReadOnly,
+				Name:        d.Name,
+				Namespaced:  d.Namespaced,
+				MinArgs:     int32(d.MinArgs),
+				MaxArgs:     int32(d.MaxArgs),
+				Readonly:    d.ReadOnly,
+				KeyArgIndex: int32(d.KeyArgIndex),
+				MultiKey:    d.MultiKey,
 			}
 		}
 	}
@@ -411,12 +427,14 @@ func Run(ctx context.Context, p Plugin) error {
 				cmdCtx := ctxFromOpMap(ctx, req.Context)
 				result := cp.HandleCommand(cmdCtx, req.Command, req.Args, req.Metadata)
 				var protoResult *gcpc.ResultV1
+				suppress := false
 				if result != nil {
 					protoResult = gcpc.ResultFromInterface(result.Value)
+					suppress = result.SuppressResponse
 				} else {
 					protoResult = gcpc.ResultFromInterface(nil)
 				}
-				resp := gcpc.NewCommandResponse(req.RequestId, protoResult)
+				resp := gcpc.NewCommandResponse(req.RequestId, protoResult, suppress)
 				if err := tc.Send(resp); err != nil {
 					pluginLog.ErrorNoCtx().Err(err).Str("command", req.Command).Msg("failed to send command response")
 				}

--- a/sdk/pluginsdk/session.go
+++ b/sdk/pluginsdk/session.go
@@ -100,6 +100,13 @@ func (po *PluginOperation) Enrich(key, value string) {
 	po.op.Enrich(key, value)
 }
 
+// PushToClient sends raw RESP data to a specific client connection.
+// The data must be pre-formatted RESP bytes. The server writes them directly
+// to the client's TCP connection, bypassing normal command-response flow.
+func (s *Session) PushToClient(connID string, data []byte) error {
+	return s.conn.Send(gcpc.NewClientPush(connID, data))
+}
+
 // dispatch routes a server query response to the waiting caller.
 // Called from Run()'s recv loop.
 func (s *Session) dispatch(resp *gcpc.ServerQueryResponseV1) {


### PR DESCRIPTION
## Summary

- **Client push architecture**: Plugins can push raw RESP data to specific client connections via `ClientPushV1` over GCPC, with mutex-serialized writes through `ConnectionRegistry`/`ConnHandle`
- **Pub/Sub plugin**: Full IPC plugin implementing SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH with subscription mode enforcement hook and connection.close cleanup
- **RESP encoding in `api/resp`**: Shared append-based (zero-alloc) and convenience encoding API for plugins, CLI, and server core
- **Plugin command operations**: Pipeline now creates operation spans for plugin-routed commands with `_readonly` enrichment
- **SDK extensions**: `ConnectionID()` helper, `PushToClient` session method, `SuppressResponse` threading, full context propagation in `ctxFromOpMap`

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] Pub/Sub subscription manager unit tests (7 test functions)
- [x] Pattern matcher unit tests (33 test cases)
- [x] RESP encoder unit tests + benchmarks
- [x] Router test updates for 3-return signature
- [ ] Integration tests (separate PR)