### PR TITLE
Add telemetry sidecar API and commons primitives

### DIFF
--- a/api/observability/identity.go
+++ b/api/observability/identity.go
@@ -1,0 +1,112 @@
+// Package observability defines plugin-safe operation telemetry contracts.
+//
+// The package is intentionally limited to stable value types and small
+// interfaces. Concrete sidecar queues, workers, context-version stores, GCPC
+// projection, and server lookup state stay outside api/.
+package observability
+
+// OperationID is the public operation correlation identifier visible at API,
+// SDK, GCPC, log, event, and plugin boundaries.
+type OperationID string
+
+// String returns the public operation id as a plain string.
+func (id OperationID) String() string { return string(id) }
+
+// IsZero reports whether id is empty.
+func (id OperationID) IsZero() bool { return id == "" }
+
+// OperationHandle is the plugin-safe handle shape exposed to API consumers.
+// It deliberately carries only the exported operation id; server-internal
+// identities used for sharding and worker lookup are not exposed here.
+type OperationHandle struct {
+	id OperationID
+}
+
+// NewOperationHandle returns a handle for an exported operation id.
+func NewOperationHandle(id string) OperationHandle {
+	return OperationHandle{id: OperationID(id)}
+}
+
+// ID returns the exported operation id.
+func (h OperationHandle) ID() OperationID { return h.id }
+
+// String returns the exported operation id as a plain string.
+func (h OperationHandle) String() string { return h.id.String() }
+
+// IsZero reports whether the handle has no exported operation id.
+func (h OperationHandle) IsZero() bool { return h.id.IsZero() }
+
+// OperationRef is the boundary-safe reference shape for an operation and its
+// public parent. ParentID is empty for root operations.
+type OperationRef struct {
+	ID       OperationID
+	ParentID OperationID
+}
+
+// NewOperationRef returns a public operation reference.
+func NewOperationRef(id, parentID string) OperationRef {
+	return OperationRef{ID: OperationID(id), ParentID: OperationID(parentID)}
+}
+
+// IsZero reports whether the reference has no operation id.
+func (r OperationRef) IsZero() bool { return r.ID.IsZero() }
+
+// InternalOperationIdentity is an opaque in-process sidecar identity. It is
+// suitable for sharding, ordering, worker lookup, and map keys inside a tracker
+// engine. It is not a public operation id and must not cross GCPC/plugin
+// boundaries as identity.
+type InternalOperationIdentity int64
+
+// IsZero reports whether id is the empty internal operation identity.
+func (id InternalOperationIdentity) IsZero() bool { return id == 0 }
+
+// ConnectionIdentity identifies a connection for internal sidecar routing and
+// context-version ownership. It is not a public tracing id.
+type ConnectionIdentity uint64
+
+// ConnectionContextVersion identifies an immutable connection-context snapshot
+// stored centrally by OperationTrackerManager implementations.
+type ConnectionContextVersion uint64
+
+// IsZero reports whether version is the empty connection-context version.
+func (version ConnectionContextVersion) IsZero() bool { return version == 0 }
+
+// TraceFlags carries the W3C trace-flags byte used by trace-context rendering.
+type TraceFlags byte
+
+// OperationIdentityInput is the data a configured strategy may need to render a
+// public operation identity. It intentionally omits node/fleet identifiers in
+// the first implementation; replica-aware identity is a future concern.
+type OperationIdentityInput struct {
+	Internal      InternalOperationIdentity
+	Parent        OperationRef
+	StartUnixNano int64
+	Sequence      uint64
+	TraceID       [16]byte
+	SpanID        [8]byte
+	ParentSpanID  [8]byte
+	TraceFlags    TraceFlags
+}
+
+// OperationIdentity is the strategy-rendered public identity plus trace fields
+// needed by tracing-compatible renderers.
+type OperationIdentity struct {
+	ID           OperationID
+	ParentID     OperationID
+	TraceID      [16]byte
+	SpanID       [8]byte
+	ParentSpanID [8]byte
+	TraceFlags   TraceFlags
+}
+
+// Ref returns the public operation reference carried by identity.
+func (id OperationIdentity) Ref() OperationRef {
+	return OperationRef{ID: id.ID, ParentID: id.ParentID}
+}
+
+// OperationIdentityStrategy renders the public operation identity for API,
+// SDK, GCPC, log, event, and plugin boundaries. Implementations may use the
+// internal identity as input, but must return only exported identity values.
+type OperationIdentityStrategy interface {
+	Render(OperationIdentityInput) (OperationIdentity, error)
+}

--- a/api/observability/identity_test.go
+++ b/api/observability/identity_test.go
@@ -1,0 +1,42 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOperationHandleExportsOnlyPublicID(t *testing.T) {
+	h := NewOperationHandle("op-1")
+	if h.ID() != "op-1" {
+		t.Fatalf("ID() = %q, want op-1", h.ID())
+	}
+	if h.String() != "op-1" {
+		t.Fatalf("String() = %q, want op-1", h.String())
+	}
+	if h.IsZero() {
+		t.Fatal("handle should not be zero")
+	}
+
+	typ := reflect.TypeOf(h)
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		if field.Type == reflect.TypeOf(InternalOperationIdentity(0)) {
+			t.Fatalf("OperationHandle field %s exposes InternalOperationIdentity", field.Name)
+		}
+	}
+}
+
+func TestOperationIdentityInputOmitsNodeID(t *testing.T) {
+	typ := reflect.TypeOf(OperationIdentityInput{})
+	if _, ok := typ.FieldByName("NodeID"); ok {
+		t.Fatal("OperationIdentityInput must not expose NodeID in the first implementation")
+	}
+}
+
+func TestOperationIdentityRef(t *testing.T) {
+	identity := OperationIdentity{ID: "child", ParentID: "parent"}
+	ref := identity.Ref()
+	if ref.ID != "child" || ref.ParentID != "parent" {
+		t.Fatalf("Ref() = %+v, want child/parent", ref)
+	}
+}

--- a/api/observability/log_level.go
+++ b/api/observability/log_level.go
@@ -1,0 +1,38 @@
+package observability
+
+// TelemetryLogLevel is a deterministic numeric log level used by telemetry log
+// records. Dynamic log messages and fields stay as bytes; only this fixed level
+// vocabulary is represented as an integer.
+type TelemetryLogLevel uint8
+
+const (
+	TelemetryLogLevelUnspecified TelemetryLogLevel = iota
+	TelemetryLogLevelTrace
+	TelemetryLogLevelDebug
+	TelemetryLogLevelInfo
+	TelemetryLogLevelWarn
+	TelemetryLogLevelError
+	TelemetryLogLevelFatal
+	TelemetryLogLevelPanic
+)
+
+func (level TelemetryLogLevel) String() string {
+	switch level {
+	case TelemetryLogLevelTrace:
+		return "trace"
+	case TelemetryLogLevelDebug:
+		return "debug"
+	case TelemetryLogLevelInfo:
+		return "info"
+	case TelemetryLogLevelWarn:
+		return "warn"
+	case TelemetryLogLevelError:
+		return "error"
+	case TelemetryLogLevelFatal:
+		return "fatal"
+	case TelemetryLogLevelPanic:
+		return "panic"
+	default:
+		return "unspecified"
+	}
+}

