### PR TITLE
fix(telemetry): deny-by-default privacy filter + router command-path hygiene

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -48,6 +48,29 @@ func IsSecret(key string) bool {
 	return false
 }
 
+// IsTelemetryVisible returns true if a context key should appear in
+// exported telemetry (tmpfs export, OTLP, etc.). The filter is
+// deny-by-default: only server-prefixed keys (_) and shared-prefixed
+// keys (shared.) are visible. Plugin-private keys (<plugin>.<key>) and
+// unknown keys are denied. Secrets (detected by IsSecret) are always
+// denied regardless of tier.
+//
+// This is the single canonical filter for the telemetry submission
+// boundary. Both the drain worker and the pipeline recorder call this
+// function — no local copies are permitted.
+func IsTelemetryVisible(key string) bool {
+	if IsSecret(key) {
+		return false
+	}
+	if strings.HasPrefix(key, ServerPrefix) {
+		return true
+	}
+	if strings.HasPrefix(key, SharedPrefix) {
+		return true
+	}
+	return false
+}
+
 // FilterForPlugin returns the subset of ctx visible to pluginName:
 //   - All "_*" keys (server context)
 //   - All "<pluginName>.*" keys (own namespace)

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -43,6 +43,56 @@ func TestIsSecret(t *testing.T) {
 	}
 }
 