--- a/api/observability/log_level_test.go
+++ b/api/observability/log_level_test.go
@@ -1,0 +1,24 @@
+package observability
+
+import "testing"
+
+func TestTelemetryLogLevelStrings(t *testing.T) {
+	tests := []struct {
+		level TelemetryLogLevel
+		want  string
+	}{
+		{TelemetryLogLevelTrace, "trace"},
+		{TelemetryLogLevelDebug, "debug"},
+		{TelemetryLogLevelInfo, "info"},
+		{TelemetryLogLevelWarn, "warn"},
+		{TelemetryLogLevelError, "error"},
+		{TelemetryLogLevelFatal, "fatal"},
+		{TelemetryLogLevelPanic, "panic"},
+		{TelemetryLogLevelUnspecified, "unspecified"},
+	}
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.want {
+			t.Fatalf("%d.String() = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}

--- a/api/observability/operation_tracker.go
+++ b/api/observability/operation_tracker.go
@@ -1,0 +1,38 @@
+package observability
+
+// OperationTracker is the injectable operation-telemetry capability used by
+// services and components. Implementations are responsible for keeping these
+// helper methods allocation-free on their submit path.
+//
+// Methods submit pointer-free telemetry requests only. The sidecar stores
+// telemetry state in memory for later FIFO reaping; it does not build actual
+// logs, materialized events, GCPC payloads, protobuf messages, zerolog output,
+// or plugin fanout on the command-executing goroutine. Reaper-side processing
+// converts operation records to runtime operation output, folds context mutation
+// records into worker-owned context state, and materializes logs/events later.
+//
+// Connection-context versioning is managed centrally by OperationTrackerManager,
+// not by callers. StartOperation carries the exact ConnectionContextVersion
+// current at operation start, and the operation is pinned to that version for
+// worker-side processing.
+type OperationTracker interface {
+	TelemetryRecorder
+
+	// StartOperation submits an operation-start request and pins the base
+	// connection-context version used by later worker-side projection.
+	StartOperation(operation InternalOperationIdentity, parent ParentRef, contextVersion ConnectionContextVersion) bool
+	// FinishOperation submits an operation-finish request.
+	FinishOperation(operation InternalOperationIdentity) bool
+	// StartCommand submits a command-start request with dynamic command bytes.
+	StartCommand(operation InternalOperationIdentity, commandName []byte, payload []byte) bool
+	// FinishCommand submits a command-finish request with the result code.
+	FinishCommand(operation InternalOperationIdentity, resultCode int64) bool
+	// Log submits a request to materialize a log later; it is not itself a log.
+	Log(operation InternalOperationIdentity, level TelemetryLogLevel, message []byte, fields ...[]byte) bool
+	// Event submits a request to emit a typed event later; it is not itself an event.
+	Event(operation InternalOperationIdentity, eventName []byte, fields ...[]byte) bool
+	// ContextUpdate submits operation context key/value deltas for worker replay.
+	ContextUpdate(operation InternalOperationIdentity, pairs ...[]byte) bool
+	// ContextRemove submits operation context key removals for worker replay.
+	ContextRemove(operation InternalOperationIdentity, keys ...[]byte) bool
+}

--- a/api/observability/operation_tracker_manager.go
+++ b/api/observability/operation_tracker_manager.go
@@ -1,0 +1,34 @@
+package observability
+
+// ConnectionContextVisitor receives immutable connection-context key/value pairs
+// for a specific ConnectionContextVersion. Implementations call it off the
+// command hot path while worker-side processing materializes telemetry context.
+type ConnectionContextVisitor func(key, value string) bool
+
+// OperationTrackerManager is the injectable telemetry manager capability for
+// core components that need to submit requests for logs, events, commands, or
+// operation context mutations for an internal operation identity.
+//
+// Implementations are configured with a fixed shard count and pre-create their
+// shard trackers during initialization. Get must be a cheap routing operation:
+// compute the shard from the internal operation identity and return the existing
+// tracker for that shard. It must not lazily allocate trackers or take a mutex
+// on the command/log/event submit path.
+//
+// Connection context versions are created by the manager, not by callers. A
+// started operation carries the exact ConnectionContextVersion current at start.
+// Later worker-side processing resolves that same immutable version, even if the
+// connection context changed while the operation was running.
+type OperationTrackerManager interface {
+	Get(operation InternalOperationIdentity) OperationTracker
+
+	UpdateConnectionContext(connection ConnectionIdentity, pairs ...[]byte) ConnectionContextVersion
+	RemoveConnectionContext(connection ConnectionIdentity, keys ...[]byte) ConnectionContextVersion
+	PinCurrentConnectionContextVersion(connection ConnectionIdentity) ConnectionContextVersion
+	RetainConnectionContextVersion(version ConnectionContextVersion) bool
+	ReleaseConnectionContextVersion(version ConnectionContextVersion) bool
+	VisitConnectionContextVersion(version ConnectionContextVersion, visitor ConnectionContextVisitor) bool
+
+	ShardCount() int
+	DroppedRecords() uint64
+}

--- a/api/observability/telemetry_record.go
+++ b/api/observability/telemetry_record.go
@@ -1,0 +1,165 @@
+package observability
+
+// TelemetryNameBytes is the fixed inline capacity for dynamic command names,
+// log messages, and event names. Names may be registered by plugins at runtime,
+// so the hot path carries bytes instead of assuming preassigned ids.
+const TelemetryNameBytes = 64
+
+// TelemetryPayloadBytes is the fixed inline payload capacity for allocation-free
+// telemetry records. Larger values should be encoded by a worker-owned side
+// store, not by adding pointers to TelemetryRecord.
+const TelemetryPayloadBytes = 128
+
+// TelemetryParentIDBytes is the fixed inline capacity for exported parent
+// operation ids on operation-start records. It fits UUIDv7 strings and W3C
+// traceparent-compatible ids without carrying a string or []byte pointer.
+const TelemetryParentIDBytes = 64
+
+// ParentRef carries an exported parent operation id inline. It is used only for
+// operation causality at operation start; logs and events are already under an
+// operation and do not carry a parent reference on the submit path.
+type ParentRef struct {
+	ParentLen uint16
+	ParentID  [TelemetryParentIDBytes]byte
+}
+
+// NewParentRef returns an inline parent reference copied from an exported id.
+func NewParentRef(parentID string) ParentRef {
+	var ref ParentRef
+	ref.SetString(parentID)
+	return ref
+}
+
+// NewParentRefBytes returns an inline parent reference copied from bytes.
+func NewParentRefBytes(parentID []byte) ParentRef {
+	var ref ParentRef
+	ref.SetBytes(parentID)
+	return ref
+}
+
+// SetString copies parentID into the inline buffer and returns bytes retained.
+// It does not retain the input string.
+func (r *ParentRef) SetString(parentID string) int {
+	n := copy(r.ParentID[:], parentID)
+	r.ParentLen = uint16(n)
+	return n
+}
+
+// SetBytes copies parentID into the inline buffer and returns bytes retained.
+// It does not retain the input slice.
+func (r *ParentRef) SetBytes(parentID []byte) int {
+	n := copy(r.ParentID[:], parentID)
+	r.ParentLen = uint16(n)
+	return n
+}
+
+// IsZero reports whether no parent id is present.
+func (r ParentRef) IsZero() bool { return r.ParentLen == 0 }
+
+// Len returns the retained parent id length.
+func (r ParentRef) Len() int { return int(r.ParentLen) }
+
+// CopyTo copies the retained parent id into dst and returns bytes copied.
+func (r ParentRef) CopyTo(dst []byte) int {
+	return copy(dst, r.ParentID[:r.ParentLen])
+}
+
+// String returns the retained parent id. It is intended for diagnostics,
+// boundaries, and tests, not the command hot path.
+func (r ParentRef) String() string {
+	return string(r.ParentID[:r.ParentLen])
+}
+
+// TelemetryRecordKind identifies the kind of compact telemetry request carried
+// by a TelemetryRecord. Kinds describe worker-side work to do later; they are not
+// materialized logs, events, GCPC messages, or plugin fanout objects.
+type TelemetryRecordKind uint8
+
+const (
+	TelemetryRecordOperationStart TelemetryRecordKind = iota
+	TelemetryRecordOperationFinish
+	TelemetryRecordCommandStart
+	TelemetryRecordCommandFinish
+	TelemetryRecordLog
+	TelemetryRecordContextUpdate
+	TelemetryRecordContextRemove
+	TelemetryRecordEvent
+	TelemetryRecordDrop
+)
+
+func (k TelemetryRecordKind) String() string {
+	switch k {
+	case TelemetryRecordOperationStart:
+		return "operation.start"
+	case TelemetryRecordOperationFinish:
+		return "operation.finish"
+	case TelemetryRecordCommandStart:
+		return "command.start"
+	case TelemetryRecordCommandFinish:
+		return "command.finish"
+	case TelemetryRecordLog:
+		return "log.request"
+	case TelemetryRecordContextUpdate:
+		return "context.update"
+	case TelemetryRecordContextRemove:
+		return "context.remove"
+	case TelemetryRecordEvent:
+		return "event.request"
+	case TelemetryRecordDrop:
+		return "drop"
+	default:
+		return "unknown"
+	}
+}
+
+// TelemetryRecord is a pointer-free, fixed-size outbox request submitted into
+// common sidecar primitives. It records telemetry intent/state in memory for
+// later processing; it is not itself the final log/event/GCPC payload and does
+// not perform emission or fanout. It carries only scalar ids, inline dynamic names, an
+// inline parent reference for operation start, and an inline byte payload so
+// ring storage does not retain request-owned buffers or force GC pointer
+// scanning.
+type TelemetryRecord struct {
+	Kind              TelemetryRecordKind
+	Level             TelemetryLogLevel
+	NameLen           uint16
+	PayloadLen        uint16
+	Operation         InternalOperationIdentity
+	TimestampUnixNano int64
+	Number            int64
+	ContextVersion    ConnectionContextVersion
+	Parent            ParentRef
+	Name              [TelemetryNameBytes]byte
+	Payload           [TelemetryPayloadBytes]byte
+}
+
+// NewTelemetryRecord creates a compact telemetry record for operation.
+func NewTelemetryRecord(kind TelemetryRecordKind, operation InternalOperationIdentity) TelemetryRecord {
+	return TelemetryRecord{Kind: kind, Operation: operation}
+}
+
+// SetName copies data into the fixed inline name buffer and returns the number
+// of bytes retained. Data longer than TelemetryNameBytes is truncated.
+func (r *TelemetryRecord) SetName(data []byte) int {
+	n := copy(r.Name[:], data)
+	r.NameLen = uint16(n)
+	return n
+}
+
+// NameBytes returns the retained inline dynamic name bytes.
+func (r *TelemetryRecord) NameBytes() []byte {
+	return r.Name[:r.NameLen]
+}
+
+// SetPayload copies data into the fixed inline payload buffer and returns the
+// number of bytes retained. Data longer than TelemetryPayloadBytes is truncated.
+func (r *TelemetryRecord) SetPayload(data []byte) int {
+	n := copy(r.Payload[:], data)
+	r.PayloadLen = uint16(n)
+	return n
+}
+
+// PayloadBytes returns the retained inline payload bytes.
+func (r *TelemetryRecord) PayloadBytes() []byte {
+	return r.Payload[:r.PayloadLen]
+}

--- a/api/observability/telemetry_record_test.go
+++ b/api/observability/telemetry_record_test.go
@@ -1,0 +1,84 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTelemetryRecordPointerFree(t *testing.T) {
+	if field := firstPointerLikeField(reflect.TypeOf(TelemetryRecord{}), "TelemetryRecord"); field != "" {
+		t.Fatalf("TelemetryRecord must remain pointer-free, found %s", field)
+	}
+}
+
+func TestParentRefPointerFree(t *testing.T) {
+	if field := firstPointerLikeField(reflect.TypeOf(ParentRef{}), "ParentRef"); field != "" {
+		t.Fatalf("ParentRef must remain pointer-free, found %s", field)
+	}
+}
+
+func firstPointerLikeField(t reflect.Type, path string) string {
+	switch t.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface, reflect.Chan, reflect.Func, reflect.String:
+		return path + " (" + t.Kind().String() + ")"
+	case reflect.Array:
+		return firstPointerLikeField(t.Elem(), path+"[]")
+	case reflect.Struct:
+		for i := range t.NumField() {
+			field := t.Field(i)
+			if nested := firstPointerLikeField(field.Type, path+"."+field.Name); nested != "" {
+				return nested
+			}
+		}
+	}
+	return ""
+}
+
+func TestTelemetryRecordSetNameAndPayload(t *testing.T) {
+	record := NewTelemetryRecord(TelemetryRecordLog, 7)
+	if retained := record.SetName([]byte("debug message")); retained != len("debug message") {
+		t.Fatalf("SetName retained %d bytes, want %d", retained, len("debug message"))
+	}
+	if retained := record.SetPayload([]byte("hello")); retained != 5 {
+		t.Fatalf("SetPayload retained %d bytes, want 5", retained)
+	}
+	if got := string(record.NameBytes()); got != "debug message" {
+		t.Fatalf("NameBytes() = %q, want debug message", got)
+	}
+	if got := string(record.PayloadBytes()); got != "hello" {
+		t.Fatalf("PayloadBytes() = %q, want hello", got)
+	}
+}
+
+func TestTelemetryRecordSetNameAndPayloadTruncate(t *testing.T) {
+	record := NewTelemetryRecord(TelemetryRecordEvent, 9)
+	name := make([]byte, TelemetryNameBytes+3)
+	payload := make([]byte, TelemetryPayloadBytes+3)
+	for i := range name {
+		name[i] = 'n'
+	}
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	if retained := record.SetName(name); retained != TelemetryNameBytes {
+		t.Fatalf("SetName retained %d bytes, want %d", retained, TelemetryNameBytes)
+	}
+	if retained := record.SetPayload(payload); retained != TelemetryPayloadBytes {
+		t.Fatalf("SetPayload retained %d bytes, want %d", retained, TelemetryPayloadBytes)
+	}
+	if len(record.NameBytes()) != TelemetryNameBytes {
+		t.Fatalf("NameBytes len = %d, want %d", len(record.NameBytes()), TelemetryNameBytes)
+	}
+	if len(record.PayloadBytes()) != TelemetryPayloadBytes {
+		t.Fatalf("PayloadBytes len = %d, want %d", len(record.PayloadBytes()), TelemetryPayloadBytes)
+	}
+}
+
+func TestParentRefCopiesInput(t *testing.T) {
+	parent := []byte("parent-operation")
+	ref := NewParentRefBytes(parent)
+	copy(parent, "mutated-parent")
+	if got := ref.String(); got != "parent-operation" {
+		t.Fatalf("ParentRef = %q, want parent-operation", got)
+	}
+}

--- a/api/observability/telemetry_recorder.go
+++ b/api/observability/telemetry_recorder.go
@@ -1,0 +1,10 @@
+package observability
+
+// TelemetryRecorder is the minimal capability for submitting compact telemetry
+// outbox records. Implementations place requests onto a sidecar path for later
+// execution and may drop records under overload, but must expose drop counts so
+// incomplete telemetry is visible to callers.
+type TelemetryRecorder interface {
+	RecordTelemetry(TelemetryRecord) bool
+	DroppedRecords() uint64
+}

--- a/commons/observability/bench_test.go
+++ b/commons/observability/bench_test.go
@@ -1,0 +1,239 @@
+package observability
+
+import (
+	"sync/atomic"
+	"testing"
+
+	apiobs "gocache/api/observability"
+)
+
+func BenchmarkTelemetryRecordSubmit(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordCommandStart, 1)
+	record.SetName([]byte("GET"))
+	record.SetPayload([]byte("key:1"))
+	capacity := len(recorder.ring.records)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !recorder.RecordTelemetry(record) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerCommandDynamicName(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	tracker := newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	commandName := []byte("PLUGIN.CUSTOM")
+	payload := []byte("arg1 arg2")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.StartCommand(1, commandName, payload) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerLogFields(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	tracker := newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	message := []byte("operation finished")
+	key1, value1 := []byte("status"), []byte("ok")
+	key2, value2 := []byte("tenant"), []byte("acme")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.Log(1, apiobs.TelemetryLogLevelDebug, message, key1, value1, key2, value2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerContextUpdate(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	tracker := newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	key1, value1 := []byte("tenant"), []byte("acme")
+	key2, value2 := []byte("role"), []byte("reader")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.ContextUpdate(1, key1, value1, key2, value2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceOperationLifecycle(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+	parent := apiobs.NewParentRefBytes([]byte("parent-operation"))
+	version := apiobs.ConnectionContextVersion(3)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i*2, capacity)
+		operation := apiobs.InternalOperationIdentity(i + 1)
+		if !tracker.StartOperation(operation, parent, version) {
+			b.Fatal("start record dropped during benchmark")
+		}
+		if !tracker.FinishOperation(operation) {
+			b.Fatal("finish record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceFinishCommand(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.FinishCommand(1, 0) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceLogFields(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	message := []byte("operation finished")
+	key1, value1 := []byte("status"), []byte("ok")
+	key2, value2 := []byte("tenant"), []byte("acme")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.Log(1, apiobs.TelemetryLogLevelDebug, message, key1, value1, key2, value2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceEventFields(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	eventName := []byte("custom.plugin.event")
+	key1, value1 := []byte("status"), []byte("ok")
+	key2, value2 := []byte("tenant"), []byte("acme")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.Event(1, eventName, key1, value1, key2, value2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceContextUpdate(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	key1, value1 := []byte("tenant"), []byte("acme")
+	key2, value2 := []byte("role"), []byte("reader")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.ContextUpdate(1, key1, value1, key2, value2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryTrackerInterfaceContextRemove(b *testing.B) {
+	recorder := newSingleProducerRecorder(1 << 16)
+	var tracker apiobs.OperationTracker = newOperationTracker(recorder)
+	capacity := len(recorder.ring.records)
+
+	key1, key2 := []byte("tenant"), []byte("role")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		drainBenchmarkBatch(b, recorder, i, capacity)
+		if !tracker.ContextRemove(1, key1, key2) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkTelemetryManagerInterfaceGetStartCommand(b *testing.B) {
+	const capacity = 1 << 16
+	concrete := NewShardedOperationTrackerManager(16, capacity)
+	var manager apiobs.OperationTrackerManager = concrete
+	operation := apiobs.InternalOperationIdentity(42)
+	shard := shardIndex(operation, concrete.ShardCount())
+
+	commandName := []byte("PLUGIN.CUSTOM")
+	payload := []byte("arg1 arg2")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i != 0 && i%capacity == 0 {
+			b.StopTimer()
+			concrete.DrainShard(shard, func(apiobs.TelemetryRecord) {})
+			b.StartTimer()
+		}
+		if !manager.Get(operation).StartCommand(operation, commandName, payload) {
+			b.Fatal("record dropped during benchmark")
+		}
+	}
+}
+
+func BenchmarkShardedManagerGetPrecreated(b *testing.B) {
+	manager := NewShardedOperationTrackerManager(16, 1<<16)
+	identity := apiobs.InternalOperationIdentity(42)
+	_ = manager.Get(identity)
+	var sink apiobs.OperationTracker
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		sink = manager.Get(identity)
+	}
+	_ = sink
+}
+
+func BenchmarkShardIndex(b *testing.B) {
+	identity := apiobs.InternalOperationIdentity(42)
+	var sink int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		atomic.AddInt64(&sink, int64(shardIndex(identity, 8)))
+	}
+}
+
+func drainBenchmarkBatch(b *testing.B, recorder telemetryRecorder, index, capacity int) {
+	b.Helper()
+	if index == 0 || index%capacity != 0 {
+		return
+	}
+	b.StopTimer()
+	recorder.drain(func(apiobs.TelemetryRecord) {})
+	b.StartTimer()
+}

--- a/commons/observability/identity.go
+++ b/commons/observability/identity.go
@@ -1,0 +1,131 @@
+// Package observability provides reusable observability primitives that can be
+// shared by the server, SDK, and plugin tooling without importing server
+// internals.
+package observability
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+
+	apiobs "gocache/api/observability"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrZeroTraceID reports that a W3C trace id could not be made non-zero.
+	ErrZeroTraceID = errors.New("observability: zero W3C trace id")
+	// ErrZeroSpanID reports that a W3C span id could not be made non-zero.
+	ErrZeroSpanID = errors.New("observability: zero W3C span id")
+)
+
+// UUIDv7Strategy renders public operation ids as UUIDv7 strings.
+type UUIDv7Strategy struct{}
+
+// Render returns a UUIDv7 operation identity. UUIDv7 is an export format only;
+// the internal operation handle remains the ordering and sharding source.
+func (UUIDv7Strategy) Render(input apiobs.OperationIdentityInput) (apiobs.OperationIdentity, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return apiobs.OperationIdentity{}, fmt.Errorf("render uuidv7 operation identity: %w", err)
+	}
+	return apiobs.OperationIdentity{
+		ID:           apiobs.OperationID(id.String()),
+		ParentID:     input.Parent.ID,
+		TraceID:      input.TraceID,
+		SpanID:       input.SpanID,
+		ParentSpanID: input.ParentSpanID,
+		TraceFlags:   input.TraceFlags,
+	}, nil
+}
+
+// W3CTraceContextStrategy renders operation identity as a traceparent-compatible
+// string: 00-<trace-id>-<span-id>-<flags>.
+type W3CTraceContextStrategy struct {
+	random io.Reader
+}
+
+// NewW3CTraceContextStrategy returns a W3C strategy backed by crypto/rand.
+func NewW3CTraceContextStrategy() W3CTraceContextStrategy {
+	return W3CTraceContextStrategy{random: rand.Reader}
+}
+
+// NewW3CTraceContextStrategyFromReader returns a W3C strategy backed by reader.
+// It is intended for deterministic tests; nil falls back to crypto/rand.
+func NewW3CTraceContextStrategyFromReader(reader io.Reader) W3CTraceContextStrategy {
+	if reader == nil {
+		reader = rand.Reader
+	}
+	return W3CTraceContextStrategy{random: reader}
+}
+
+// Render returns a W3C traceparent-compatible operation identity. The trace id
+// and span id remain separate fields so tracing semantics are not flattened into
+// a trace-id-only operation tree.
+func (s W3CTraceContextStrategy) Render(input apiobs.OperationIdentityInput) (apiobs.OperationIdentity, error) {
+	reader := s.random
+	if reader == nil {
+		reader = rand.Reader
+	}
+
+	traceID := input.TraceID
+	if isZero(traceID[:]) {
+		if err := fillNonZero(reader, traceID[:], ErrZeroTraceID); err != nil {
+			return apiobs.OperationIdentity{}, err
+		}
+	}
+
+	spanID := input.SpanID
+	if isZero(spanID[:]) {
+		if err := fillNonZero(reader, spanID[:], ErrZeroSpanID); err != nil {
+			return apiobs.OperationIdentity{}, err
+		}
+	}
+
+	var traceparent [55]byte
+	traceparent[0] = '0'
+	traceparent[1] = '0'
+	traceparent[2] = '-'
+	hex.Encode(traceparent[3:35], traceID[:])
+	traceparent[35] = '-'
+	hex.Encode(traceparent[36:52], spanID[:])
+	traceparent[52] = '-'
+	writeLowerHexByte(traceparent[53:55], byte(input.TraceFlags))
+
+	return apiobs.OperationIdentity{
+		ID:           apiobs.OperationID(string(traceparent[:])),
+		ParentID:     input.Parent.ID,
+		TraceID:      traceID,
+		SpanID:       spanID,
+		ParentSpanID: input.ParentSpanID,
+		TraceFlags:   input.TraceFlags,
+	}, nil
+}
+
+func fillNonZero(reader io.Reader, dst []byte, zeroErr error) error {
+	if _, err := io.ReadFull(reader, dst); err != nil {
+		return fmt.Errorf("render W3C operation identity: %w", err)
+	}
+	if isZero(dst) {
+		return zeroErr
+	}
+	return nil
+}
+
+func isZero(data []byte) bool {
+	for _, b := range data {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func writeLowerHexByte(dst []byte, b byte) {
+	const digits = "0123456789abcdef"
+	dst[0] = digits[b>>4]
+	dst[1] = digits[b&0x0f]
+}

--- a/commons/observability/identity_test.go
+++ b/commons/observability/identity_test.go
@@ -1,0 +1,94 @@
+package observability
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	apiobs "gocache/api/observability"
+
+	"github.com/google/uuid"
+)
+
+func TestUUIDv7StrategyRender(t *testing.T) {
+	identity, err := (UUIDv7Strategy{}).Render(apiobs.OperationIdentityInput{
+		Parent: apiobs.NewOperationRef("parent", ""),
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	parsed, err := uuid.Parse(identity.ID.String())
+	if err != nil {
+		t.Fatalf("parse UUIDv7 identity: %v", err)
+	}
+	if parsed.Version() != 7 {
+		t.Fatalf("Version() = %d, want 7", parsed.Version())
+	}
+	if parsed.Variant() != uuid.RFC4122 {
+		t.Fatalf("Variant() = %v, want RFC4122", parsed.Variant())
+	}
+	if identity.ParentID != "parent" {
+		t.Fatalf("ParentID = %q, want parent", identity.ParentID)
+	}
+	if parsed.Time() == 0 {
+		t.Fatal("UUIDv7 Time() should be non-zero")
+	}
+}
+
+func TestW3CTraceContextStrategyUsesProvidedTraceAndSpan(t *testing.T) {
+	traceID := [16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := [8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	parentSpanID := [8]byte{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
+
+	identity, err := NewW3CTraceContextStrategyFromReader(bytes.NewReader(nil)).Render(apiobs.OperationIdentityInput{
+		Parent:       apiobs.NewOperationRef("parent", ""),
+		TraceID:      traceID,
+		SpanID:       spanID,
+		ParentSpanID: parentSpanID,
+		TraceFlags:   0x01,
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	want := "00-0102030405060708090a0b0c0d0e0f10-1112131415161718-01"
+	if identity.ID.String() != want {
+		t.Fatalf("identity = %q, want %q", identity.ID, want)
+	}
+	if identity.TraceID != traceID || identity.SpanID != spanID || identity.ParentSpanID != parentSpanID {
+		t.Fatalf("trace fields were not preserved: %+v", identity)
+	}
+	if identity.ParentID != "parent" {
+		t.Fatalf("ParentID = %q, want parent", identity.ParentID)
+	}
+}
+
+func TestW3CTraceContextStrategyGeneratesMissingTraceAndSpan(t *testing.T) {
+	generated := append([]byte{}, strings.Repeat("a", 16)...)
+	generated = append(generated, []byte("spanseed")...)
+
+	identity, err := NewW3CTraceContextStrategyFromReader(bytes.NewReader(generated)).Render(apiobs.OperationIdentityInput{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	want := "00-61616161616161616161616161616161-7370616e73656564-00"
+	if identity.ID.String() != want {
+		t.Fatalf("identity = %q, want %q", identity.ID, want)
+	}
+	if isZero(identity.TraceID[:]) {
+		t.Fatal("TraceID should be generated")
+	}
+	if isZero(identity.SpanID[:]) {
+		t.Fatal("SpanID should be generated")
+	}
+}
+
+func TestW3CTraceContextStrategyRejectsGeneratedZeroTraceID(t *testing.T) {
+	_, err := NewW3CTraceContextStrategyFromReader(bytes.NewReader(make([]byte, 16))).Render(apiobs.OperationIdentityInput{})
+	if !errors.Is(err, ErrZeroTraceID) {
+		t.Fatalf("Render() error = %v, want ErrZeroTraceID", err)
+	}
+}

--- a/commons/observability/manager.go
+++ b/commons/observability/manager.go
@@ -1,0 +1,250 @@
+package observability
+
+import (
+	"sync"
+
+	apiobs "gocache/api/observability"
+)
+
+// ShardedOperationTrackerManager is the singleton common
+// OperationTrackerManager implementation. It owns a fixed set of pre-created
+// tracker shards and routes each internal operation identity to exactly one
+// shard tracker. The manager stores telemetry requests/state for later FIFO
+// sidecar reaping; it does not materialize logs/events, call zerolog, build GCPC
+// payloads, or fan out to plugins.
+type ShardedOperationTrackerManager struct {
+	trackers []apiobs.OperationTracker
+	drainers []telemetryRecorder
+	contexts connectionContextStore
+}
+
+// NewShardedOperationTrackerManager returns a singleton manager configured with
+// shardCount pre-created tracker shards. Get is then only shard-index math plus
+// array lookup, with no lazy creation mutex on the submit path.
+func NewShardedOperationTrackerManager(shardCount, ringCapacity int) *ShardedOperationTrackerManager {
+	if shardCount < 1 {
+		shardCount = 1
+	}
+	manager := &ShardedOperationTrackerManager{
+		trackers: make([]apiobs.OperationTracker, shardCount),
+		drainers: make([]telemetryRecorder, shardCount),
+	}
+	for i := range manager.trackers {
+		recorder := newMultiProducerRecorder(ringCapacity)
+		manager.trackers[i] = newOperationTracker(recorder)
+		manager.drainers[i] = recorder
+	}
+	manager.contexts.init()
+	return manager
+}
+
+func (m *ShardedOperationTrackerManager) Get(operation apiobs.InternalOperationIdentity) apiobs.OperationTracker {
+	return m.trackers[shardIndex(operation, len(m.trackers))]
+}
+
+func (m *ShardedOperationTrackerManager) UpdateConnectionContext(connection apiobs.ConnectionIdentity, pairs ...[]byte) apiobs.ConnectionContextVersion {
+	return m.contexts.update(connection, pairs)
+}
+
+func (m *ShardedOperationTrackerManager) RemoveConnectionContext(connection apiobs.ConnectionIdentity, keys ...[]byte) apiobs.ConnectionContextVersion {
+	return m.contexts.remove(connection, keys)
+}
+
+func (m *ShardedOperationTrackerManager) PinCurrentConnectionContextVersion(connection apiobs.ConnectionIdentity) apiobs.ConnectionContextVersion {
+	return m.contexts.pinCurrent(connection)
+}
+
+func (m *ShardedOperationTrackerManager) RetainConnectionContextVersion(version apiobs.ConnectionContextVersion) bool {
+	return m.contexts.retain(version)
+}
+
+func (m *ShardedOperationTrackerManager) ReleaseConnectionContextVersion(version apiobs.ConnectionContextVersion) bool {
+	return m.contexts.release(version)
+}
+
+func (m *ShardedOperationTrackerManager) VisitConnectionContextVersion(version apiobs.ConnectionContextVersion, visitor apiobs.ConnectionContextVisitor) bool {
+	return m.contexts.visit(version, visitor)
+}
+
+func (m *ShardedOperationTrackerManager) ShardCount() int {
+	return len(m.trackers)
+}
+
+func (m *ShardedOperationTrackerManager) DroppedRecords() uint64 {
+	var dropped uint64
+	for _, tracker := range m.trackers {
+		dropped += tracker.DroppedRecords()
+	}
+	return dropped
+}
+
+// DrainShard drains accepted records from a pre-created tracker shard in FIFO
+// order. It is the common worker surface used by tests and later server-owned
+// reap callbacks that fold context mutations before subsequent log/event
+// materialization; it is not part of the API contract exposed to plugins.
+func (m *ShardedOperationTrackerManager) DrainShard(index int, fn func(apiobs.TelemetryRecord)) int {
+	if index < 0 || index >= len(m.drainers) {
+		return 0
+	}
+	return m.drainers[index].drain(fn)
+}
+
+type connectionContextStore struct {
+	mu       sync.Mutex
+	next     uint64
+	current  map[apiobs.ConnectionIdentity]apiobs.ConnectionContextVersion
+	versions map[apiobs.ConnectionContextVersion]*connectionContextVersion
+}
+
+type connectionContextVersion struct {
+	connection apiobs.ConnectionIdentity
+	current    bool
+	refs       uint64
+	pairs      map[string]string
+}
+
+func (s *connectionContextStore) init() {
+	s.current = make(map[apiobs.ConnectionIdentity]apiobs.ConnectionContextVersion)
+	s.versions = make(map[apiobs.ConnectionContextVersion]*connectionContextVersion)
+}
+
+func (s *connectionContextStore) update(connection apiobs.ConnectionIdentity, pairs [][]byte) apiobs.ConnectionContextVersion {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	base := s.currentPairsLocked(connection)
+	next := clonePairs(base, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		next[string(pairs[i])] = string(pairs[i+1])
+	}
+	return s.replaceCurrentLocked(connection, next)
+}
+
+func (s *connectionContextStore) remove(connection apiobs.ConnectionIdentity, keys [][]byte) apiobs.ConnectionContextVersion {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	base := s.currentPairsLocked(connection)
+	if base == nil {
+		return 0
+	}
+	next := clonePairs(base, 0)
+	for _, key := range keys {
+		delete(next, string(key))
+	}
+	return s.replaceCurrentLocked(connection, next)
+}
+
+func (s *connectionContextStore) pinCurrent(connection apiobs.ConnectionIdentity) apiobs.ConnectionContextVersion {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	version := s.current[connection]
+	if version == 0 {
+		return 0
+	}
+	s.versions[version].refs++
+	return version
+}
+
+func (s *connectionContextStore) retain(version apiobs.ConnectionContextVersion) bool {
+	if version == 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	entry, ok := s.versions[version]
+	if !ok {
+		return false
+	}
+	entry.refs++
+	return true
+}
+
+func (s *connectionContextStore) release(version apiobs.ConnectionContextVersion) bool {
+	if version == 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	entry, ok := s.versions[version]
+	if !ok {
+		return false
+	}
+	if entry.refs > 0 {
+		entry.refs--
+	}
+	if entry.refs == 0 && !entry.current {
+		delete(s.versions, version)
+	}
+	return true
+}
+
+func (s *connectionContextStore) visit(version apiobs.ConnectionContextVersion, visitor apiobs.ConnectionContextVisitor) bool {
+	if version == 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensureLocked()
+	entry, ok := s.versions[version]
+	if !ok {
+		return false
+	}
+	if visitor == nil {
+		return true
+	}
+	for key, value := range entry.pairs {
+		if !visitor(key, value) {
+			return true
+		}
+	}
+	return true
+}
+
+func (s *connectionContextStore) ensureLocked() {
+	if s.current == nil || s.versions == nil {
+		s.init()
+	}
+}
+
+func (s *connectionContextStore) currentPairsLocked(connection apiobs.ConnectionIdentity) map[string]string {
+	version := s.current[connection]
+	if version == 0 {
+		return nil
+	}
+	return s.versions[version].pairs
+}
+
+func (s *connectionContextStore) replaceCurrentLocked(connection apiobs.ConnectionIdentity, pairs map[string]string) apiobs.ConnectionContextVersion {
+	old := s.current[connection]
+	if old != 0 {
+		entry := s.versions[old]
+		entry.current = false
+		if entry.refs == 0 {
+			delete(s.versions, old)
+		}
+	}
+	s.next++
+	version := apiobs.ConnectionContextVersion(s.next)
+	s.current[connection] = version
+	s.versions[version] = &connectionContextVersion{
+		connection: connection,
+		current:    true,
+		pairs:      pairs,
+	}
+	return version
+}
+
+func clonePairs(base map[string]string, extra int) map[string]string {
+	if extra < 0 {
+		extra = 0
+	}
+	clone := make(map[string]string, len(base)+extra)
+	for key, value := range base {
+		clone[key] = value
+	}
+	return clone
+}

--- a/commons/observability/recorder.go
+++ b/commons/observability/recorder.go
@@ -1,0 +1,216 @@
+package observability
+
+import (
+	"sync/atomic"
+
+	apiobs "gocache/api/observability"
+)
+
+const cacheLineBytes = 64
+
+type telemetryRecorder interface {
+	RecordTelemetry(apiobs.TelemetryRecord) bool
+	DroppedRecords() uint64
+	drain(func(apiobs.TelemetryRecord)) int
+}
+
+// NewSingleProducerTelemetryRecorder returns a bounded, non-blocking recorder
+// intended for one producer and one consumer. Shared shard trackers should use
+// the multi-producer recorder hidden behind ShardedOperationTrackerManager.
+func NewSingleProducerTelemetryRecorder(capacity int) apiobs.TelemetryRecorder {
+	return newSingleProducerRecorder(capacity)
+}
+
+func newSingleProducerRecorder(capacity int) *singleProducerRecorder {
+	return &singleProducerRecorder{ring: newRing(capacity)}
+}
+
+type singleProducerRecorder struct {
+	ring *ring
+}
+
+func (r *singleProducerRecorder) RecordTelemetry(record apiobs.TelemetryRecord) bool {
+	return r.ring.push(record)
+}
+
+func (r *singleProducerRecorder) DroppedRecords() uint64 {
+	return r.ring.dropped()
+}
+
+func (r *singleProducerRecorder) drain(fn func(apiobs.TelemetryRecord)) int {
+	return r.ring.drain(fn)
+}
+
+type ring struct {
+	mask    uint64
+	records []apiobs.TelemetryRecord
+	_       [cacheLineBytes - 8]byte
+	head    uint64
+	_       [cacheLineBytes - 8]byte
+	tail    uint64
+	_       [cacheLineBytes - 8]byte
+	drops   uint64
+}
+
+func newRing(capacity int) *ring {
+	if capacity < 1 {
+		capacity = 1
+	}
+	size := 1
+	for size < capacity {
+		size <<= 1
+	}
+	return &ring{mask: uint64(size - 1), records: make([]apiobs.TelemetryRecord, size)}
+}
+
+func (r *ring) push(record apiobs.TelemetryRecord) bool {
+	tail := r.tail
+	if tail-atomic.LoadUint64(&r.head) >= uint64(len(r.records)) {
+		atomic.AddUint64(&r.drops, 1)
+		return false
+	}
+	r.records[tail&r.mask] = record
+	atomic.StoreUint64(&r.tail, tail+1)
+	return true
+}
+
+func (r *ring) pop(record *apiobs.TelemetryRecord) bool {
+	head := r.head
+	if head == atomic.LoadUint64(&r.tail) {
+		return false
+	}
+	*record = r.records[head&r.mask]
+	atomic.StoreUint64(&r.head, head+1)
+	return true
+}
+
+func (r *ring) drain(fn func(apiobs.TelemetryRecord)) int {
+	var record apiobs.TelemetryRecord
+	count := 0
+	for r.pop(&record) {
+		fn(record)
+		count++
+	}
+	return count
+}
+
+func (r *ring) dropped() uint64 {
+	return atomic.LoadUint64(&r.drops)
+}
+
+func newMultiProducerRecorder(capacity int) *multiProducerRecorder {
+	return &multiProducerRecorder{ring: newMultiProducerRing(capacity)}
+}
+
+type multiProducerRecorder struct {
+	ring *multiProducerRing
+}
+
+func (r *multiProducerRecorder) RecordTelemetry(record apiobs.TelemetryRecord) bool {
+	return r.ring.push(record)
+}
+
+func (r *multiProducerRecorder) DroppedRecords() uint64 {
+	return r.ring.dropped()
+}
+
+func (r *multiProducerRecorder) drain(fn func(apiobs.TelemetryRecord)) int {
+	return r.ring.drain(fn)
+}
+
+type multiProducerRing struct {
+	mask    uint64
+	records []multiProducerRingSlot
+	_       [cacheLineBytes - 8]byte
+	head    uint64
+	_       [cacheLineBytes - 8]byte
+	tail    uint64
+	_       [cacheLineBytes - 8]byte
+	drops   uint64
+}
+
+type multiProducerRingSlot struct {
+	sequence uint64
+	record   apiobs.TelemetryRecord
+}
+
+func newMultiProducerRing(capacity int) *multiProducerRing {
+	if capacity < 1 {
+		capacity = 1
+	}
+	size := 1
+	for size < capacity {
+		size <<= 1
+	}
+	ring := &multiProducerRing{mask: uint64(size - 1), records: make([]multiProducerRingSlot, size)}
+	for i := range ring.records {
+		ring.records[i].sequence = uint64(i)
+	}
+	return ring
+}
+
+func (r *multiProducerRing) push(record apiobs.TelemetryRecord) bool {
+	pos := atomic.LoadUint64(&r.tail)
+	for {
+		slot := &r.records[pos&r.mask]
+		sequence := atomic.LoadUint64(&slot.sequence)
+		delta := int64(sequence) - int64(pos)
+		if delta == 0 {
+			if atomic.CompareAndSwapUint64(&r.tail, pos, pos+1) {
+				slot.record = record
+				atomic.StoreUint64(&slot.sequence, pos+1)
+				return true
+			}
+			pos = atomic.LoadUint64(&r.tail)
+			continue
+		}
+		if delta < 0 {
+			atomic.AddUint64(&r.drops, 1)
+			return false
+		}
+		pos = atomic.LoadUint64(&r.tail)
+	}
+}
+
+func (r *multiProducerRing) pop(record *apiobs.TelemetryRecord) bool {
+	pos := atomic.LoadUint64(&r.head)
+	for {
+		slot := &r.records[pos&r.mask]
+		sequence := atomic.LoadUint64(&slot.sequence)
+		delta := int64(sequence) - int64(pos+1)
+		if delta == 0 {
+			if atomic.CompareAndSwapUint64(&r.head, pos, pos+1) {
+				*record = slot.record
+				atomic.StoreUint64(&slot.sequence, pos+r.mask+1)
+				return true
+			}
+			pos = atomic.LoadUint64(&r.head)
+			continue
+		}
+		if delta < 0 {
+			return false
+		}
+		pos = atomic.LoadUint64(&r.head)
+	}
+}
+
+func (r *multiProducerRing) drain(fn func(apiobs.TelemetryRecord)) int {
+	var record apiobs.TelemetryRecord
+	count := 0
+	for r.pop(&record) {
+		fn(record)
+		count++
+	}
+	return count
+}
+
+func (r *multiProducerRing) dropped() uint64 {
+	return atomic.LoadUint64(&r.drops)
+}
+
+func shardIndex(identity apiobs.InternalOperationIdentity, shardCount int) int {
+	if shardCount <= 1 {
+		return 0
+	}
+	return int(uint64(identity) % uint64(shardCount))
+}

--- a/commons/observability/recorder_test.go
+++ b/commons/observability/recorder_test.go
@@ -1,0 +1,310 @@
+package observability
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	apiobs "gocache/api/observability"
+)
+
+func TestSingleProducerRecorderFIFO(t *testing.T) {
+	recorder := newSingleProducerRecorder(8)
+	tracker := newOperationTracker(recorder)
+	parent := apiobs.NewParentRef("parent-op")
+	version := apiobs.ConnectionContextVersion(10)
+
+	if !tracker.StartOperation(1, parent, version) {
+		t.Fatal("StartOperation should be accepted")
+	}
+	if !tracker.StartCommand(1, []byte("GET"), []byte("key:1")) {
+		t.Fatal("StartCommand should be accepted")
+	}
+	if !tracker.FinishCommand(1, 0) {
+		t.Fatal("FinishCommand should be accepted")
+	}
+	if !tracker.FinishOperation(1) {
+		t.Fatal("FinishOperation should be accepted")
+	}
+
+	var got []apiobs.TelemetryRecord
+	recorder.drain(func(record apiobs.TelemetryRecord) {
+		got = append(got, record)
+	})
+
+	wantKinds := []apiobs.TelemetryRecordKind{
+		apiobs.TelemetryRecordOperationStart,
+		apiobs.TelemetryRecordCommandStart,
+		apiobs.TelemetryRecordCommandFinish,
+		apiobs.TelemetryRecordOperationFinish,
+	}
+	if len(got) != len(wantKinds) {
+		t.Fatalf("drained %d records, want %d", len(got), len(wantKinds))
+	}
+	for i, want := range wantKinds {
+		if got[i].Kind != want {
+			t.Fatalf("record[%d].Kind = %v, want %v", i, got[i].Kind, want)
+		}
+	}
+	if got[0].ContextVersion != version {
+		t.Fatalf("operation start context version = %d, want %d", got[0].ContextVersion, version)
+	}
+	if got[0].Parent.String() != "parent-op" {
+		t.Fatalf("operation parent = %q, want parent-op", got[0].Parent.String())
+	}
+	if string(got[1].NameBytes()) != "GET" {
+		t.Fatalf("command name = %q, want GET", got[1].NameBytes())
+	}
+	if string(got[1].PayloadBytes()) != "key:1" {
+		t.Fatalf("command payload = %q, want key:1", got[1].PayloadBytes())
+	}
+}
+
+func TestSingleProducerRecorderDropsWhenFull(t *testing.T) {
+	recorder := NewSingleProducerTelemetryRecorder(1)
+	if !recorder.RecordTelemetry(apiobs.NewTelemetryRecord(apiobs.TelemetryRecordEvent, 1)) {
+		t.Fatal("first record should fit")
+	}
+	if recorder.RecordTelemetry(apiobs.NewTelemetryRecord(apiobs.TelemetryRecordEvent, 2)) {
+		t.Fatal("second record should drop when capacity is one")
+	}
+	if dropped := recorder.DroppedRecords(); dropped != 1 {
+		t.Fatalf("DroppedRecords() = %d, want 1", dropped)
+	}
+}
+
+func TestShardIndexRouteStableByIdentity(t *testing.T) {
+	for identity := apiobs.InternalOperationIdentity(1); identity < 32; identity++ {
+		first := shardIndex(identity, 8)
+		for range 10 {
+			if got := shardIndex(identity, 8); got != first {
+				t.Fatalf("shardIndex(%d, 8) changed from %d to %d", identity, first, got)
+			}
+		}
+	}
+	if got := shardIndex(99, 0); got != 0 {
+		t.Fatalf("shardIndex with zero shards = %d, want 0", got)
+	}
+}
+
+func TestTelemetryTrackerCopiesNamePayloadAndFields(t *testing.T) {
+	recorder := newSingleProducerRecorder(4)
+	tracker := newOperationTracker(recorder)
+	message := []byte("original-message")
+	key := []byte("status")
+	value := []byte("ok")
+	if !tracker.Log(1, apiobs.TelemetryLogLevelDebug, message, key, value) {
+		t.Fatal("Log should be accepted")
+	}
+	copy(message, "mutated-message")
+	copy(value, "no")
+
+	var got apiobs.TelemetryRecord
+	if !recorder.ring.pop(&got) {
+		t.Fatal("expected one record")
+	}
+	if string(got.NameBytes()) != "original-message" {
+		t.Fatalf("log message = %q, want original-message", got.NameBytes())
+	}
+	if got.Level != apiobs.TelemetryLogLevelDebug {
+		t.Fatalf("log level = %v, want debug", got.Level)
+	}
+	if got.Payload[0] != 1 {
+		t.Fatalf("packed field count = %d, want 1", got.Payload[0])
+	}
+}
+
+func TestTelemetryTrackerPacksEventAndContextMutations(t *testing.T) {
+	recorder := newSingleProducerRecorder(4)
+	tracker := newOperationTracker(recorder)
+	if !tracker.Event(1, []byte("custom.plugin.event"), []byte("tenant"), []byte("acme")) {
+		t.Fatal("Event should be accepted")
+	}
+	if !tracker.ContextUpdate(1, []byte("tenant"), []byte("acme"), []byte("role"), []byte("reader")) {
+		t.Fatal("ContextUpdate should be accepted")
+	}
+	if !tracker.ContextRemove(1, []byte("role")) {
+		t.Fatal("ContextRemove should be accepted")
+	}
+
+	var event apiobs.TelemetryRecord
+	if !recorder.ring.pop(&event) {
+		t.Fatal("expected event record")
+	}
+	if event.Kind != apiobs.TelemetryRecordEvent {
+		t.Fatalf("kind = %v, want event", event.Kind)
+	}
+	if string(event.NameBytes()) != "custom.plugin.event" {
+		t.Fatalf("event name = %q, want custom.plugin.event", event.NameBytes())
+	}
+	if event.Payload[0] != 1 {
+		t.Fatalf("event field count = %d, want 1", event.Payload[0])
+	}
+
+	var update apiobs.TelemetryRecord
+	if !recorder.ring.pop(&update) {
+		t.Fatal("expected update record")
+	}
+	if update.Kind != apiobs.TelemetryRecordContextUpdate {
+		t.Fatalf("kind = %v, want context update", update.Kind)
+	}
+	if update.Payload[0] != 2 {
+		t.Fatalf("packed pair count = %d, want 2", update.Payload[0])
+	}
+
+	var remove apiobs.TelemetryRecord
+	if !recorder.ring.pop(&remove) {
+		t.Fatal("expected remove record")
+	}
+	if remove.Kind != apiobs.TelemetryRecordContextRemove {
+		t.Fatalf("kind = %v, want context remove", remove.Kind)
+	}
+	if remove.Payload[0] != 1 {
+		t.Fatalf("packed remove count = %d, want 1", remove.Payload[0])
+	}
+}
+
+func TestTelemetryTrackerContextMutationRecordsDrainBeforeLaterLogs(t *testing.T) {
+	recorder := newSingleProducerRecorder(8)
+	tracker := newOperationTracker(recorder)
+
+	if !tracker.ContextUpdate(7, []byte("tenant"), []byte("acme")) {
+		t.Fatal("ContextUpdate should be accepted")
+	}
+	if !tracker.Log(7, apiobs.TelemetryLogLevelInfo, []byte("tenant active")) {
+		t.Fatal("first Log should be accepted")
+	}
+	if !tracker.ContextRemove(7, []byte("tenant")) {
+		t.Fatal("ContextRemove should be accepted")
+	}
+	if !tracker.Log(7, apiobs.TelemetryLogLevelInfo, []byte("tenant removed")) {
+		t.Fatal("second Log should be accepted")
+	}
+
+	var got []apiobs.TelemetryRecordKind
+	recorder.drain(func(record apiobs.TelemetryRecord) {
+		got = append(got, record.Kind)
+	})
+
+	want := []apiobs.TelemetryRecordKind{
+		apiobs.TelemetryRecordContextUpdate,
+		apiobs.TelemetryRecordLog,
+		apiobs.TelemetryRecordContextRemove,
+		apiobs.TelemetryRecordLog,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("drained %d records, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("record[%d].Kind = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestShardedManagerRoutesPrecreatedTrackersByShard(t *testing.T) {
+	manager := NewShardedOperationTrackerManager(4, 8)
+	first := manager.Get(1)
+	sameShard := manager.Get(5)
+	differentShard := manager.Get(2)
+	if first != sameShard {
+		t.Fatal("operations 1 and 5 should route to the same pre-created shard tracker")
+	}
+	if first == differentShard {
+		t.Fatal("operations 1 and 2 should route to different shard trackers")
+	}
+	if manager.ShardCount() != 4 {
+		t.Fatalf("ShardCount() = %d, want 4", manager.ShardCount())
+	}
+}
+
+func TestShardedManagerDrainsByShard(t *testing.T) {
+	manager := NewShardedOperationTrackerManager(4, 8)
+	tracker := manager.Get(5)
+	if !tracker.StartCommand(5, []byte("PLUGIN.CMD"), []byte("arg")) {
+		t.Fatal("StartCommand should be accepted")
+	}
+	var got []apiobs.TelemetryRecord
+	if drained := manager.DrainShard(1, func(record apiobs.TelemetryRecord) {
+		got = append(got, record)
+	}); drained != 1 {
+		t.Fatalf("DrainShard drained %d records, want 1", drained)
+	}
+	if len(got) != 1 || got[0].Operation != 5 {
+		t.Fatalf("drained records = %+v, want operation 5", got)
+	}
+}
+
+func TestConnectionContextVersionsArePinnedImmutable(t *testing.T) {
+	manager := NewShardedOperationTrackerManager(2, 8)
+	conn := apiobs.ConnectionIdentity(7)
+	v1 := manager.UpdateConnectionContext(conn, []byte("tenant"), []byte("acme"), []byte("role"), []byte("reader"))
+	pinned := manager.PinCurrentConnectionContextVersion(conn)
+	if pinned != v1 {
+		t.Fatalf("pinned version = %d, want %d", pinned, v1)
+	}
+	v2 := manager.UpdateConnectionContext(conn, []byte("tenant"), []byte("globex"))
+	if v2 == v1 {
+		t.Fatal("context update should create a new version")
+	}
+
+	gotV1 := collectContext(t, manager, v1)
+	if gotV1["tenant"] != "acme" || gotV1["role"] != "reader" {
+		t.Fatalf("v1 context = %+v, want tenant=acme role=reader", gotV1)
+	}
+	gotV2 := collectContext(t, manager, v2)
+	if gotV2["tenant"] != "globex" || gotV2["role"] != "reader" {
+		t.Fatalf("v2 context = %+v, want tenant=globex role=reader", gotV2)
+	}
+	if !manager.ReleaseConnectionContextVersion(v1) {
+		t.Fatal("release of pinned v1 should succeed")
+	}
+	if manager.VisitConnectionContextVersion(v1, nil) {
+		t.Fatal("released non-current v1 should be reclaimed")
+	}
+}
+
+func collectContext(t *testing.T, manager *ShardedOperationTrackerManager, version apiobs.ConnectionContextVersion) map[string]string {
+	t.Helper()
+	got := make(map[string]string)
+	if !manager.VisitConnectionContextVersion(version, func(key, value string) bool {
+		got[key] = value
+		return true
+	}) {
+		t.Fatalf("version %d not found", version)
+	}
+	return got
+}
+
+func TestShardedManagerMultiProducerRace(t *testing.T) {
+	const producers = 8
+	const perProducer = 128
+	const total = producers * perProducer
+	manager := NewShardedOperationTrackerManager(1, total*2)
+	tracker := manager.Get(1)
+
+	var wg sync.WaitGroup
+	wg.Add(producers)
+	for producer := range producers {
+		producer := producer
+		go func() {
+			defer wg.Done()
+			for i := range perProducer {
+				operation := apiobs.InternalOperationIdentity(producer*perProducer + i + 1)
+				for !tracker.StartCommand(operation, []byte("PING"), nil) {
+					runtime.Gosched()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	var drained int64
+	manager.DrainShard(0, func(apiobs.TelemetryRecord) {
+		atomic.AddInt64(&drained, 1)
+	})
+	if got := atomic.LoadInt64(&drained); got != total {
+		t.Fatalf("drained %d records, want %d", got, total)
+	}
+}

--- a/commons/observability/tracker.go
+++ b/commons/observability/tracker.go
@@ -1,0 +1,134 @@
+package observability
+
+import (
+	"time"
+
+	apiobs "gocache/api/observability"
+)
+
+// NewSingleProducerOperationTracker returns an injectable OperationTracker whose
+// concrete implementation stays hidden inside commons/observability.
+func NewSingleProducerOperationTracker(capacity int) apiobs.OperationTracker {
+	return newOperationTracker(newSingleProducerRecorder(capacity))
+}
+
+type operationTracker struct {
+	recorder telemetryRecorder
+}
+
+func newOperationTracker(recorder telemetryRecorder) *operationTracker {
+	return &operationTracker{recorder: recorder}
+}
+
+func (t *operationTracker) RecordTelemetry(record apiobs.TelemetryRecord) bool {
+	return t.recorder.RecordTelemetry(record)
+}
+
+func (t *operationTracker) DroppedRecords() uint64 {
+	return t.recorder.DroppedRecords()
+}
+
+func (t *operationTracker) StartOperation(operation apiobs.InternalOperationIdentity, parent apiobs.ParentRef, contextVersion apiobs.ConnectionContextVersion) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordOperationStart, operation)
+	record.Parent = parent
+	record.ContextVersion = contextVersion
+	record.TimestampUnixNano = nowUnixNano()
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) FinishOperation(operation apiobs.InternalOperationIdentity) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordOperationFinish, operation)
+	record.TimestampUnixNano = nowUnixNano()
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) StartCommand(operation apiobs.InternalOperationIdentity, commandName []byte, payload []byte) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordCommandStart, operation)
+	record.TimestampUnixNano = nowUnixNano()
+	record.SetName(commandName)
+	record.SetPayload(payload)
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) FinishCommand(operation apiobs.InternalOperationIdentity, resultCode int64) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordCommandFinish, operation)
+	record.Number = resultCode
+	record.TimestampUnixNano = nowUnixNano()
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) Log(operation apiobs.InternalOperationIdentity, level apiobs.TelemetryLogLevel, message []byte, fields ...[]byte) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordLog, operation)
+	record.Level = level
+	record.TimestampUnixNano = nowUnixNano()
+	record.SetName(message)
+	record.PayloadLen = uint16(packKeyValues(record.Payload[:], fields))
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) Event(operation apiobs.InternalOperationIdentity, eventName []byte, fields ...[]byte) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordEvent, operation)
+	record.TimestampUnixNano = nowUnixNano()
+	record.SetName(eventName)
+	record.PayloadLen = uint16(packKeyValues(record.Payload[:], fields))
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) ContextUpdate(operation apiobs.InternalOperationIdentity, pairs ...[]byte) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordContextUpdate, operation)
+	record.TimestampUnixNano = nowUnixNano()
+	record.PayloadLen = uint16(packKeyValues(record.Payload[:], pairs))
+	return t.RecordTelemetry(record)
+}
+
+func (t *operationTracker) ContextRemove(operation apiobs.InternalOperationIdentity, keys ...[]byte) bool {
+	record := apiobs.NewTelemetryRecord(apiobs.TelemetryRecordContextRemove, operation)
+	record.TimestampUnixNano = nowUnixNano()
+	record.PayloadLen = uint16(packKeys(record.Payload[:], keys))
+	return t.RecordTelemetry(record)
+}
+
+func nowUnixNano() int64 { return time.Now().UnixNano() }
+
+func packKeyValues(dst []byte, pairs [][]byte) int {
+	if len(dst) == 0 {
+		return 0
+	}
+	pos := 1
+	count := 0
+	for i := 0; i+1 < len(pairs); i += 2 {
+		key := pairs[i]
+		value := pairs[i+1]
+		if len(key) > 255 || len(value) > 255 || pos+2+len(key)+len(value) > len(dst) {
+			break
+		}
+		dst[pos] = byte(len(key))
+		pos++
+		pos += copy(dst[pos:], key)
+		dst[pos] = byte(len(value))
+		pos++
+		pos += copy(dst[pos:], value)
+		count++
+	}
+	dst[0] = byte(count)
+	return pos
+}
+
+func packKeys(dst []byte, keys [][]byte) int {
+	if len(dst) == 0 {
+		return 0
+	}
+	pos := 1
+	count := 0
+	for _, key := range keys {
+		if len(key) > 255 || pos+1+len(key) > len(dst) {
+			break
+		}
+		dst[pos] = byte(len(key))
+		pos++
+		pos += copy(dst[pos:], key)
+		count++
+	}
+	dst[0] = byte(count)
+	return pos
+}

--- a/docs/adr/0029-operationtracker-sidecar-low-overhead-telemetry.md
+++ b/docs/adr/0029-operationtracker-sidecar-low-overhead-telemetry.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0029 OperationTracker Sidecar for Low-Overhead Telemetry
 description: Move operation telemetry production off the command goroutine through a low-allocation OperationTracker submit path and worker-owned telemetry projection
-status: proposed
+status: accepted
 date: 2026-06-01
 deciders: [witherxse]
 related:
@@ -32,7 +32,7 @@ This ADR is intentionally the umbrella performance decision. Focused follow-up A
 
 GoCache introduces an `OperationTracker` sidecar pattern for runtime telemetry. The command goroutine submits compact, pointer-free operation records into a bounded tracker path and returns to command execution; worker goroutines own the expensive work of telemetry-context folding, typed event/log projection, and GCPC/protobuf materialization. Workers must not turn this into server-owned semantic grouping, server-owned aggregation, or exporter-specific telemetry calculation.
 
-The public package for plugin-safe observability contracts is `api/observability`, and it contains interfaces plus stable value contracts only. Reusable concrete tracker, ring, sharding, and operation-identity strategy primitives that both the server and plugin tooling can share live under `commons/observability`. Concrete server wiring, connection context version stores, worker scheduling, subscriber queues, and projection internals remain server-owned implementation under `pkg/`. Plugins interact through SDK/API facades, common primitives where appropriate, and GCPC messages; they do not import `pkg/operations`, `pkg/events`, `pkg/plugin`, `pkg/workers`, or any server-internal tracker implementation.
+The public package for plugin-safe observability contracts is `api/observability`, and it contains interfaces plus stable value contracts only. Reusable concrete tracker, ring, sharding, generic context-version, FIFO drain, and operation-identity strategy primitives that both the server and plugin tooling can share live under `commons/observability`. Concrete server wiring, `ClientContext` extraction, redaction, worker scheduling, subscriber queues, GCPC/log projection, and zerolog emission remain server-owned implementation under `pkg/`. Plugins interact through SDK/API facades, common primitives where appropriate, and GCPC messages; they do not import `pkg/operations`, `pkg/events`, `pkg/plugin`, `pkg/workers`, or any server-internal tracker implementation.
 
 The sidecar design separates telemetry context from Go `context.Context`. Go `context.Context` remains in APIs that need cancellation, deadlines, or request lifetime. Telemetry context becomes operation-associated data managed by `OperationTracker` and carried as immutable snapshots, context patches, or typed event/log fields depending on the boundary. Connection context version references are server-only: the server captures the connection-context version current at operation start, while IPC plugins receive serialized filtered context or provide their own producer context when they create plugin-owned operations.
 
@@ -74,15 +74,17 @@ Telemetry is fire-and-forget and may drop under overload. It is not an audit log
 
 Warning/error logs and lifecycle records may receive priority in implementation, but they remain telemetry signals unless a later durable/audit event system explicitly reclassifies them.
 
-## Priority Review Gates Before Implementation
+## Accepted Scope and Follow-up Gates
 
-This ADR remains `proposed` until the following user-visible gates are resolved or explicitly deferred:
+Accepted on 2026-06-02 for Subplan A: `api/observability` plugin-safe contracts and `commons/observability` reusable tracker, ring, identity, FIFO drain, and generic context-version primitives. Package-level submit-path benchmarks now defend the API/commons surface as zero-allocation. Server runtime wiring remains Subplan B.
 
-1. **Operation identity wiring**: define how the server-selected UUIDv7 or W3C strategy is exposed through API/commons, injected into IPC plugins through GCPC registration/configuration, and reused by embedded plugins.
+The following gates remain before full server runtime telemetry is complete:
+
+1. **Operation identity wiring**: extend the server-selected UUIDv7 or W3C strategy through IPC plugin registration/configuration and embedded plugin setup.
 2. **GCPC typed-event projection**: align the worker projection target with ADR-0030's typed oneof events plus common context/source fields.
-3. **Context snapshot/version proof**: align with ADR-0032 so command-time context is event-time correct and GCPC receives serialized/dereferenced context, not server version ids.
-4. **Performance proof**: require package benchmarks plus Docker benchmark before/after evidence for submit-path allocation, p99 latency, overload visibility, and IPC projection cost before accepting the implementation.
-5. **Common/API split**: keep `api/observability` as interfaces/value contracts, `commons/observability` as reusable engine primitives and strategy implementations, and server projection/context-version state in `pkg/` as described by ADR-0033.
+3. **Server context materialization**: align server `ClientContext` extraction, redaction, and projection with ADR-0032 so GCPC receives serialized/dereferenced context, not server version ids.
+4. **End-to-end performance proof**: require Docker benchmark before/after evidence for command p99 latency, overload visibility, and IPC projection cost before claiming runtime throughput improvement.
+5. **Server/API/common split enforcement**: keep `api/observability` as interfaces/value contracts, `commons/observability` as reusable engine primitives and strategy implementations, and server projection/context-version state in `pkg/` as described by ADR-0033.
 
 ## Alternatives Considered
 

--- a/docs/adr/0032-telemetry-context-version-ownership.md
+++ b/docs/adr/0032-telemetry-context-version-ownership.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0032 Telemetry Context Version Ownership
 description: Keep server context versions internal while exposing event-time serialized context buckets to plugins
-status: proposed
+status: accepted
 date: 2026-06-01
 deciders: [witherxse]
 related:
@@ -25,9 +25,9 @@ This ADR covers telemetry context ownership only. It does not redefine Go `conte
 
 ## Decision
 
-Server-side `ClientContext` state is converted into a telemetry-relevant base context map at operation start. The operation start record pins the server-only base context version current for that operation. `OperationTracker` workers resolve that version, fold operation-level context update/remove records on top of it in submit order, and project serialized filtered context only when records cross an API, SDK, GCPC, event, or log boundary.
+Server-side `ClientContext` state is converted into a telemetry-relevant base context map at operation start. The operation start record pins the manager-owned base context version current for that operation. `OperationTracker` workers or reap callbacks resolve that version, fold operation-level context update/remove records on top of it in FIFO submit order, and project serialized filtered context only when records cross an API, SDK, GCPC, event, or log boundary.
 
-Connection context version ids are server/worker-local handles. They never cross GCPC as common fields, typed event fields, metadata, or SDK-visible ids. Plugins receive serialized filtered context or typed context buckets, never references to the server version table. Plugin-originated background operations own their own telemetry context and may parent to a server operation by exported operation id when there is real operation causality, but they do not mutate or borrow server connection context versions.
+Connection context version ids are in-process manager/worker-local handles. They never cross GCPC as common fields, typed event fields, metadata, or SDK-visible ids. Plugins receive serialized filtered context or typed context buckets, never references to the version table. Plugin-originated background operations own their own telemetry context and may parent to a server operation by exported operation id when there is real operation causality, but they do not mutate or borrow server connection context versions.
 
 GoCache operation `parent_id` represents GoCache operation causality only. A normal client command is a root operation with empty `parent_id`; connection identity, connection context ancestry, context version ancestry, and command sequencing must not be interpreted as GoCache operation parentage. REX `traceparent` may be mapped by an exporter plugin into external trace/span parentage, but core and `OperationTracker` must not rewrite GoCache `parent_id` from REX metadata.
 
@@ -89,14 +89,16 @@ GCPC carries serialized filtered telemetry context or typed `EventContext` bucke
 
 Redaction and visibility filtering happen before context crosses the plugin/GCPC boundary. Redaction tests must cover sensitive keys in base context, REX connection context, REX command context, and additional context. Context replay is best-effort telemetry; dropped context records may make reconstructed telemetry context incomplete and must not be treated as audit-durable truth.
 
-## Priority Review Gates Before Implementation
+## Accepted Scope and Follow-up Gates
 
-This ADR remains `proposed` until these context-lifecycle gates are resolved or explicitly deferred:
+Accepted on 2026-06-02 for Subplan A's manager-owned context-version primitive and FIFO mutation replay contract in `api/observability` and `commons/observability`. Server-specific `ClientContext` mapping, redaction, GCPC materialization, and version lifetime cleanup remain Subplan B.
+
+The following gates remain before full server integration:
 
 1. **Version lifetime**: define finish, abandon, replay-window, async-retainer, and reaper release rules for pinned base context versions.
 2. **Mutation inputs**: enumerate which `ClientContext`, `RexMeta`, `CmdMeta`, hook, plugin, and operation fields become base context, `rexConnectionContext`, `rexCommandContext`, or `additionalContext`.
 3. **Parent rewrite**: replace current command-parent-to-connection-operation behavior with empty command parents by default and update legacy `conn_1` parent tests/docs accordingly.
-4. **Replay tests**: require delayed-worker, concurrent-mutation, update/remove ordering, and tombstone tests proving event-time context correctness.
+4. **Replay tests**: extend delayed-worker, concurrent-mutation, update/remove ordering, and tombstone tests around server-side projection once Subplan B wiring exists.
 5. **Redaction/filtering tests**: verify sensitive keys are removed before plugin/GCPC materialization across all `EventContext` buckets.
 6. **REX/exporter integration**: prove REX traceparent stays context for exporter mapping and does not rewrite core GoCache `parent_id`.
 

--- a/docs/adr/0033-common-operationtracker-sharding-contract.md
+++ b/docs/adr/0033-common-operationtracker-sharding-contract.md
@@ -1,7 +1,7 @@
 ---
 title: ADR-0033 Common OperationTracker Sharding Contract
 description: Share pointer-free OperationTracker engine primitives from commons while keeping server projection and context-version state internal
-status: proposed
+status: accepted
 date: 2026-06-01
 deciders: [witherxse]
 related:
@@ -24,21 +24,21 @@ This ADR covers package placement, sharding, and the common engine boundary. It 
 
 ## Decision
 
-GoCache places reusable pointer-free OperationTracker engine primitives in `commons/observability`, while keeping server-owned projection, connection context version storage, event/GCPC fanout, subscriber queues, and lifecycle management in `pkg/`. The shared common layer may include record layouts, ring mechanics, shard routing helpers, operation identity strategy implementations, and minimal producer/consumer interfaces. It must not include server connection context state, plugin manager logic, event-bus coupling, or backend/export aggregation.
+GoCache places reusable pointer-free OperationTracker engine primitives in `commons/observability`, while keeping server-owned projection, event/GCPC fanout, subscriber queues, concrete `ClientContext` mapping, redaction, and lifecycle integration in `pkg/`. The shared common layer may include record layouts, ring mechanics, shard routing helpers, operation identity strategy implementations, minimal producer/consumer interfaces, and generic in-memory context-version primitives needed by the manager-owned submit/reap contract. It must not include concrete server connection state, plugin manager logic, event-bus coupling, GCPC/log materialization, zerolog calls, or backend/export aggregation.
 
 `api/observability` remains interface/value-contract only. It defines what plugins and SDK helpers can depend on, not how the server implements the sidecar. `commons/observability` is the reusable implementation layer for code that can safely be shared by server, SDK, embedded plugins, or IPC plugin tooling without importing server internals.
 
 The sidecar runs a configurable number of OperationTracer instances. Records are assigned to tracer instances by the optimized internal operation handle from ADR-0031, using a deterministic sharding rule such as modulo or a stable hash. This keeps a single operation's records on one tracer while distributing concurrent operations across workers. The configured tracer count, ring capacity, and worker scheduling are server configuration and benchmark parameters, not plugin-controlled API.
 
-The common engine remains generic. It submits and drains records; it does not calculate grouped telemetry, aggregate metrics, create traces, export backend-specific data, or own telemetry schemas. Plugins may use common primitives for plugin-local background operation telemetry, but server-side context-version resolution and projection remain server-owned. Plugin-local internal handles are local to the plugin-side engine instance; they are not server internal handles and never cross GCPC.
+The common engine remains generic. It submits and drains records in FIFO order; it does not calculate grouped telemetry, aggregate metrics, create traces, export backend-specific data, or own telemetry schemas. Reap callbacks later convert operation kinds to runtime/GCPC operation output, fold context mutation records into worker-owned context state before subsequent log/event records, and materialize runtime logs/zerolog output off the command goroutine. Plugins may use common primitives for plugin-local background operation telemetry, but server-side `ClientContext` extraction, redaction, GCPC projection, and plugin fanout remain server-owned. Plugin-local internal handles are local to the plugin-side engine instance; they are not server internal handles and never cross GCPC.
 
 ## Contract Shape
 
 ### Package boundary
 
 - `api/observability`: stable value types and interfaces visible to plugins.
-- `commons/observability`: reusable pointer-free records, ring/tracer primitives, shard routing helpers, UUIDv7/W3C identity strategy implementations, and allocation-sensitive tests/benchmarks.
-- `pkg/...`: server OperationTracker sidecar wiring, connection context version store, worker projection, event/GCPC adapters, subscriber queues, overload reporting, and lifecycle/reaper logic.
+- `commons/observability`: reusable pointer-free records, ring/tracer primitives, shard routing helpers, UUIDv7/W3C identity strategy implementations, generic manager-owned context-version primitives, FIFO drain surfaces, and allocation-sensitive tests/benchmarks.
+- `pkg/...`: server OperationTracker sidecar wiring, concrete `ClientContext` to telemetry-context mapping, redaction/filtering, worker projection, event/GCPC adapters, subscriber queues, overload reporting, zerolog/log emission, and lifecycle/reaper scheduling logic.
 - `sdk/...`: plugin ergonomics for starting plugin-owned operations and producing typed records without importing `pkg/`.
 
 ### Sharding
@@ -56,15 +56,17 @@ Telemetry is fire-and-forget and may drop under overload. The common engine shou
 
 This ADR does not turn the server into a telemetry backend or durable audit log. It only defines the common sidecar engine boundary, sharding contract, and minimum visibility expectation for overload.
 
-## Priority Review Gates Before Implementation
+## Accepted Scope and Follow-up Gates
 
-This ADR remains `proposed` until these placement and sharding gates are resolved or explicitly deferred:
+Accepted on 2026-06-02 for Subplan A's `api/observability` and `commons/observability` package split, sharded manager contract, FIFO drain surfaces, identity strategies, generic context-version primitives, and allocation-sensitive package benchmarks. Server projection, GCPC/log materialization, plugin fanout, and lifecycle scheduling remain Subplan B.
 
-1. **Package split**: confirm `api/observability` for plugin-facing interfaces/value contracts, `commons/observability` for reusable engine primitives and identity strategies, and `pkg/` for server projection/context-version state.
-2. **Shard routing key**: align with ADR-0031's internal numeric handle and exported identity mapping.
+The following gates remain before full server integration:
+
+1. **Server wiring**: keep `pkg/` responsible for server `ClientContext` mapping, projection, redaction, GCPC/log emission, plugin fanout, and lifecycle scheduling.
+2. **Shard routing validation**: continue aligning shard routing with ADR-0031's internal numeric handle and exported identity mapping as server wiring adopts the common manager.
 3. **Overload visibility**: define cheap counters, gap metadata, or health-query data that make drop-allowed telemetry visibly incomplete without blocking command execution.
 4. **Plugin-local use**: document that plugin-local handles are never server handles and cannot be used for server operation lookup.
-5. **Benchmarks**: add allocation and throughput benchmarks around common ring/tracer primitives before relying on them in server hot paths.
+5. **Server benchmarks**: extend allocation and throughput benchmarks from common ring/tracer primitives to server hot paths before claiming runtime improvements.
 
 ## Alternatives Considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,7 +2,7 @@
 title: Architecture Decision Records
 description: Index of architectural decisions captured for gocache — Nygard-format ADRs, one per significant decision
 status: living
-last_updated: 2026-06-01
+last_updated: 2026-06-02
 related:
   - Server-Architecture
   - Performance
@@ -58,11 +58,11 @@ proposed → accepted → [deprecated | superseded by ADR-NNNN]
 | [0026](0026-event-traffic-classes-and-backpressure.md) | Event Traffic Classes and Backpressure | proposed | 2026-05-29 |
 | [0027](0027-event-replay-cursors-and-gaps.md) | Event Replay, Cursors, and Gaps | proposed | 2026-05-29 |
 | [0028](0028-operation-observability-and-log-records.md) | Operation Observability and Log Records | proposed | 2026-05-30 |
-| [0029](0029-operationtracker-sidecar-low-overhead-telemetry.md) | OperationTracker Sidecar for Low-Overhead Telemetry | proposed | 2026-06-01 |
+| [0029](0029-operationtracker-sidecar-low-overhead-telemetry.md) | OperationTracker Sidecar for Low-Overhead Telemetry | accepted | 2026-06-01 |
 | [0030](0030-gcpc-v1-observability-context-contract.md) | GCPC v1 Observability Context Contract | proposed | 2026-06-01 |
 | [0031](0031-operation-identity-export-contract.md) | Operation Identity Export Contract | proposed | 2026-06-01 |
-| [0032](0032-telemetry-context-version-ownership.md) | Telemetry Context Version Ownership | proposed | 2026-06-01 |
-| [0033](0033-common-operationtracker-sharding-contract.md) | Common OperationTracker Sharding Contract | proposed | 2026-06-01 |
+| [0032](0032-telemetry-context-version-ownership.md) | Telemetry Context Version Ownership | accepted | 2026-06-01 |
+| [0033](0033-common-operationtracker-sharding-contract.md) | Common OperationTracker Sharding Contract | accepted | 2026-06-01 |
 
 ## Writing a new ADR
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/gammazero/deque v1.2.1
+	github.com/google/uuid v1.6.0
 	github.com/klauspost/compress v1.18.6
 	github.com/rs/zerolog v1.34.0
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -85,7 +86,6 @@ require (
 	github.com/go-task/template v0.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect


### PR DESCRIPTION
## Summary
- add plugin-safe api/observability operation identity, telemetry record, log level, tracker, and manager contracts
- add commons/observability identity strategies, bounded FIFO recorder/tracker primitives, sharded manager, generic context-version store, tests, and benchmarks
- accept ADR-0029, ADR-0032, and ADR-0033 for Subplan A while keeping server/GCPC/log projection as Subplan B

## Verification
- lsp_diagnostics api/observability and commons/observability: 0 errors
- go test -race ./api/... ./commons/...
- scripts/check-plugin-isolation.sh
- go build ./...
- go vet ./...
- go test -race ./...
- go test ./commons/observability -run "^$" -bench "Benchmark(Telemetry|Sharded|Shard)" -benchmem
- staticcheck ./... not run: staticcheck unavailable

## Notes
- Submit-path package benchmarks are 0 B/op and 0 allocs/op for the public tracker/manager paths.
- No end-to-end Docker/RPS improvement is claimed in this PR; that remains Subplan B work.