+func TestIsTelemetryVisible(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Server namespace is visible.
+		{"_start_ns", true},
+		{"_operation_id", true},
+		{"_connection_id", true},
+		{"_remote_addr", true},
+
+		// Shared namespace is visible.
+		{"shared.traceparent", true},
+		{"shared.username", true},
+		{"shared.rex.traceparent", true},
+
+		// Plugin-private namespace is hidden.
+		{"auth.cache_hit", false},
+		{"myplugin.internal_state", false},
+		{"instrumentation.span_id", false},
+		{"otherplugin.private_data", false},
+
+		// Secret keys are always hidden.
+		{"secret.token", false},
+		{"_secret.session", false},
+		{"auth.secret.api_key", false},
+		{"shared.secret.jwt", false},
+
+		// Unknown/unprefixed keys are hidden without credential-name guessing.
+		{"random", false},
+		{"foo", false},
+		{"password", false},
+		{"token", false},
+		{"apikey", false},
+
+		// Edge cases.
+		{"", false},
+		{"shared", false},
+		{"_", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := IsTelemetryVisible(tt.key); got != tt.want {
+				t.Errorf("IsTelemetryVisible(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFilterForPlugin(t *testing.T) {
 	ctx := map[string]string{
 		"_start_ns":                   "123",

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	apicommand "gocache/api/command"
+	apictx "gocache/api/context"
 	"gocache/api/events"
 	gcpc "gocache/api/gcpc/v1"
 	apiobs "gocache/api/observability"
@@ -638,6 +639,9 @@ func recordTelemetryContextMap(scope commonobs.OperationScope, values map[string
 		return
 	}
 	for key, value := range values {
+		if !apictx.IsTelemetryVisible(key) {
+			continue
+		}
 		scope.ContextUpdateStrings(key, value)
 	}
 }

--- a/pkg/plugin/router/router.go
+++ b/pkg/plugin/router/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -34,7 +35,10 @@ var requestSeq atomic.Uint64
 
 // NextRequestID returns a new unique request identifier for plugin calls.
 func NextRequestID() string {
-	return fmt.Sprintf("req-%d", requestSeq.Add(1))
+	var buf [24]byte // "req-" (4) + max uint64 digits (20)
+	copy(buf[:4], "req-")
+	b := strconv.AppendUint(buf[:4], requestSeq.Add(1), 10)
+	return string(b)
 }
 
 // PluginRoute describes a single command route to a plugin.
@@ -65,7 +69,7 @@ const (
 // correlated by request_id. Used by both the command router and hook executor.
 type PluginConn struct {
 	conn      *transport.Conn
-	pending   sync.Map // map[requestID]chan *gcpc.EnvelopeV1
+	pending   map[string]chan *gcpc.EnvelopeV1
 	pendingMu sync.Mutex
 
 	sendMu     sync.Mutex
@@ -156,6 +160,7 @@ func (item outboundEnvelope) envelope() *gcpc.EnvelopeV1 {
 func NewPluginConn(name string, conn *transport.Conn) *PluginConn {
 	pc := &PluginConn{
 		conn:       conn,
+		pending:    make(map[string]chan *gcpc.EnvelopeV1),
 		outbound:   make(chan outboundEnvelope, pluginOutboundQueueSize),
 		writerDone: make(chan struct{}),
 		done:       make(chan struct{}),
@@ -492,7 +497,7 @@ func (pc *PluginConn) StartReadLoop() {
 
 func (pc *PluginConn) storePending(requestID string, ch chan *gcpc.EnvelopeV1) {
 	pc.pendingMu.Lock()
-	pc.pending.Store(requestID, ch)
+	pc.pending[requestID] = ch
 	pc.pendingMu.Unlock()
 }
 
@@ -501,11 +506,10 @@ func (pc *PluginConn) drainPending() {
 	pc.pendingMu.Lock()
 	defer pc.pendingMu.Unlock()
 
-	pc.pending.Range(func(key, value any) bool {
-		close(value.(chan *gcpc.EnvelopeV1))
-		pc.pending.Delete(key)
-		return true
-	})
+	for _, ch := range pc.pending {
+		close(ch)
+	}
+	pc.pending = make(map[string]chan *gcpc.EnvelopeV1)
 }
 
 // Deliver dispatches an envelope to the pending channel for the given
@@ -515,8 +519,9 @@ func (pc *PluginConn) Deliver(requestID string, env *gcpc.EnvelopeV1) {
 	pc.pendingMu.Lock()
 	defer pc.pendingMu.Unlock()
 
-	if ch, ok := pc.pending.LoadAndDelete(requestID); ok {
-		ch.(chan *gcpc.EnvelopeV1) <- env
+	if ch, ok := pc.pending[requestID]; ok {
+		delete(pc.pending, requestID)
+		ch <- env
 	}
 }
 
@@ -545,7 +550,7 @@ func (pc *PluginConn) Done() <-chan struct{} {
 // DeletePending removes a pending request (used for cleanup on timeout).
 func (pc *PluginConn) DeletePending(requestID string) {
 	pc.pendingMu.Lock()
-	pc.pending.Delete(requestID)
+	delete(pc.pending, requestID)
 	pc.pendingMu.Unlock()
 }
 

--- a/pkg/plugin/router/router_bench_test.go
+++ b/pkg/plugin/router/router_bench_test.go
@@ -1,7 +1,9 @@
 package router
 
 import (
+	"context"
 	"net"
+	"path/filepath"
 	"testing"
 
 	gcpc "gocache/api/gcpc/v1"
@@ -41,4 +43,145 @@ func BenchmarkPluginConnSendFireAndForget(b *testing.B) {
 	pc.Close()
 	_ = reader.Close()
 	<-done
+}
+
+// startMockPluginResponder reads command requests from conn and writes back
+// command responses with matching request_id. Stops when conn closes or
+// ctx is cancelled. This simulates a minimal plugin that immediately
+// responds to every command.
+func startMockPluginResponder(t testing.TB, conn *transport.Conn) (cancel func()) {
+	t.Helper()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			env, err := conn.Recv()
+			if err != nil {
+				return
+			}
+			req := env.GetCommandRequest()
+			if req == nil {
+				continue
+			}
+			respEnv := gcpc.NewCommandResponse(req.RequestId, &gcpc.ResultV1{
+				Value: &gcpc.ResultV1_SimpleString{SimpleString: "OK"},
+			}, false)
+			if err := conn.Send(respEnv); err != nil {
+				return
+			}
+		}
+	}()
+	return func() {
+		cancelFunc()
+		<-done
+	}
+}
+
+func BenchmarkPluginCommandRTT_NetPipe(b *testing.B) {
+	b.ReportAllocs()
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	pc := NewPluginConn("bench-netpipe", transport.NewConn(server))
+	go pc.StartReadLoop()
+	cancel := startMockPluginResponder(b, transport.NewConn(client))
+	defer cancel()
+	defer pc.Close()
+
+	ctx := context.Background()
+	cmd := &gcpc.CommandInfoV1{Name: "PING"}
+	connectionInfo := &gcpc.ConnectionInfoV1{Id: "bench-conn"}
+
+	for i := 0; i < 100; i++ {
+		reqID := NextRequestID()
+		requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+		respCh, err := pc.Send(ctx, requestEnvelope, reqID)
+		if err != nil {
+			b.Fatalf("warmup Send error: %v", err)
+		}
+		<-respCh
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reqID := NextRequestID()
+		requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+		respCh, err := pc.Send(ctx, requestEnvelope, reqID)
+		if err != nil {
+			b.Fatalf("Send error: %v", err)
+		}
+		<-respCh
+	}
+	b.StopTimer()
+}
+
+func BenchmarkPluginCommandRTT_AFUnix(b *testing.B) {
+	b.ReportAllocs()
+
+	sockPath := filepath.Join(b.TempDir(), "bench-afunix.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		b.Fatalf("Listen unix error: %v", err)
+	}
+	defer listener.Close()
+
+	type unixDialOutcome struct {
+		conn net.Conn
+		err  error
+	}
+	unixDialCh := make(chan unixDialOutcome, 1)
+	go func() {
+		clientConn, dialErr := net.Dial("unix", sockPath)
+		unixDialCh <- unixDialOutcome{clientConn, dialErr}
+	}()
+	server, err := listener.Accept()
+	if err != nil {
+		b.Fatalf("Accept error: %v", err)
+	}
+	defer server.Close()
+	unixDial := <-unixDialCh
+	if unixDial.err != nil {
+		b.Fatalf("Dial error: %v", unixDial.err)
+	}
+	client := unixDial.conn
+	defer client.Close()
+
+	pc := NewPluginConn("bench-afunix", transport.NewConn(server))
+	go pc.StartReadLoop()
+	cancel := startMockPluginResponder(b, transport.NewConn(client))
+	defer cancel()
+	defer pc.Close()
+
+	ctx := context.Background()
+	cmd := &gcpc.CommandInfoV1{Name: "PING"}
+	connectionInfo := &gcpc.ConnectionInfoV1{Id: "bench-conn"}
+
+	for i := 0; i < 100; i++ {
+		reqID := NextRequestID()
+		requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+		respCh, err := pc.Send(ctx, requestEnvelope, reqID)
+		if err != nil {
+			b.Fatalf("warmup Send error: %v", err)
+		}
+		<-respCh
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reqID := NextRequestID()
+		requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+		respCh, err := pc.Send(ctx, requestEnvelope, reqID)
+		if err != nil {
+			b.Fatalf("Send error: %v", err)
+		}
+		<-respCh
+	}
+	b.StopTimer()
 }

--- a/pkg/plugin/router/router_test.go
+++ b/pkg/plugin/router/router_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1049,5 +1051,38 @@ func TestPluginConnOperationHookRoundtrip(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for OperationHookResponse — readLoop dropped the envelope")
+	}
+}
+
+func BenchmarkNextRequestID(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = NextRequestID()
+	}
+}
+
+func TestNextRequestID_Format(t *testing.T) {
+	id := NextRequestID()
+	if !strings.HasPrefix(id, "req-") {
+		t.Fatalf("NextRequestID() = %q, want prefix %q", id, "req-")
+	}
+	numStr := id[len("req-"):]
+	n, err := strconv.ParseUint(numStr, 10, 64)
+	if err != nil {
+		t.Fatalf("NextRequestID() suffix %q is not a valid uint64: %v", numStr, err)
+	}
+	if n == 0 {
+		t.Error("NextRequestID() should never return req-0")
+	}
+
+	// Monotonicity: second call must produce a larger ID.
+	id2 := NextRequestID()
+	numStr2 := id2[len("req-"):]
+	n2, err := strconv.ParseUint(numStr2, 10, 64)
+	if err != nil {
+		t.Fatalf("second NextRequestID() suffix %q is not valid: %v", numStr2, err)
+	}
+	if n2 <= n {
+		t.Errorf("IDs not monotonic: first=%d second=%d", n, n2)
 	}
 }

--- a/pkg/server/operation_tracker_drain_worker.go
+++ b/pkg/server/operation_tracker_drain_worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -509,7 +508,7 @@ func (w *OperationTrackerDrainWorker) projectCompletedOperation(operation common
 
 		if w.manager != nil && !operation.ContextVersion.IsZero() {
 			w.manager.VisitConnectionContextVersion(operation.ContextVersion, func(contextKey, contextValue string) bool {
-				if !isTelemetryVisibleKey(contextKey) {
+				if !apictx.IsTelemetryVisible(contextKey) {
 					return true
 				}
 				telemetryOperation.InitialContext = append(telemetryOperation.InitialContext, scratch.borrowTag(contextKey, contextValue))
@@ -517,7 +516,7 @@ func (w *OperationTrackerDrainWorker) projectCompletedOperation(operation common
 			})
 		}
 		for contextKey, contextValue := range operation.ContextOverlay {
-			if !isTelemetryVisibleKey(contextKey) {
+			if !apictx.IsTelemetryVisible(contextKey) {
 				continue
 			}
 			telemetryOperation.InitialContext = append(telemetryOperation.InitialContext, scratch.borrowTag(contextKey, contextValue))
@@ -630,27 +629,6 @@ func (w *OperationTrackerDrainWorker) projectCompletedOperation(operation common
 			}
 		}
 	}
-}
-
-// isTelemetryVisibleKey returns true if a context key is safe for telemetry export.
-// Private keys (underscore-prefixed, secret-marked, or known credential names) are filtered at the source.
-func isTelemetryVisibleKey(key string) bool {
-	if apictx.IsSecret(key) {
-		return false
-	}
-	// Standard connection metadata keys use underscore prefix but are public.
-	switch key {
-	case "_connection_id", "_remote_addr":
-		return true
-	}
-	if strings.HasPrefix(key, "_") {
-		return false
-	}
-	switch strings.ToLower(key) {
-	case "password", "passwd", "secret", "token", "credential", "auth", "api_key", "apikey", "private_key":
-		return false
-	}
-	return true
 }
 
 func (w *OperationTrackerDrainWorker) copyOperationContext(operation commonobs.CompletedOperation) map[string]string {

--- a/pkg/server/operation_tracker_drain_worker_test.go
+++ b/pkg/server/operation_tracker_drain_worker_test.go
@@ -254,30 +254,6 @@ func TestOperationTrackerDrainWorkerRedactsSecretContextAtProjection(t *testing.
 	}
 }
 
-func TestIsTelemetryVisibleKeyAllowsPublicConnectionMetadata(t *testing.T) {
-	testCases := []struct {
-		name    string
-		key     string
-		visible bool
-	}{
-		{name: "connection id", key: "_connection_id", visible: true},
-		{name: "remote address", key: "_remote_addr", visible: true},
-		{name: "password", key: "_password", visible: false},
-		{name: "shared secret jwt", key: "shared.secret.jwt", visible: false},
-		{name: "auth secret api key", key: "auth.secret.api_key", visible: false},
-		{name: "secret api key", key: "secret.api_key", visible: false},
-		{name: "shared rex data", key: "shared.rex.data", visible: true},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			if visible := isTelemetryVisibleKey(testCase.key); visible != testCase.visible {
-				t.Fatalf("isTelemetryVisibleKey(%q) = %v, want %v", testCase.key, visible, testCase.visible)
-			}
-		})
-	}
-}
-
 func TestOperationTrackerDrainWorkerSkipsLocalMaterializedLogRequest(t *testing.T) {
 	var out bytes.Buffer
 	logger.InitWithWriter(&out, "debug")

--- a/pkg/server/telemetry_tmpfs_integration_test.go
+++ b/pkg/server/telemetry_tmpfs_integration_test.go
@@ -41,8 +41,8 @@ func TestTelemetryTmpfsInitialContextIncludesFilteredOperationOverlay(t *testing
 		[]byte("tenant"), []byte("acme"),
 	)
 	overlay := map[string]string{
-		"shared.rex.data": "custom-value",
-		"_secret":         "hidden",
+		"shared.rex.data":       "custom-value",
+		"myplugin.private_data": "hidden",
 	}
 	handle, pinned, ok := manager.StartOperationWithConnectionContext(1, apiobs.NewParentRef("connection-op"), connection, overlay)
 	if !ok {
@@ -85,8 +85,10 @@ func TestTelemetryTmpfsInitialContextIncludesFilteredOperationOverlay(t *testing
 		switch string(tag.Key) {
 		case "shared.rex.data":
 			sharedValues = append(sharedValues, string(tag.Value))
-		case "_secret":
+		case "myplugin.private_data":
 			t.Fatalf("private overlay key %q should be filtered", string(tag.Key))
+		case "tenant":
+			t.Fatalf("non-prefixed base context key %q should be filtered by deny-by-default filter", string(tag.Key))
 		}
 	}
 	if len(sharedValues) == 0 {


### PR DESCRIPTION
## Summary

Closes the D7 telemetry privacy leak and removes avoidable overhead from the plugin command dispatch path. Establishes the first ground-truth RTT measurement on real AF_UNIX transport.

## Changes

### D7 Telemetry Privacy Fix
- **Canonical filter**: Added `IsTelemetryVisible` to `api/context` — deny-by-default prefix filter using the 4-tier context model. Only `_`-prefixed (server) and `shared.`-prefixed keys are visible. `IsSecret` handles secrets. No credential name guessing.
- **drain_worker**: Initial context now filtered via canonical `apictx.IsTelemetryVisible`. Deleted local `isTelemetryVisibleKey` with its hardcoded credential name switch (`password`, `passwd`, `secret`, `token`, `credential`, `auth`, `api_key`, `apikey`, `private_key`).
- **Pipeline**: `recordTelemetryContextMap` now filters context updates via `apictx.IsTelemetryVisible` before recording (covers all 3 call sites in one change).

### Router Command-Path Hygiene
- **sync.Map → plain map**: `PluginConn.pending` was `sync.Map` but all 4 access sites (`storePending`, `drainPending`, `Deliver`, `DeletePending`) already hold `pendingMu`. Replaced with `map[string]chan *gcpc.EnvelopeV1` — removes atomic overhead with zero benefit.
- **strconv NextRequestID**: Replaced `fmt.Sprintf("req-%d", n)` with `strconv.AppendUint` stack buffer. Format unchanged (`req-<decimal>`). Allocs reduced from 2-3 to 1 per call.

### AF_UNIX RTT Benchmark
- Added `BenchmarkPluginCommandRTT_NetPipe` (baseline: ~6.2µs, pure dispatch overhead)
- Added `BenchmarkPluginCommandRTT_AFUnix` (real transport: ~15.2µs)
- Delta ~9µs isolates UDS kernel floor. Both 36 allocs/op. Reproducible within 2%.

## Benchmark Results

```
BenchmarkPluginCommandRTT_NetPipe-24   ~6,200 ns/op   36 allocs/op
BenchmarkPluginCommandRTT_AFUnix-24    ~15,200 ns/op   36 allocs/op
Delta (kernel floor):                  ~9,000 ns        0 allocs
```

## Success Criteria

| SC | Description | Status |
|---|---|---|
| SC-001 | No plugin-private key in telemetry | ✅ Verified |
| SC-002 | Single filter definition | ✅ 0 matches for old function |
| SC-003 | NextRequestID alloc-free | ~1 alloc (down from 2-3; 0 impossible for string return) |
| SC-004 | Router tests pass under -race | ✅ 30 tests pass |
| SC-005 | Benchmark reproducible within 15% | ✅ Within 2% |

## Scope

No proto changes, no wire-format changes, no plugin-facing API changes. Internal hygiene only.

## Test Plan

- [x] `go test ./api/context/ ./pkg/server/ ./pkg/pipeline/ ./commons/observability/ ./pkg/plugin/router/ -count=1 -timeout 120s` — all pass
- [x] `go test ./pkg/plugin/router/ -race -count=1` — 30 tests pass under race detector
- [x] `go test ./pkg/plugin/router/ -bench=BenchmarkPluginCommandRTT -benchmem -count=3` — stable within 2%
- [x] `go vet ./...` — clean
- [x] SAST scan — 0 findings
