### PR TITLE
perf(bench): comprehensive plugin command + hook + event benchmark suite

### DIFF
--- a/bench/profiles/run-benchstat.sh
+++ b/bench/profiles/run-benchstat.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Purpose: run benchmarks with -count=10 and analyze via benchstat (FR-006).
+#
+# WHY -count=10: single-run b.N is an anecdote, not a measurement.
+# benchstat needs multiple runs to compute confidence intervals.
+#
+# Any thesis evidence claim MUST cite benchstat confidence intervals, not raw deltas.
+#
+# Note: benchstat compares old vs new. For single-config analysis (no comparison),
+# use `benchstat -geomean` or just review the raw output.
+
+set -euo pipefail
+
+BENCH="${1:-}"
+COUNT="${2:-10}"
+PACKAGE="${3:-./pkg/plugin/benchsuite/}"
+
+if [[ -z "$BENCH" ]]; then
+    echo "Usage: $0 <bench-pattern> [count] [package]" >&2
+    echo "  bench-pattern: benchmark name regex (required, e.g. BenchmarkRawSyscallPingPong)" >&2
+    echo "  count: number of runs (default: 10, per FR-006 mandate)" >&2
+    echo "  package: Go package path (default: ./pkg/plugin/benchsuite/)" >&2
+    exit 2
+fi
+
+if ! command -v benchstat >/dev/null 2>&1; then
+    echo "Install: go install golang.org/x/perf/cmd/benchstat@latest" >&2
+    exit 1
+fi
+
+REPO=$(git rev-parse --show-toplevel)
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUT="$REPO/bench/results/benchstat/$TIMESTAMP"
+
+mkdir -p "$OUT"
+
+go test -bench="$BENCH" -count="$COUNT" -benchmem "$PACKAGE" > "$OUT/raw.txt" 2>&1
+benchstat "$OUT/raw.txt" > "$OUT/analysis.txt" 2>&1 || true
+
+cat "$OUT/analysis.txt"
+
+echo
+echo "Raw output: $OUT/raw.txt"
+echo "Benchstat analysis: $OUT/analysis.txt"

--- a/bench/profiles/run-benchsuite-profiles.sh
+++ b/bench/profiles/run-benchsuite-profiles.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Purpose: capture pprof profiles in isolation for FR-008 compliance.
+#
+# WHY separate invocations: Go profiling tools interfere with each other;
+# memory profiling skews CPU profiles, and block profiling affects scheduler
+# trace/parking behavior. Each profile type below therefore runs in a separate
+# go test invocation.
+#
+# Contrast with run-profiles.sh: that script combines profiles for quick
+# diagnosis; this script NEVER combines profiles because thesis-grade evidence
+# requires isolated captures.
+#
+# Sampling rates:
+#   memprofilerate=1 — every byte, for allocation-site analysis
+#   block rate=1 — every blocking event
+#   mutex fraction=1 — every contention event
+# These settings add heavy overhead, so timing from profiled runs MUST NOT be
+# cited as canonical. Canonical timing numbers come from unprofiled -bench runs.
+
+set -euo pipefail
+
+PROFILE_TYPE="${1:-all}"
+BENCH="${2:-BenchmarkRawSyscallPingPong}"
+DUR="${3:-3s}"
+
+REPO=$(git rev-parse --show-toplevel)
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUT="$REPO/bench/results/benchsuite-profiles/$TIMESTAMP"
+PROFILE_TYPES=(cpu heap block mutex goroutine)
+CAPTURED_PROFILES=()
+
+mkdir -p "$OUT"/{cpu,heap,block,mutex,goroutine}
+
+run_profile() {
+    local profile_type=$1
+
+    echo
+    echo ">>> $profile_type profile  (bench=$BENCH  duration=$DUR)"
+
+    case "$profile_type" in
+        cpu)
+            go test -bench="$BENCH" -benchmem -benchtime="$DUR" \
+                -cpuprofile="$OUT/cpu/profile.prof" \
+                ./pkg/plugin/benchsuite/
+            CAPTURED_PROFILES+=("cpu:$OUT/cpu/profile.prof")
+            ;;
+        heap)
+            go test -bench="$BENCH" -benchmem -benchtime="$DUR" \
+                -memprofile="$OUT/heap/profile.prof" -memprofilerate=1 \
+                ./pkg/plugin/benchsuite/
+            CAPTURED_PROFILES+=("heap:$OUT/heap/profile.prof")
+            ;;
+        block)
+            GOCACHE_BENCH_BLOCK_RATE=1 \
+            go test -bench="$BENCH" -benchmem -benchtime="$DUR" \
+                -blockprofile="$OUT/block/profile.prof" \
+                ./pkg/plugin/benchsuite/
+            CAPTURED_PROFILES+=("block:$OUT/block/profile.prof")
+            ;;
+        mutex)
+            GOCACHE_BENCH_MUTEX_FRACTION=1 \
+            go test -bench="$BENCH" -benchmem -benchtime="$DUR" \
+                -mutexprofile="$OUT/mutex/profile.prof" \
+                ./pkg/plugin/benchsuite/
+            CAPTURED_PROFILES+=("mutex:$OUT/mutex/profile.prof")
+            ;;
+        goroutine)
+            GOCACHE_BENCH_GOROUTINE_PROFILE="$OUT/goroutine/profile.prof" \
+            go test -bench="$BENCH" -benchmem -benchtime="$DUR" \
+                ./pkg/plugin/benchsuite/
+            CAPTURED_PROFILES+=("goroutine:$OUT/goroutine/profile.prof")
+            ;;
+        *)
+            echo "Unknown profile type: $profile_type" >&2
+            echo "Usage: $0 [cpu|heap|block|mutex|goroutine|all] [bench-name] [duration]" >&2
+            exit 2
+            ;;
+    esac
+}
+
+case "$PROFILE_TYPE" in
+    all)
+        for profile_type in "${PROFILE_TYPES[@]}"; do
+            run_profile "$profile_type"
+        done
+        ;;
+    cpu|heap|block|mutex|goroutine)
+        run_profile "$PROFILE_TYPE"
+        ;;
+    *)
+        echo "Unknown profile type: $PROFILE_TYPE" >&2
+        echo "Usage: $0 [cpu|heap|block|mutex|goroutine|all] [bench-name] [duration]" >&2
+        exit 2
+        ;;
+esac
+
+echo
+echo "Profile captures complete."
+echo "Output directory: $OUT"
+echo "Captured profiles:"
+for captured_profile in "${CAPTURED_PROFILES[@]}"; do
+    echo "  ${captured_profile%%:*}: ${captured_profile#*:}"
+done

--- a/bench/profiles/run-evidence-grade.sh
+++ b/bench/profiles/run-evidence-grade.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Evidence-grade benchmark run wrapper (FR-010).
+set -euo pipefail
+
+echo "=== Evidence-Grade Benchmark Run ==="
+echo "Go version: $(go version)"
+echo "Kernel: $(uname -r)"
+echo "Platform: $(uname -m)"
+echo "CPU: $(grep 'model name' /proc/cpuinfo | head -1 | cut -d: -f2 | xargs)"
+echo "GOMAXPROCS: $(nproc)"
+
+if command -v cpupower >/dev/null 2>&1; then
+    sudo -n cpupower frequency-set -g performance 2>/dev/null && echo "CPU governor: performance" || echo "CPU governor: FAILED (need root)"
+else
+    echo "CPU governor: cpupower not available"
+fi
+
+exec "$(dirname "$0")/run-threshold-validation.sh"

--- a/bench/profiles/run-threshold-validation.sh
+++ b/bench/profiles/run-threshold-validation.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Purpose: validate FR-007 tiered reproducibility thresholds across benchmark classes.
+#
+# Each class is run with -count=10 and -benchmem. The script computes coefficient
+# of variation for ns/op and requires allocs/op to be exact across all runs.
+
+set -euo pipefail
+
+REPO=$(git rev-parse --show-toplevel)
+OUT="$REPO/bench/results/threshold-validation.md"
+TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+GO_VERSION=$(go version)
+KERNEL=$(uname -r)
+CPU=$(grep 'model name' /proc/cpuinfo | head -1 | cut -d: -f2 | xargs || true)
+if [[ -z "$CPU" ]]; then
+    CPU="unknown"
+fi
+GOMAXPROCS=$(nproc)
+BENCH_TIMEOUT=${BENCH_TIMEOUT:-180s}
+
+mkdir -p "$(dirname "$OUT")"
+
+declare -a BENCHMARK_IDS=(
+    "command_netpipe"
+    "command_afunix"
+    "hook_nohook"
+    "hook_prehook_16"
+    "telemetry_local"
+    "telemetry_tmpfs"
+    "telemetry_fanout_100"
+    "concurrent_shared_goroutines_4"
+    "publish_subscribers_10"
+    "raw_syscall_afunix"
+)
+
+declare -A BENCHMARK_NAMES=(
+    [command_netpipe]="CommandRTT_NetPipe"
+    [command_afunix]="CommandRTT_AFUnix"
+    [hook_nohook]="HookDispatchRTT_NoHook"
+    [hook_prehook_16]="HookDispatchRTT_PreHook_16"
+    [telemetry_local]="TelemetryDeliveryLatency_Local"
+    [telemetry_tmpfs]="TelemetryDeliveryLatency_Tmpfs"
+    [telemetry_fanout_100]="TelemetryDeliveryFanout_Subscribers_100"
+    [concurrent_shared_goroutines_4]="ConcurrentCommandThroughput_Shared_Goroutines_4"
+    [publish_subscribers_10]="PluginCommandPUBLISH_Subscribers_10"
+    [raw_syscall_afunix]="RawSyscallPingPong_AFUnix"
+)
+
+declare -A BENCHMARK_PATTERNS=(
+    [command_netpipe]="^BenchmarkPluginCommandRTT_NetPipe$"
+    [command_afunix]="^BenchmarkPluginCommandRTT_AFUnix$"
+    [hook_nohook]="^BenchmarkHookDispatchRTT$/^NoHook$"
+    [hook_prehook_16]="^BenchmarkHookDispatchRTT$/^PreHook_16$"
+    [telemetry_local]="^BenchmarkTelemetryDeliveryLatency_Local$"
+    [telemetry_tmpfs]="^BenchmarkTelemetryDeliveryLatency_Tmpfs$"
+    [telemetry_fanout_100]="^BenchmarkTelemetryDeliveryFanout$/^Subscribers_100$"
+    [concurrent_shared_goroutines_4]="^BenchmarkConcurrentCommandThroughput_Shared$/^Goroutines_4$"
+    [publish_subscribers_10]="^BenchmarkPluginCommandPUBLISH$/^Subscribers_10$"
+    [raw_syscall_afunix]="^BenchmarkRawSyscallPingPong_AFUnix$"
+)
+
+declare -A BENCHMARK_PACKAGES=(
+    [command_netpipe]="./pkg/plugin/router/"
+    [command_afunix]="./pkg/plugin/router/"
+    [hook_nohook]="./pkg/pipeline/"
+    [hook_prehook_16]="./pkg/pipeline/"
+    [telemetry_local]="./pkg/events/"
+    [telemetry_tmpfs]="./commons/observability/"
+    [telemetry_fanout_100]="./pkg/events/"
+    [concurrent_shared_goroutines_4]="./pkg/plugin/router/"
+    [publish_subscribers_10]="./plugins/pubsub/"
+    [raw_syscall_afunix]="./pkg/plugin/benchsuite/"
+)
+
+declare -A BENCHMARK_THRESHOLDS=(
+    [command_netpipe]="5"
+    [command_afunix]="10"
+    [hook_nohook]="15"
+    [hook_prehook_16]="15"
+    [telemetry_local]="15"
+    [telemetry_tmpfs]="15"
+    [telemetry_fanout_100]="15"
+    [concurrent_shared_goroutines_4]="15"
+    [publish_subscribers_10]="15"
+    [raw_syscall_afunix]="10"
+)
+
+cat > "$OUT" <<REPORT
+# Tiered Reproducibility Threshold Validation (FR-007)
+
+## Metadata
+- Date: $TIMESTAMP
+- Go version: $GO_VERSION
+- Kernel: $KERNEL
+- CPU: $CPU
+- GOMAXPROCS: $GOMAXPROCS
+- Benchtime: 500ms per run, 10 runs per benchmark
+- Benchmark timeout: $BENCH_TIMEOUT per class
+
+## Results
+
+| Benchmark | Threshold | CV (ns/op) | Status | Allocs/op Variance |
+|-----------|-----------|------------|--------|-------------------|
+REPORT
+
+passed=0
+total=0
+failed_classes=()
+
+cd "$REPO"
+
+for benchmark_id in "${BENCHMARK_IDS[@]}"; do
+    benchmark_name=${BENCHMARK_NAMES[$benchmark_id]}
+    pattern=${BENCHMARK_PATTERNS[$benchmark_id]}
+    package=${BENCHMARK_PACKAGES[$benchmark_id]}
+    threshold=${BENCHMARK_THRESHOLDS[$benchmark_id]}
+
+    total=$((total + 1))
+    echo ">>> Validating $benchmark_name (threshold: $threshold%)"
+
+    run_output=""
+    set +e
+    run_output=$(timeout "$BENCH_TIMEOUT" go test -bench="$pattern" -count=10 -benchmem -benchtime=500ms "$package" 2>&1)
+    run_status=$?
+    set -e
+
+    if [[ $run_status -ne 0 ]]; then
+        reason=$(printf '%s\n' "$run_output" | tr '\n' ' ' | cut -c1-160)
+        echo "    SKIP: go test failed or timed out"
+        printf '| %s | %s%% | n/a | SKIP | go test failed or timed out: `%s` |\n' "$benchmark_name" "$threshold" "$reason" >> "$OUT"
+        failed_classes+=("$benchmark_name")
+        continue
+    fi
+
+    mapfile -t ns_values < <(printf '%s\n' "$run_output" | awk '
+        /^Benchmark/ {
+            pending_benchmark = $1
+            for (field_index = 1; field_index <= NF; field_index++) {
+                if ($field_index == "ns/op") { print $(field_index - 1); pending_benchmark = "" }
+            }
+            next
+        }
+        /^[[:space:]]*[0-9]+[[:space:]]+/ && pending_benchmark != "" {
+            for (field_index = 1; field_index <= NF; field_index++) {
+                if ($field_index == "ns/op") { print $(field_index - 1); pending_benchmark = "" }
+            }
+        }
+    ')
+    mapfile -t alloc_values < <(printf '%s\n' "$run_output" | awk '
+        /^Benchmark/ {
+            pending_benchmark = $1
+            for (field_index = 1; field_index <= NF; field_index++) {
+                if ($field_index == "allocs/op") { print $(field_index - 1); pending_benchmark = "" }
+            }
+            next
+        }
+        /^[[:space:]]*[0-9]+[[:space:]]+/ && pending_benchmark != "" {
+            for (field_index = 1; field_index <= NF; field_index++) {
+                if ($field_index == "allocs/op") { print $(field_index - 1); pending_benchmark = "" }
+            }
+        }
+    ')
+
+    if [[ ${#ns_values[@]} -ne 10 ]]; then
+        reason="expected 10 ns/op samples, found ${#ns_values[@]}"
+        echo "    SKIP: $reason"
+        printf '| %s | %s%% | n/a | SKIP | %s |\n' "$benchmark_name" "$threshold" "$reason" >> "$OUT"
+        failed_classes+=("$benchmark_name")
+        continue
+    fi
+
+    stats=$(printf '%s\n' "${ns_values[@]}" | awk '
+        { ns_samples[NR] = $1 + 0; sum += ns_samples[NR]; count++ }
+        END {
+            mean = sum / count
+            for (sample_index = 1; sample_index <= count; sample_index++) {
+                delta = ns_samples[sample_index] - mean
+                variance += delta * delta
+            }
+            variance = variance / count
+            stddev = sqrt(variance)
+            cv = mean == 0 ? 0 : (stddev / mean) * 100
+            printf "%.2f %.2f %.2f %d", mean, stddev, cv, count
+        }
+    ')
+    read -r mean_ns stddev_ns cv_percent sample_count <<< "$stats"
+
+    if [[ ${#alloc_values[@]} -ne 10 ]]; then
+        alloc_variance="missing alloc samples (${#alloc_values[@]}/10)"
+        alloc_exact=0
+    else
+        unique_alloc_count=$(printf '%s\n' "${alloc_values[@]}" | awk '!seen[$0]++ { count++ } END { print count + 0 }')
+        if [[ "$unique_alloc_count" == "1" ]]; then
+            alloc_variance="0% (exact: ${alloc_values[0]})"
+            alloc_exact=1
+        else
+            alloc_variance="NONZERO (${unique_alloc_count} distinct values)"
+            alloc_exact=0
+        fi
+    fi
+
+    cv_pass=$(awk -v cv="$cv_percent" -v limit="$threshold" 'BEGIN { print (cv <= limit) ? "yes" : "no" }')
+    status="FAIL"
+    if [[ "$cv_pass" == "yes" && "$alloc_exact" -eq 1 ]]; then
+        status="PASS"
+        passed=$((passed + 1))
+    else
+        failed_classes+=("$benchmark_name")
+    fi
+
+    echo "    $status: cv=${cv_percent}% mean=${mean_ns}ns stddev=${stddev_ns}ns samples=${sample_count} allocs=${alloc_variance}"
+    printf '| %s | %s%% | %s%% | %s | %s |\n' "$benchmark_name" "$threshold" "$cv_percent" "$status" "$alloc_variance" >> "$OUT"
+done
+
+if [[ ${#failed_classes[@]} -eq 0 ]]; then
+    isolation_list="none"
+else
+    isolation_list=$(printf '%s, ' "${failed_classes[@]}")
+    isolation_list=${isolation_list%, }
+fi
+
+cat >> "$OUT" <<REPORT
+
+## Summary
+- $passed/$total classes passed their tiered threshold
+- Classes requiring hardware isolation: $isolation_list
+
+## Notes
+- Allocs/op variance is expected to be 0% (deterministic). Any non-zero variance indicates a real change in allocation behavior.
+- CV is computed as (stddev/mean × 100) across 10 independent runs.
+- This is a preliminary validation on the development host. Final thesis evidence should be run on a dedicated benchmark host with CPU governor=performance and Turbo Boost disabled.
+REPORT
+
+echo "Report written to $OUT"

--- a/bench/results/pprof-alloc-breakdown.md
+++ b/bench/results/pprof-alloc-breakdown.md
@@ -1,0 +1,186 @@
+# Alloc-Site Breakdown: BenchmarkPluginCommandRTT_NetPipe
+
+## Metadata
+
+- Benchmark: `BenchmarkPluginCommandRTT_NetPipe` (`pkg/plugin/router/router_bench_test.go:86`)
+- Profile method: `-memprofile` with `-memprofilerate=1`, `-benchtime=10000x`
+- Date: 2026-07-07
+- Go version: `go version go1.26.4-X:nodwarf5 linux/amd64`
+- Total allocs/op: 36 allocs/op
+- Total B/op: 3278 B/op
+- CPU: AMD Ryzen 9 7900X 12-Core Processor
+
+Exact command requested by FR-009:
+
+```bash
+go test -bench=BenchmarkPluginCommandRTT_NetPipe -benchmem -memprofile=/tmp/alloc-breakdown.prof -memprofilerate=1 -benchtime=10000x ./pkg/plugin/router/
+go tool pprof -alloc_objects -top /tmp/alloc-breakdown.prof
+go tool pprof -alloc_space -top /tmp/alloc-breakdown.prof
+```
+
+The exact command produced:
+
+```text
+BenchmarkPluginCommandRTT_NetPipe-24    10000    92169 ns/op    3280 B/op    36 allocs/op
+```
+
+Because the exact command also runs package tests before the benchmark, the profile contained a small amount of non-benchmark setup/test allocation. For cleaner attribution, I also ran the same benchmark with tests disabled and used that profile for the site breakdown below:
+
+```bash
+go test '-run=^$' -bench=BenchmarkPluginCommandRTT_NetPipe -benchmem -memprofile=/tmp/alloc-breakdown-benchonly.prof -memprofilerate=1 -benchtime=10000x ./pkg/plugin/router/
+go tool pprof -alloc_objects -top /tmp/alloc-breakdown-benchonly.prof
+go tool pprof -alloc_space -top /tmp/alloc-breakdown-benchonly.prof
+```
+
+The bench-only command produced:
+
+```text
+BenchmarkPluginCommandRTT_NetPipe-24    10000    91898 ns/op    3278 B/op    36 allocs/op
+```
+
+Notes on attribution:
+
+- `pprof` merged the 36 reported allocs/op into 14 benchmark-relevant top-level flat allocation sites plus smaller dropped/runtime nodes. The top object profile showed `323998` objects, 99.32% of `326217` profile objects, not 36 separately named source lines.
+- Per-site `Allocs/op` and `Bytes/op` below are normalized from the bench-only profile over 10,000 iterations and rounded. The classification summary uses the benchmark's 36 allocs/op and 3278 B/op as the total.
+- Optimization targets are sorted by bytes, not object count.
+
+## Classification Summary
+
+| Category | Sites | Allocs/op | Bytes/op | % Bytes |
+|----------|-------|-----------|----------|---------|
+| Irreducible | 10 | ~30.7 | ~1215 B | 37.1% |
+| Reducible | 1 | ~1.0 | ~1828 B | 55.8% |
+| Poolable | 3 | ~4.3 | ~235 B | 7.2% |
+
+## Alloc Sites (sorted by bytes)
+
+### 1. REDUCIBLE `(*PluginConn).collectBatchWithDelay`
+
+- Location: `pkg/plugin/router/router.go:197`
+- Allocs/op: ~1.02
+- Bytes/op: ~1828 B
+- Evidence: `pprof -alloc_space` shows `17851.75kB` flat in `collectBatchWithDelay`, all at `batch := make([]outboundEnvelope, 0, pluginOutboundBatchMax)`; `pprof -alloc_objects` shows `10201` flat objects at the same line.
+- Classification reason: This is an internal writer-loop batch buffer. It does not escape through the public API, and the batch capacity is a stable constant (`pluginOutboundBatchMax = 32`). It could be reduced by reusing an internal buffer or using a stack-backed fixed array, without changing the `Send` API or GCPC wire contract.
+
+### 2. IRREDUCIBLE `(*PluginConn).Send` response channel
+
+- Location: `pkg/plugin/router/router.go:358`
+- Allocs/op: ~2.04
+- Bytes/op: ~123 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `ch := make(chan *gcpc.EnvelopeV1, 1)`; `pprof -alloc_space` shows `1.17MB` at that line.
+- Classification reason: `Send` returns a response channel to the caller. Pooling or reusing this channel is rejected as unsafe because ownership escapes to callers and the receive lifecycle is caller-controlled.
+
+### 3. IRREDUCIBLE `(*PluginConn).Send` write-ack channel
+
+- Location: `pkg/plugin/router/router.go:361`
+- Allocs/op: ~2.04
+- Bytes/op: ~128 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `errCh := make(chan error, 1)`; `pprof -alloc_space` shows `1.25MB` at that line.
+- Classification reason: This channel is the per-send writer acceptance/error synchronization path. Removing it would change the current `Send` semantics, and pooling channel instances would be unsafe because the write loop and caller-side send path have distinct ownership windows.
+
+### 4. IRREDUCIBLE `(*Conn).Recv` envelope object
+
+- Location: `commons/transport/transport.go:108`
+- Allocs/op: ~2.04
+- Bytes/op: ~160 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `env := &gcpc.EnvelopeV1{}`; `pprof -alloc_space` shows `1.56MB` at that line.
+- Classification reason: `Recv` returns the decoded `*gcpc.EnvelopeV1` to callers. The object escapes by design, so it cannot be safely reused by the transport without introducing ownership or lifetime hazards.
+
+### 5. IRREDUCIBLE `(*EnvelopeV1).UnmarshalVT` command-request payload struct
+
+- Location: `api/gcpc/v1/gcpc_vtproto.pb.go:6347` and `api/gcpc/v1/gcpc_vtproto.pb.go:6351`
+- Allocs/op: ~2.04
+- Bytes/op: ~106 B
+- Evidence: `pprof -alloc_space` shows `958.59kB` for `v := &CommandRequestV1{}` and `79.88kB` for `m.Payload = &EnvelopeV1_CommandRequest{CommandRequest: v}`.
+- Classification reason: These are generated protobuf oneof/message objects required to materialize the incoming GCPC command-request envelope.
+
+### 6. IRREDUCIBLE `NewCommandRequest`
+
+- Location: `api/gcpc/v1/helpers.go:142`, `api/gcpc/v1/helpers.go:145`, `api/gcpc/v1/helpers.go:146`
+- Allocs/op: ~3.06
+- Bytes/op: ~188 B
+- Evidence: `pprof -alloc_objects` shows `30603` flat objects in `NewCommandRequest`; `pprof -alloc_space` shows `796.95kB` for `&EnvelopeV1`, `79.70kB` for `&EnvelopeV1_CommandRequest`, and `956.34kB` for `&CommandRequestV1`.
+- Classification reason: The request envelope and protobuf oneof/message structs are required for the GCPC command request wire contract.
+
+### 7. IRREDUCIBLE `(*CommandRequestV1).UnmarshalVT`
+
+- Location: `api/gcpc/v1/gcpc_vtproto.pb.go:8522`, `8554`, `8590`
+- Allocs/op: ~2.91
+- Bytes/op: ~177 B
+- Evidence: `pprof -alloc_objects` shows `29061` flat objects in `CommandRequestV1.UnmarshalVT`; line attribution includes `RequestId` string copy plus nested `CommandInfoV1` and `ConnectionInfoV1` message allocation.
+- Classification reason: The generated protobuf decoder must materialize strings and nested messages for the received command request. Eliminating these would require changing decode semantics or generated-code strategy.
+
+### 8. IRREDUCIBLE `NewCommandResponse` and responder result construction
+
+- Location: `api/gcpc/v1/helpers.go:161`, `api/gcpc/v1/helpers.go:162`, and `pkg/plugin/router/router_bench_test.go:72`
+- Allocs/op: ~4.08
+- Bytes/op: ~172 B
+- Evidence: `pprof -alloc_space` shows `876.65kB` flat in `NewCommandResponse`; the benchmark responder closure also contributes `796.95kB` flat at `startMockPluginResponder.func1`, where it constructs the `ResultV1` response payload.
+- Classification reason: The benchmark simulates a real plugin returning a GCPC command response. The response envelope, oneof/message wrappers, and `ResultV1` payload are part of the wire protocol being measured.
+
+### 9. POOLABLE `(*Conn).SendBatch` frame buffer
+
+- Location: `commons/transport/transport.go:66`
+- Allocs/op: ~2.04
+- Bytes/op: ~82 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `buf := make([]byte, total)`; `pprof -alloc_space` shows `796.88kB` at that line.
+- Classification reason: This is a short-lived per-frame write buffer with stable small sizes in this workload. A carefully reset `sync.Pool` for transport write buffers could reduce bytes without changing API shape.
+
+### 10. IRREDUCIBLE `(*CommandResponseV1).UnmarshalVT`
+
+- Location: `api/gcpc/v1/gcpc_vtproto.pb.go:8931`, `8963`, `8965`
+- Allocs/op: ~2.03
+- Bytes/op: ~81 B
+- Evidence: `pprof -alloc_objects` shows `20274` flat objects in `CommandResponseV1.UnmarshalVT`; `pprof -alloc_space` shows `796.95kB` flat with nested `ResultV1` decode contributing to the cumulative total.
+- Classification reason: The response decoder must materialize the request ID string and nested result message for the response envelope.
+
+### 11. POOLABLE `(*EnvelopeV1).MarshalVT` serialization buffer
+
+- Location: `api/gcpc/v1/gcpc_vtproto.pb.go:28`
+- Allocs/op: ~2.04
+- Bytes/op: ~75 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `dAtA = make([]byte, size)`; `pprof -alloc_space` shows `732.96kB` at that line.
+- Classification reason: The serialized protobuf byte slice is short-lived and immediately copied into the transport frame buffer. A transport/protobuf buffer-pool design could reduce this, but it must preserve generated-code ownership expectations.
+
+### 12. POOLABLE `(*Conn).Recv` payload buffer
+
+- Location: `commons/transport/transport.go:103`
+- Allocs/op: ~2.04
+- Bytes/op: ~75 B
+- Evidence: `pprof -alloc_objects` shows `20402` objects at `data := make([]byte, size)`; `pprof -alloc_space` shows `732.96kB` at that line. The same function also shows a much smaller header allocation at line 90.
+- Classification reason: The payload byte slice is a short-lived decode buffer. It is a plausible pool candidate if the decoder does not retain references into the slice after unmarshal.
+
+### 13. IRREDUCIBLE `NextRequestID`
+
+- Location: `pkg/plugin/router/router.go:41`
+- Allocs/op: ~0.89
+- Bytes/op: ~14 B
+- Evidence: `pprof -alloc_objects` shows `8897` objects at `return string(b)`; `pprof -alloc_space` shows `139.02kB` at that line.
+- Classification reason: The public request correlation path currently uses string IDs in both `Send` and GCPC request/response messages. Avoiding this allocation would require changing the request-ID representation or broader correlation contract.
+
+### 14. IRREDUCIBLE `(*ConnectionInfoV1).UnmarshalVT` string copy
+
+- Location: `api/gcpc/v1/gcpc_vtproto.pb.go:8292`
+- Allocs/op: ~0.87
+- Bytes/op: ~14 B
+- Evidence: `pprof -alloc_objects` shows `8737` flat objects in `ConnectionInfoV1.UnmarshalVT`; `pprof -alloc_space` shows `136.52kB` at `m.Id = string(dAtA[iNdEx:postIndex])`.
+- Classification reason: The generated decoder copies wire bytes into an owned Go string for the decoded connection ID.
+
+## Optimization Targets (by bytes saved, descending)
+
+1. `(*PluginConn).collectBatchWithDelay` batch slice — potential savings: up to ~1828 B/op if replaced with reusable or stack-backed internal batch storage.
+2. `(*Conn).SendBatch` frame buffer — potential savings: ~82 B/op via a reset-safe byte buffer pool.
+3. `(*EnvelopeV1).MarshalVT` serialization buffer — potential savings: ~75 B/op if marshaling can target pooled/reused buffers safely.
+4. `(*Conn).Recv` payload buffer — potential savings: ~75 B/op if the unmarshal path does not retain input slices and a read-buffer pool is safe.
+5. `(*Conn).Recv` header buffer — potential savings: ~3 B/op; low value compared with the larger byte sites.
+
+Channel count reductions are intentionally excluded from this target list: removing channel allocations would reduce alloc count but not the largest byte bucket, and channel pooling is unsafe under the current API.
+
+## Channel Allocs (MUST be irreducible)
+
+- `pkg/plugin/router/router.go:358` — `ch := make(chan *gcpc.EnvelopeV1, 1)`: response channel returned by `Send`; pooling rejected as unsafe because `Send` returns channels to callers.
+- `pkg/plugin/router/router.go:361` — `errCh := make(chan error, 1)`: write-ack channel used to synchronize accepted/failed writes for each blocking send; pooling rejected as unsafe because lifecycle overlaps the per-send writer path and would risk stale sends/receives.
+
+## Bottom Line
+
+The largest byte target is not a protobuf object or channel: it is the internal outbound batch slice in `collectBatchWithDelay`, accounting for roughly 1.8 KiB/op by itself. The channel allocations are visible in object count but are not the primary byte target and must remain classified as irreducible under the current `Send` contract. The next byte-oriented targets are transport/protobuf buffers, which are plausible pool candidates but require careful reset and ownership proof before implementation.

--- a/bench/results/threshold-validation.md
+++ b/bench/results/threshold-validation.md
@@ -1,0 +1,34 @@
+# Tiered Reproducibility Threshold Validation (FR-007)
+
+## Metadata
+- Date: 2026-07-07T20:16:03Z
+- Go version: go version go1.26.4-X:nodwarf5 linux/amd64
+- Kernel: 7.0.10-arch1-1
+- CPU: AMD Ryzen 9 7900X 12-Core Processor
+- GOMAXPROCS: 24
+- Benchtime: 500ms per run, 10 runs per benchmark
+- Benchmark timeout: 180s per class
+
+## Results
+
+| Benchmark | Threshold | CV (ns/op) | Status | Allocs/op Variance |
+|-----------|-----------|------------|--------|-------------------|
+| CommandRTT_NetPipe | 5% | 1.95% | PASS | 0% (exact: 36) |
+| CommandRTT_AFUnix | 10% | 26.49% | FAIL | 0% (exact: 36) |
+| HookDispatchRTT_NoHook | 15% | 2.17% | PASS | 0% (exact: 6) |
+| HookDispatchRTT_PreHook_16 | 15% | 2.56% | PASS | 0% (exact: 22) |
+| TelemetryDeliveryLatency_Local | 15% | 0.73% | PASS | 0% (exact: 0) |
+| TelemetryDeliveryLatency_Tmpfs | 15% | 4.24% | PASS | 0% (exact: 0) |
+| TelemetryDeliveryFanout_Subscribers_100 | 15% | 3.01% | PASS | 0% (exact: 1) |
+| ConcurrentCommandThroughput_Shared_Goroutines_4 | 15% | 1.91% | PASS | 0% (exact: 36) |
+| PluginCommandPUBLISH_Subscribers_10 | 15% | 41.04% | FAIL | 0% (exact: 149) |
+| RawSyscallPingPong_AFUnix | 10% | 1.34% | PASS | 0% (exact: 0) |
+
+## Summary
+- 8/10 classes passed their tiered threshold
+- Classes requiring hardware isolation: CommandRTT_AFUnix, PluginCommandPUBLISH_Subscribers_10
+
+## Notes
+- Allocs/op variance is expected to be 0% (deterministic). Any non-zero variance indicates a real change in allocation behavior.
+- CV is computed as (stddev/mean × 100) across 10 independent runs.
+- This is a preliminary validation on the development host. Final thesis evidence should be run on a dedicated benchmark host with CPU governor=performance and Turbo Boost disabled.

--- a/commons/observability/telemetry_delivery_bench_test.go
+++ b/commons/observability/telemetry_delivery_bench_test.go
@@ -1,0 +1,142 @@
+//go:build linux
+
+package observability
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"testing"
+)
+
+type tmpfsTelemetryBenchmarkReader struct {
+	file         *os.File
+	headerBytes  [TmpfsTelemetryHeaderSize]byte
+	lengthPrefix [tmpfsTelemetryLengthPrefixSize]byte
+	messageBytes []byte
+	readOffset   uint64
+}
+
+func openTmpfsTelemetryBenchmarkReader(b *testing.B, pluginName string, payloadSize int) *tmpfsTelemetryBenchmarkReader {
+	b.Helper()
+
+	filePath, err := tmpfsTelemetryFilePath(pluginName)
+	if err != nil {
+		b.Fatalf("tmpfsTelemetryFilePath() error = %v", err)
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		b.Fatalf("open tmpfs telemetry benchmark reader: %v", err)
+	}
+	b.Cleanup(func() {
+		if closeErr := file.Close(); closeErr != nil {
+			b.Fatalf("close tmpfs telemetry benchmark reader: %v", closeErr)
+		}
+	})
+
+	return &tmpfsTelemetryBenchmarkReader{
+		file:         file,
+		messageBytes: make([]byte, payloadSize),
+	}
+}
+
+func (r *tmpfsTelemetryBenchmarkReader) readNext(writer *TmpfsTelemetryWriter) error {
+	for {
+		if _, err := r.file.ReadAt(r.headerBytes[:], 0); err != nil {
+			return fmt.Errorf("read tmpfs telemetry header: %w", err)
+		}
+
+		initialSequence := binary.LittleEndian.Uint64(r.headerBytes[tmpfsTelemetryHeaderSequenceOffset:tmpfsTelemetryHeaderWriteOffset])
+		if initialSequence%2 != 0 {
+			continue
+		}
+
+		writeOffset := binary.LittleEndian.Uint64(r.headerBytes[tmpfsTelemetryHeaderWriteOffset:tmpfsTelemetryHeaderConsumedOffset])
+		if _, err := r.file.ReadAt(r.headerBytes[tmpfsTelemetryHeaderSequenceOffset:tmpfsTelemetryHeaderWriteOffset], 0); err != nil {
+			return fmt.Errorf("reread tmpfs telemetry header sequence: %w", err)
+		}
+		confirmedSequence := binary.LittleEndian.Uint64(r.headerBytes[tmpfsTelemetryHeaderSequenceOffset:tmpfsTelemetryHeaderWriteOffset])
+		if initialSequence != confirmedSequence {
+			continue
+		}
+
+		if writeOffset < r.readOffset {
+			r.readOffset = 0
+		}
+		if writeOffset-r.readOffset < tmpfsTelemetryLengthPrefixSize {
+			continue
+		}
+
+		lengthPosition := int64(TmpfsTelemetryHeaderSize + r.readOffset)
+		if _, err := r.file.ReadAt(r.lengthPrefix[:], lengthPosition); err != nil {
+			return fmt.Errorf("read tmpfs telemetry length prefix: %w", err)
+		}
+
+		messageLength := uint64(binary.BigEndian.Uint32(r.lengthPrefix[:]))
+		entrySize := uint64(tmpfsTelemetryLengthPrefixSize) + messageLength
+		if writeOffset-r.readOffset < entrySize {
+			continue
+		}
+		if messageLength > uint64(cap(r.messageBytes)) {
+			r.messageBytes = make([]byte, messageLength)
+		}
+		messageBuffer := r.messageBytes[:messageLength]
+		messagePosition := lengthPosition + tmpfsTelemetryLengthPrefixSize
+		if _, err := r.file.ReadAt(messageBuffer, messagePosition); err != nil {
+			return fmt.Errorf("read tmpfs telemetry payload: %w", err)
+		}
+
+		r.readOffset += entrySize
+		writer.Acknowledge(r.readOffset)
+		return nil
+	}
+}
+
+func BenchmarkTelemetryDeliveryLatency_Tmpfs(b *testing.B) {
+	if _, err := os.Stat(TmpfsTelemetryDir); err != nil {
+		b.Skipf("tmpfs telemetry directory unavailable: %v", err)
+	}
+
+	pluginName := fmt.Sprintf("bench-tmpfs-%s", b.Name())
+	writer, err := NewTmpfsTelemetryWriter(pluginName)
+	if err != nil {
+		b.Fatalf("NewTmpfsTelemetryWriter() error = %v", err)
+	}
+	b.Cleanup(func() {
+		if closeErr := writer.Close(); closeErr != nil {
+			b.Fatalf("Close() error = %v", closeErr)
+		}
+	})
+
+	const telemetryPayloadSize = 128
+	payload := make([]byte, telemetryPayloadSize)
+	reader := openTmpfsTelemetryBenchmarkReader(b, pluginName, telemetryPayloadSize)
+	received := make(chan struct{}, 1)
+	readErrors := make(chan error, 1)
+	iterationCount := b.N
+
+	go func() {
+		for iteration := 0; iteration < iterationCount; iteration++ {
+			if err := reader.readNext(writer); err != nil {
+				readErrors <- err
+				return
+			}
+			received <- struct{}{}
+		}
+	}()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for iteration := 0; iteration < b.N; iteration++ {
+		if _, err := writer.Write(payload); err != nil {
+			b.Fatalf("Write() error = %v", err)
+		}
+
+		select {
+		case <-received:
+		case err := <-readErrors:
+			b.Fatalf("tmpfs telemetry benchmark reader error: %v", err)
+		}
+	}
+}

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -2,7 +2,7 @@
 title: Performance
 description: Per-shard locking arc — shipped optimizations, measured deltas, and what's still on the table
 status: living
-last_updated: 2026-06-23
+last_updated: 2026-07-08
 related:
   - Audit-per-shard-arc-summary
   - Audit-go-bench-vs-docker-gap
@@ -16,6 +16,58 @@ related:
 This page is the single entry point for the gocache performance work. It narrates the per-shard locking arc, links every PR/issue that contributed, points at the audits that quantify what shipped, and lists the levers still on the table. It is the wiki-facing companion to the bench captures under `bench/results/<branch>/`.
 
 The current modular-performance arc is tracked in [Modular Overhead Optimization Plan](modular-overhead-optimization-plan.md) and governed by [ADR-0022](../adr/0022-modular-performance-budget.md): IPC, runtime instrumentation, lifecycle OTLP, and Pub/Sub hot-path features must land within a <=20% modular overhead budget before being called performance-acceptable.
+
+## Comprehensive benchmark suite (Phase 1)
+
+Phase 1 completed the shared plugin-path benchmark harness in `pkg/plugin/benchsuite/`.
+It is a leaf package: package-level benchmarks stay in their owning packages, while the harness supplies the shared matrix, percentile recorder, provenance capture, and profiling workflow.
+
+- `DimensionMatrix` / `EnumerateDimensions` cover transport, hook count, plugin count, payload size, fan-out depth, and pipeline depth.
+- `DurationRecorder` reports nearest-rank `P50`, `P95`, `P99`, and `P999`; `SampleSizeWarning()` flags runs below the thesis thresholds (`p99 >= 1,000`, `p999 >= 10,000`).
+- `LockBaseline()` writes benchmark provenance (`commit_sha`, Go version, date, `GOARCH`, CPU count, hardware) under `bench/results/baseline-*.json`.
+- `BenchmarkRawSyscallPingPong_AFUnix` and `BenchmarkRawSyscallPingPong_Inproc` provide raw-syscall control cases for kernel-floor validation.
+- `bench/profiles/run-benchsuite-profiles.sh` captures CPU, heap, block, mutex, and goroutine profiles in separate `go test -bench` runs; block and mutex profiling stay opt-in through `GOCACHE_BENCH_BLOCK_RATE` and `GOCACHE_BENCH_MUTEX_FRACTION`.
+- `bench/profiles/run-benchstat.sh` wraps `go test -count=10` and `benchstat` for statistical comparison.
+- `bench/results/pprof-alloc-breakdown.md` records the Phase 1 alloc-site audit for `BenchmarkPluginCommandRTT_NetPipe` (36 allocs/op total, split into irreducible, reducible, and poolable buckets).
+
+## Phase 3: Concurrent Throughput + Real Workload Benchmarks
+
+### Concurrent Command Throughput (FR-004)
+
+- Location: `pkg/plugin/router/concurrent_throughput_bench_test.go`
+- Shared variant: ONE `PluginConn` across all goroutines (production contention model)
+- Per-goroutine variant: each goroutine owns its connection (no-contention ceiling)
+- Goroutine sweep: `{1,2,4,8,16,32,64}` via `SetParallelism` with `GOMAXPROCS=1`
+
+### PUBLISH Fan-out (FR-005)
+
+- Location: `plugins/pubsub/publish_bench_test.go`
+- Real plugin path via `pluginsdk.Run` exercising `handlePublish + PushToClient`
+- Delta method: `(N-subs minus 0-subs) = per-subscriber IPC cost`
+- Per-subscriber cost: `2.5-3.3 µs` (IPC-send-order, not map-iteration ns)
+
+## Phase 4: Validation + Provenance + Documentation
+
+### Tiered Threshold Validation (FR-007)
+
+- Location: `bench/profiles/run-threshold-validation.sh`
+- Results: 8/10 classes pass on dev host, 2 FAIL (AF_UNIX RTT, PUBLISH — need hardware isolation)
+- All allocs/op: 0% variance (deterministic)
+
+### Hardware Controls (FR-010)
+
+- Location: `docs/performance/benchmark-controls.md`
+- Evidence-grade wrapper: `bench/profiles/run-evidence-grade.sh`
+
+### Versioned Suite (FR-012)
+
+- SuiteVersion: `v1-pre-aof`
+- EventSink interface: `pkg/plugin/benchsuite/sink.go`
+
+### Comparison Methodology (FR-013)
+
+- Location: `docs/performance/comparison-methodology.md`
+- Rule: Redis/Valkey comparison MUST use identical flags via `redis-benchmark/valkey-benchmark`
 
 ## Why per-shard?
 

--- a/docs/performance/benchmark-controls.md
+++ b/docs/performance/benchmark-controls.md
@@ -1,0 +1,90 @@
+---
+title: Benchmark Controls
+description: Hardware and toolchain controls for evidence-grade GoCache benchmark runs
+status: living
+last_updated: 2026-07-08
+related:
+  - Performance
+  - ADR-0022-modular-performance-budget
+---
+
+# Benchmark Controls
+
+Evidence-grade benchmark runs must record enough host context for thesis readers to understand what was controlled, what remained variable, and which runs are comparable. These controls apply to final benchmark captures and threshold validation runs. Exploratory local runs may skip them, but the resulting numbers should not be presented as evidence-grade.
+
+The Valkey benchmark methodology is the external compatibility reference for this checklist: <https://valkey.io/topics/benchmark/>.
+
+## CPU Governor
+
+Use the Linux `performance` CPU frequency governor before recording evidence-grade results:
+
+```sh
+sudo cpupower frequency-set -g performance
+```
+
+Record whether this command succeeded. If `cpupower` is unavailable or root access is not available, document the omission next to the benchmark result.
+
+## Turbo Boost
+
+Disable CPU boost so repeated runs are less affected by short-lived frequency spikes.
+
+On AMD systems:
+
+```sh
+echo 0 > /sys/devices/system/cpu/cpufreq/boost
+```
+
+On Intel systems using `intel_pstate`:
+
+```sh
+echo 1 > /sys/devices/system/cpu/intel_pstate/no_turbo
+```
+
+Record the CPU vendor and the exact boost control used. Do not compare boosted and non-boosted runs as if they were taken under the same hardware controls.
+
+## NUMA Pinning
+
+Pin evidence-grade benchmark processes to one NUMA node when running on multi-socket or multi-NUMA hosts:
+
+```sh
+numactl --cpunodebind=0 --membind=0 go test -bench=...
+```
+
+Record the NUMA binding in the result summary. Single-node developer machines can mark this control as not applicable, but should still record the host topology if available.
+
+## No Competing Load
+
+Run benchmarks on an otherwise quiet host. Stop browsers, IDEs, Docker containers, background build jobs, local databases, and other CPU- or IO-heavy processes before recording final captures.
+
+If competing load cannot be eliminated, document it as a caveat and treat the run as weaker evidence.
+
+## Go Toolchain Version
+
+The Go version is captured by `CaptureBaselineProvenance` and by the evidence-grade run wrapper. Cross-version allocation comparisons are invalid unless the comparison explicitly controls for Go runtime and compiler changes.
+
+When comparing two commits, use the same Go toolchain for both sides. If the toolchain changes, report it as a methodology change rather than as an application-code delta.
+
+## Kernel Version and Platform
+
+Record the kernel version and platform for every evidence-grade capture. Native Linux results are not directly comparable to WSL2 results because syscall, scheduler, filesystem, and virtualization behavior can differ.
+
+For thesis evidence, compare native Linux to native Linux, WSL2 to WSL2, and containerized runs only to runs with matching container assumptions.
+
+## Evidence-Grade Run Checklist
+
+- [ ] Go version recorded.
+- [ ] Git commit SHA or baseline provenance recorded.
+- [ ] Kernel version and CPU architecture recorded.
+- [ ] CPU model and core count recorded.
+- [ ] CPU governor set to `performance`, or omission documented.
+- [ ] Turbo Boost disabled, or omission documented.
+- [ ] NUMA binding applied where relevant, or marked not applicable.
+- [ ] Competing load stopped, including browsers, IDEs, Docker containers, and background jobs.
+
+## Thesis Budget Note
+
+These controls are SHOULD-level for thesis runs: apply them whenever practical, and document which controls were applied for every benchmark result used in the thesis. A result with missing controls can still be useful, but the methodology section must state the missing controls and avoid overstating comparability.
+
+## Valkey Methodology Reference
+
+Valkey's benchmark methodology emphasizes controlled hardware, stable environments, and careful interpretation of benchmark results. Use it as the external methodology reference when explaining GoCache's Redis-compatible benchmark setup: <https://valkey.io/topics/benchmark/>.

--- a/docs/performance/comparison-methodology.md
+++ b/docs/performance/comparison-methodology.md
@@ -1,0 +1,143 @@
+---
+title: Comparison Methodology
+description: Baseline provenance and Redis-compatible benchmark comparison rules for thesis evidence
+status: living
+last_updated: 2026-07-08
+related:
+  - Performance
+  - Benchmark Controls
+---
+
+# Comparison Methodology
+
+This document defines the evidence contract for GoCache benchmark provenance and Redis/Valkey-compatible comparisons. It is the final methodology layer for the benchmark suite: benchmark numbers are thesis-grade only when they can be traced back to a controlled host, a reproducible command, a specific GoCache revision, and a comparison harness that measures the same workload on both systems.
+
+## 1. Baseline Provenance
+
+Every evidence-grade benchmark capture must include a baseline provenance record. The provenance record is not a performance result by itself; it is the metadata that makes a performance result reproducible and comparable.
+
+### Measurement host
+
+Record the host configuration beside every benchmark result:
+
+- CPU model.
+- Physical core count and logical CPU count.
+- RAM capacity.
+- Storage type used by the repository, benchmark output directory, and any persistence files involved in the run.
+- Kernel version.
+- Platform: native Linux, WSL2, containerized Linux, or another explicitly named environment.
+
+Native Linux, WSL2, and containerized results are separate evidence classes. Do not compare them as equivalent unless the thesis claim is explicitly about environment sensitivity.
+
+### Isolation level
+
+Record which controls from [Benchmark Controls](benchmark-controls.md) were applied:
+
+- CPU governor set to `performance`, or the omission documented.
+- Turbo Boost disabled, or the omission documented with the CPU vendor and control path.
+- NUMA pinning applied for multi-NUMA hosts, or marked not applicable for single-node hosts.
+- Competing load removed from the host, or listed as a caveat.
+
+The isolation record must say what was actually applied, not only what was intended. If a control was unavailable, the result can still be useful, but the evidence must not present it as equivalent to a fully isolated run.
+
+### Reproducibility mode
+
+The default reproducibility mode is **median-of-10** using `benchstat` over ten independent benchmark runs. For Go benchmarks, use the FR-006 wrapper path documented by `bench/profiles/run-benchstat.sh`, which runs benchmarks with `-count=10` and analyzes the result with `benchstat`.
+
+When reporting percentages, state whether the percentage is:
+
+- median-of-runs, preferred for thesis evidence;
+- best-of-runs, allowed only for exploratory ceilings and labeled as such;
+- another statistic, with the calculation described next to the result.
+
+Best-of-runs must not be mixed with median-of-runs in the same comparison table.
+
+### Go toolchain
+
+Record the exact Go version for each capture. Go compiler escape analysis, inlining, runtime scheduling, and allocation accounting can shift `allocs/op`, `B/op`, and latency distributions between releases. Allocation deltas are comparable only when both sides of the comparison use the same Go toolchain, or when the Go toolchain change is explicitly treated as a methodology change.
+
+### Benchmark date and commit SHA
+
+Use `CaptureBaselineProvenance` from `pkg/plugin/benchsuite/provenance.go` for benchmark-suite captures. The current provenance payload records:
+
+- `commit_sha` from `git rev-parse HEAD`;
+- `go_version` from the running Go toolchain;
+- UTC `date` in RFC3339 format;
+- `goarch`;
+- `num_cpu`;
+- a compact `hardware` string.
+
+`LockBaseline` writes this payload under `bench/results/baseline-*.json`. Treat that JSON file as the provenance anchor for Go benchmark evidence, then supplement it with the host fields above when the compact payload does not include enough detail for a thesis table.
+
+## 2. Redis/Valkey Comparison Methodology
+
+**THE RULE:** Any Redis/Valkey performance comparison in thesis evidence MUST use `redis-benchmark` or `valkey-benchmark` with identical flags against both systems.
+
+Redis-compatible comparisons are client-visible comparisons. They measure how a Redis-compatible client observes Valkey and GoCache under the same workload. They do not substitute for Go microbenchmarks, and Go microbenchmarks do not substitute for Redis-compatible client benchmarks.
+
+### Required identical flags
+
+The following flags must be identical for both systems in any side-by-side comparison:
+
+- `-c <clients>`: number of concurrent connections, for example `-c 50`.
+- `-n <requests>`: total number of requests, for example `-n 100000`.
+- `-d <data-size>`: payload size in bytes, for example `-d 64`.
+- `-P <pipelining>`: number of pipelined requests, for example `-P 1` for no pipelining or `-P 16` for pipelined traffic.
+- `-r <keyspacelen>`: random key space length, for example `-r 1000000` to prevent hot-key caching from dominating the result.
+
+If a benchmark script exposes these values through environment variables, record the resolved values in the result summary. The comparison is invalid if one side uses a different client count, request count, payload size, pipeline depth, or keyspace length.
+
+### Existing comparison infrastructure
+
+Use the repository harnesses in `bench/redis-benchmark/` before writing an ad hoc Redis-compatible comparison:
+
+- `task bench:redis` runs the `valkey-benchmark` harness against GoCache core or Valkey, depending on the selected target.
+- `task bench:redis:ipc` runs the `valkey-benchmark` harness against the GoCache IPC plugin path.
+- `task bench:redis:matrix` runs the full Valkey/Core/IPC matrix.
+- `task bench:redis:pubsub` runs the Pub/Sub fan-out benchmark.
+
+The default matrix is documented in `bench/redis-benchmark/README.md`. It records standard and pipelined CSV output under `bench/results/<branch>/`, along with memory and configuration artifacts where relevant.
+
+### Forbidden comparison patterns
+
+The following comparison patterns are invalid for thesis evidence:
+
+1. **NEVER** compare a GoCache microbenchmark (`ns/op` from `go test -bench`) to a published Redis benchmark number from a different harness. These are apples-to-oranges: different methodology, workload, and concurrency model.
+2. **NEVER** compare GoCache's in-process event bus latency, such as `BenchmarkBusEmit`, to Redis `PUBLISH` latency. GoCache's bus is in-process; Redis `PUBLISH` crosses a network socket.
+3. **NEVER** compare GoCache's PluginConn RTT, such as `BenchmarkPluginCommandRTT`, to `redis-benchmark` GET/SET latency. PluginConn measures IPC to a plugin subprocess, not client-facing command latency.
+
+### Valid comparison patterns
+
+The following patterns are valid when the commands, host, date, and commit SHA are recorded:
+
+1. Run `task bench:redis:matrix` to execute `valkey-benchmark` with identical flags against Valkey as the Redis-compatible baseline and against GoCache. Report both numbers side-by-side.
+2. Compare the **scaling shape**: how throughput changes with concurrency, client count, pipeline depth, or fan-out. GoCache's goroutine-based concurrency model differs from Redis's single-threaded event loop, so absolute numbers measure different implementation shapes.
+3. Cite benchmark numbers only with the exact command used, host configuration, benchmark date, and GoCache commit SHA.
+
+When the thesis needs an absolute headline ratio, the ratio must come from the same `redis-benchmark` or `valkey-benchmark` invocation family on the same host class. Do not derive a ratio by mixing a Go benchmark, a Docker benchmark, and a published external number.
+
+## 3. Thesis Evidence Requirements
+
+Any performance number cited in thesis evidence must satisfy the following checklist:
+
+1. It is backed by `benchstat` with `-count=10` for Go benchmark evidence, satisfying FR-006 statistical rigor.
+2. It cites the relevant tiered reproducibility threshold and confirms whether the result met that threshold, satisfying FR-007.
+3. It includes provenance metadata: host controls, Go toolchain, date, and commit SHA, satisfying FR-010.
+4. It uses the Redis/Valkey comparison methodology in this document whenever the number is compared to Redis or Valkey.
+5. It marks the benchmark suite version as `v1-pre-aof` and states the scope being measured, satisfying FR-012.
+
+Recommended evidence footer for thesis tables:
+
+```text
+Suite: v1-pre-aof
+Scope: <core | IPC plugin path | Pub/Sub fan-out | Go microbenchmark package>
+Command: <exact command or Task invocation>
+Host: <CPU, cores, RAM, storage, kernel, platform>
+Controls: <governor, Turbo Boost, NUMA, competing load>
+Statistic: <median-of-10 benchstat | best-of-runs exploratory | other named statistic>
+Date: <UTC date>
+Commit: <GoCache commit SHA>
+Comparison rule: <none | identical valkey-benchmark flags>
+```
+
+If any footer field is missing, the thesis text must state the omission and narrow the claim accordingly.

--- a/pkg/events/telemetry_delivery_bench_test.go
+++ b/pkg/events/telemetry_delivery_bench_test.go
@@ -1,0 +1,56 @@
+package events
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	apiEvents "gocache/api/events"
+)
+
+// BenchmarkTelemetryDeliveryLatency_Local measures FR-003 subscriber-round-trip latency,
+// not fire-and-forget emit cost. The local baseline establishes the in-process floor;
+// tmpfs-backed transports add IPC overhead above this path.
+func BenchmarkTelemetryDeliveryLatency_Local(b *testing.B) {
+	bus := NewBusWithCapacity(0)
+	received := make(chan struct{}, 1)
+	bus.Subscribe("bench-local", []apiEvents.Type{apiEvents.CommandCompleted}, func(apiEvents.Event) {
+		received <- struct{}{}
+	})
+	evt := apiEvents.NewCommandCompleted("PING", nil, 100, "PONG", "", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bus.Emit(evt)
+		<-received
+	}
+}
+
+// BenchmarkTelemetryDeliveryFanout measures FR-003 emit-to-all-subscribers receipt,
+// not fire-and-forget emit cost. Each iteration waits for every in-process subscriber;
+// tmpfs-backed transports add IPC overhead above this local fan-out floor.
+func BenchmarkTelemetryDeliveryFanout(b *testing.B) {
+	subscriberCounts := []int{1, 10, 100}
+	evt := apiEvents.NewCommandCompleted("PING", nil, 100, "PONG", "", nil)
+
+	for _, subscriberCount := range subscriberCounts {
+		b.Run(fmt.Sprintf("Subscribers_%d", subscriberCount), func(b *testing.B) {
+			bus := NewBusWithCapacity(0)
+			var waitGroup sync.WaitGroup
+			for i := 0; i < subscriberCount; i++ {
+				bus.Subscribe(fmt.Sprintf("sub-%d", i), []apiEvents.Type{apiEvents.CommandCompleted}, func(apiEvents.Event) {
+					waitGroup.Done()
+				})
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				waitGroup.Add(subscriberCount)
+				bus.Emit(evt)
+				waitGroup.Wait()
+			}
+		})
+	}
+}

--- a/pkg/pipeline/hook_dispatch_bench_test.go
+++ b/pkg/pipeline/hook_dispatch_bench_test.go
@@ -1,0 +1,83 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apicommand "gocache/api/command"
+	gcpc "gocache/api/gcpc/v1"
+	"gocache/pkg/clientctx"
+)
+
+// noOpHook is a single no-op PRE hook function. It does no work and returns
+// nil (no denial). The benchmark measures DISPATCH overhead, not hook-body
+// execution, so the hook body must be trivially cheap.
+type noOpHook func(ctx context.Context, cmd *gcpc.CommandInfoV1, conn *gcpc.ConnectionInfoV1) *apicommand.PreHookResult
+
+// countingHookExecutor implements command.HookExecutor with a configurable
+// number of no-op hooks. It simulates the dispatch overhead of N hooks
+// without actual plugin IPC — the delta between hook counts isolates the
+// per-hook marginal dispatch cost.
+type countingHookExecutor struct {
+	hooks []noOpHook
+}
+
+func (executor *countingHookExecutor) HasAny() bool { return len(executor.hooks) > 0 }
+
+func (executor *countingHookExecutor) HasHooksForCommand(string) bool {
+	return len(executor.hooks) > 0
+}
+
+func (executor *countingHookExecutor) RunPreHooks(ctx context.Context, cmd *gcpc.CommandInfoV1, conn *gcpc.ConnectionInfoV1, hookCtx map[string]string) *apicommand.PreHookResult {
+	// No hooks registered: nil signals "no matching hooks" per HookExecutor.
+	if len(executor.hooks) == 0 {
+		return nil
+	}
+
+	for _, hook := range executor.hooks {
+		preHookOutcome := hook(ctx, cmd, conn)
+		if preHookOutcome != nil && preHookOutcome.Denied {
+			return preHookOutcome
+		}
+	}
+
+	return &apicommand.PreHookResult{Context: hookCtx}
+}
+
+func (executor *countingHookExecutor) RunPostHooks(context.Context, *gcpc.CommandInfoV1, *gcpc.ConnectionInfoV1, string, string, map[string]string) {
+}
+
+// BenchmarkHookDispatchRTT measures full pipeline Evaluate RTT with no-op PRE
+// hooks registered at multiple counts. Per-hook marginal cost =
+// (RTT_N - RTT_0) / N. This isolates dispatch overhead from hook-body
+// execution. Absolute RTT excludes socket transport, which is constant and
+// cancels in the delta.
+func BenchmarkHookDispatchRTT(b *testing.B) {
+	hookCounts := []int{0, 1, 4, 16}
+	for _, hookCount := range hookCounts {
+		benchmarkName := "NoHook"
+		if hookCount > 0 {
+			benchmarkName = fmt.Sprintf("PreHook_%d", hookCount)
+		}
+		b.Run(benchmarkName, func(b *testing.B) {
+			evaluator, engineInstance, _ := newTestPipeline()
+			defer engineInstance.Stop()
+
+			hooks := make([]noOpHook, hookCount)
+			for hookIndex := range hooks {
+				hooks[hookIndex] = func(_ context.Context, _ *gcpc.CommandInfoV1, _ *gcpc.ConnectionInfoV1) *apicommand.PreHookResult {
+					return nil
+				}
+			}
+			evaluator.SetHookExecutor(&countingHookExecutor{hooks: hooks})
+
+			clientContext := clientctx.New()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = evaluator.Evaluate(context.Background(), clientContext, "PING", nil)
+			}
+		})
+	}
+}

--- a/pkg/plugin/benchsuite/controls_bench_test.go
+++ b/pkg/plugin/benchsuite/controls_bench_test.go
@@ -1,0 +1,90 @@
+//go:build unix
+
+package benchsuite
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// Kernel floor validation (difference-of-differences):
+//
+//	Full RTT delta  = AFUnix_full_RTT - NetPipe_full_RTT  (from existing benchmarks)
+//	Raw control delta = AFUnix_raw_RTT - Inproc_raw_RTT   (from THESE benchmarks)
+//	True kernel floor attribution = Full delta - Raw delta
+//
+// If Full delta ≈ Raw delta, the "~9µs kernel floor" from PR #101 is validated.
+// If Full delta > Raw delta, some of the "kernel floor" was actually GoCache dispatch overhead.
+// If Full delta < Raw delta (should not happen), the measurement is confounded.
+func BenchmarkRawSyscallPingPong_AFUnix(b *testing.B) {
+	socketFDs, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if closeErr := unix.Close(socketFDs[0]); closeErr != nil {
+			b.Errorf("close socket fd 0: %v", closeErr)
+		}
+		if closeErr := unix.Close(socketFDs[1]); closeErr != nil {
+			b.Errorf("close socket fd 1: %v", closeErr)
+		}
+	})
+
+	payload := make([]byte, 1)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for iteration := 0; iteration < b.N; iteration++ {
+		bytesWritten, writeErr := unix.Write(socketFDs[0], payload)
+		if writeErr != nil {
+			b.Fatal(writeErr)
+		}
+		if bytesWritten != len(payload) {
+			b.Fatalf("write socket fd 0: wrote %d bytes, expected %d", bytesWritten, len(payload))
+		}
+
+		bytesRead, readErr := unix.Read(socketFDs[1], payload)
+		if readErr != nil {
+			b.Fatal(readErr)
+		}
+		if bytesRead != len(payload) {
+			b.Fatalf("read socket fd 1: read %d bytes, expected %d", bytesRead, len(payload))
+		}
+
+		bytesWritten, writeErr = unix.Write(socketFDs[1], payload)
+		if writeErr != nil {
+			b.Fatal(writeErr)
+		}
+		if bytesWritten != len(payload) {
+			b.Fatalf("write socket fd 1: wrote %d bytes, expected %d", bytesWritten, len(payload))
+		}
+
+		bytesRead, readErr = unix.Read(socketFDs[0], payload)
+		if readErr != nil {
+			b.Fatal(readErr)
+		}
+		if bytesRead != len(payload) {
+			b.Fatalf("read socket fd 0: read %d bytes, expected %d", bytesRead, len(payload))
+		}
+	}
+}
+
+func BenchmarkRawSyscallPingPong_Inproc(b *testing.B) {
+	pingSignal := make(chan struct{})
+	pongSignal := make(chan struct{})
+
+	go func() {
+		for range pingSignal {
+			pongSignal <- struct{}{}
+		}
+	}()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for iteration := 0; iteration < b.N; iteration++ {
+		pingSignal <- struct{}{}
+		<-pongSignal
+	}
+	close(pingSignal)
+}

--- a/pkg/plugin/benchsuite/dimensions.go
+++ b/pkg/plugin/benchsuite/dimensions.go
@@ -1,0 +1,87 @@
+package benchsuite
+
+import "fmt"
+
+// TransportKind names the transport under benchmark.
+type TransportKind string
+
+const (
+	// TransportNetPipe uses net.Pipe for in-process command transport.
+	TransportNetPipe TransportKind = "net.Pipe"
+	// TransportAFUnix uses an AF_UNIX socket for IPC-shaped command transport.
+	TransportAFUnix TransportKind = "AF_UNIX"
+)
+
+// BenchmarkDimensions describes one table-driven benchmark case.
+type BenchmarkDimensions struct {
+	Transport     TransportKind
+	Hooks         int
+	Plugins       int
+	PayloadSize   int
+	FanoutDepth   int
+	PipelineDepth int
+}
+
+// Name returns a stable sub-benchmark name for the dimension case.
+func (dimensions BenchmarkDimensions) Name() string {
+	return fmt.Sprintf(
+		"transport=%s/hooks=%d/plugins=%d/payload=%dB/fanout=%d/pipeline=%d",
+		dimensions.Transport,
+		dimensions.Hooks,
+		dimensions.Plugins,
+		dimensions.PayloadSize,
+		dimensions.FanoutDepth,
+		dimensions.PipelineDepth,
+	)
+}
+
+// DimensionMatrix is a table of benchmark dimension cases.
+type DimensionMatrix []BenchmarkDimensions
+
+// Cases returns a copy of the matrix cases for callers that need inspection.
+func (matrix DimensionMatrix) Cases() []BenchmarkDimensions {
+	benchmarkCases := make([]BenchmarkDimensions, len(matrix))
+	copy(benchmarkCases, matrix)
+	return benchmarkCases
+}
+
+// DimensionOptions lists per-axis values for Cartesian matrix generation.
+type DimensionOptions struct {
+	Transports     []TransportKind
+	Hooks          []int
+	Plugins        []int
+	PayloadSizes   []int
+	FanoutDepths   []int
+	PipelineDepths []int
+}
+
+// EnumerateDimensions creates the Cartesian product of all dimension axes.
+func EnumerateDimensions(options DimensionOptions) DimensionMatrix {
+	matrixSize := len(options.Transports) * len(options.Hooks) * len(options.Plugins) * len(options.PayloadSizes) * len(options.FanoutDepths) * len(options.PipelineDepths)
+	if matrixSize == 0 {
+		return nil
+	}
+
+	benchmarkCases := make(DimensionMatrix, 0, matrixSize)
+	for _, transport := range options.Transports {
+		for _, hookCount := range options.Hooks {
+			for _, pluginCount := range options.Plugins {
+				for _, payloadSize := range options.PayloadSizes {
+					for _, fanoutDepth := range options.FanoutDepths {
+						for _, pipelineDepth := range options.PipelineDepths {
+							benchmarkCases = append(benchmarkCases, BenchmarkDimensions{
+								Transport:     transport,
+								Hooks:         hookCount,
+								Plugins:       pluginCount,
+								PayloadSize:   payloadSize,
+								FanoutDepth:   fanoutDepth,
+								PipelineDepth: pipelineDepth,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+	return benchmarkCases
+}

--- a/pkg/plugin/benchsuite/doc.go
+++ b/pkg/plugin/benchsuite/doc.go
@@ -1,0 +1,91 @@
+// Package benchsuite provides shared benchmark harness utilities for GoCache's
+// plugin-path measurement work.
+//
+// The package is deliberately a leaf utility. It imports only the standard
+// library and contains no router, event bus, command-hook, or plugin-manager
+// knowledge. Package-level benchmarks stay in their owning packages and import
+// benchsuite to enumerate dimensions, record latency samples, and persist
+// baseline provenance.
+//
+// # Percentile backend decision
+//
+// Benchmarks use the package-local DurationRecorder instead of
+// github.com/HdrHistogram/hdrhistogram-go. HdrHistogram is well-maintained and
+// battle-tested, but adding it would expand the dependency graph for a harness
+// whose thesis role is to make the measurement method easy to inspect. The
+// custom recorder stores []time.Duration samples and computes nearest-rank
+// percentiles from a sorted copy. That is less memory-efficient for very large
+// runs, but it is dependency-free, transparent in the thesis, and sufficient for
+// Go package benchmarks where b.N already bounds sample volume. If future
+// benchmark volume makes sample retention too costly, the recorder interface is
+// the single replacement point.
+//
+// # Dimension matrix
+//
+// BenchmarkDimensions contains the shared matrix axes used by the modular
+// overhead benchmark plan:
+//
+//   - Transport: net.Pipe or AF_UNIX command transport.
+//   - Hooks: PRE-hook count, normally 0, 1, or N.
+//   - Plugins: plugin connection count, normally 1 or N.
+//   - PayloadSize: command payload size in bytes.
+//   - FanoutDepth: event or telemetry subscriber fan-out.
+//   - PipelineDepth: pipelined command depth.
+//
+// DimensionMatrix can be constructed directly from selected cases or generated
+// with EnumerateDimensions from per-axis option lists. This keeps new benchmark
+// paths table-driven: extending coverage means adding matrix entries, not
+// writing standalone benchmark loops.
+//
+// # Profiling isolation
+//
+// Each pprof profile type MUST be captured in a separate go test -bench
+// invocation. Combining flags (-cpuprofile + -memprofile + -mutexprofile)
+// in a single run produces corrupted evidence because profiling tools
+// interfere with each other. This is mandated by FR-008.
+//
+// Block and mutex profiling are not enabled by default in the Go runtime.
+// TestMain reads GOCACHE_BENCH_BLOCK_RATE and GOCACHE_BENCH_MUTEX_FRACTION
+// env vars and calls runtime.SetBlockProfileRate / runtime.SetMutexProfileFraction
+// before any benchmark runs. Normal benchmark runs have zero profiling overhead.
+//
+// Profile-type-to-benchmark mapping:
+//   - CPU:       all benchmark classes (where CPU time is spent)
+//   - Heap:      all classes (alloc sources) — required for FR-009 alloc-site
+//     classification
+//   - Mutex:     concurrent throughput (FR-004) and hook dispatch — shows
+//     lock contention hotspots
+//   - Block:     concurrent throughput and hook dispatch — shows goroutine
+//     blocking and scheduling latency
+//   - Goroutine: all benchmark classes — leak detection after run completes
+//
+// # Versioning and EventSink
+//
+// The suite is versioned: v1 = pre-AOF baseline. All fire-and-forget
+// numbers are scoped as "send-cost only" and become meaningless post-AOF.
+// SuiteVersion and SuiteScope constants provide metadata for benchmark
+// output.
+//
+// EventSink is the interface for telemetry/event delivery backends. The
+// benchmark suite targets EventSink so tmpfs (current) and future AOF
+// backends can be compared without suite redesign. TmpfsTelemetryWriter
+// in commons/observability already satisfies EventSink. When AOF lands,
+// a new AOFEventSink implementing EventSink enables before/after comparison
+// with the same benchmark code.
+//
+// Usage example
+//
+//	matrix := benchsuite.DimensionMatrix{
+//		{Transport: benchsuite.TransportNetPipe, Hooks: 0, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+//		{Transport: benchsuite.TransportAFUnix, Hooks: 1, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+//	}
+//	benchsuite.RunMatrix(b, matrix, func(b *testing.B, dimensions benchsuite.BenchmarkDimensions, recorder *benchsuite.DurationRecorder) {
+//		b.ReportAllocs()
+//		b.ResetTimer()
+//		for i := 0; i < b.N; i++ {
+//			startedAt := time.Now()
+//			// benchmark owner performs package-specific work here.
+//			recorder.RecordSince(startedAt)
+//		}
+//	})
+package benchsuite

--- a/pkg/plugin/benchsuite/harness.go
+++ b/pkg/plugin/benchsuite/harness.go
@@ -1,0 +1,30 @@
+package benchsuite
+
+import "testing"
+
+// BenchmarkFunc runs one benchmark case and records optional latency samples.
+type BenchmarkFunc func(b *testing.B, dimensions BenchmarkDimensions, recorder *DurationRecorder)
+
+// RunMatrix executes benchmarkFunc once per dimension case as sub-benchmarks.
+func RunMatrix(b *testing.B, matrix DimensionMatrix, benchmarkFunc BenchmarkFunc) {
+	b.Helper()
+	for _, benchmarkCase := range matrix {
+		benchmarkCase := benchmarkCase
+		b.Run(benchmarkCase.Name(), func(b *testing.B) {
+			b.Helper()
+			recorder := NewDurationRecorder(b.N)
+			benchmarkFunc(b, benchmarkCase, recorder)
+			snapshot := recorder.Snapshot()
+			if snapshot.Count == 0 {
+				return
+			}
+			if warning := snapshot.SampleSizeWarning(); warning != "" {
+				b.Logf("WARNING: %s (count=%d)", warning, snapshot.Count)
+			}
+			b.ReportMetric(float64(snapshot.P50.Nanoseconds()), "p50-ns")
+			b.ReportMetric(float64(snapshot.P95.Nanoseconds()), "p95-ns")
+			b.ReportMetric(float64(snapshot.P99.Nanoseconds()), "p99-ns")
+			b.ReportMetric(float64(snapshot.P999.Nanoseconds()), "p999-ns")
+		})
+	}
+}

--- a/pkg/plugin/benchsuite/harness_test.go
+++ b/pkg/plugin/benchsuite/harness_test.go
@@ -1,0 +1,227 @@
+package benchsuite
+
+import (
+	"context"
+	"regexp"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEnumerateDimensions(t *testing.T) {
+	matrix := EnumerateDimensions(DimensionOptions{
+		Transports:     []TransportKind{TransportNetPipe, TransportAFUnix},
+		Hooks:          []int{0, 1},
+		Plugins:        []int{1},
+		PayloadSizes:   []int{64},
+		FanoutDepths:   []int{0},
+		PipelineDepths: []int{1, 8},
+	})
+
+	if len(matrix) != 8 {
+		t.Fatalf("expected 8 generated cases, got %d", len(matrix))
+	}
+
+	copiedCases := matrix.Cases()
+	copiedCases[0].Hooks = 99
+	if matrix[0].Hooks == 99 {
+		t.Fatal("Cases must return a copy")
+	}
+}
+
+func TestEnumerateDimensionsSmallMatrixCartesianProduct(t *testing.T) {
+	matrix := EnumerateDimensions(DimensionOptions{
+		Transports:     []TransportKind{TransportNetPipe, TransportAFUnix},
+		Hooks:          []int{0, 1, 16},
+		Plugins:        []int{1},
+		PayloadSizes:   []int{64},
+		FanoutDepths:   []int{0},
+		PipelineDepths: []int{1},
+	})
+
+	expectedCases := []BenchmarkDimensions{
+		{Transport: TransportNetPipe, Hooks: 0, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportNetPipe, Hooks: 1, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportNetPipe, Hooks: 16, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportAFUnix, Hooks: 0, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportAFUnix, Hooks: 1, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportAFUnix, Hooks: 16, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+	}
+
+	if len(matrix) != len(expectedCases) {
+		t.Fatalf("expected %d generated cases, got %d", len(expectedCases), len(matrix))
+	}
+	for caseIndex, expectedCase := range expectedCases {
+		if matrix[caseIndex] != expectedCase {
+			t.Fatalf("case %d mismatch: expected %+v, got %+v", caseIndex, expectedCase, matrix[caseIndex])
+		}
+	}
+}
+
+func TestDurationRecorderSnapshot(t *testing.T) {
+	recorder := NewDurationRecorder(100)
+	for sampleNumber := 1; sampleNumber <= 100; sampleNumber++ {
+		recorder.Record(time.Duration(sampleNumber) * time.Millisecond)
+	}
+
+	snapshot := recorder.Snapshot()
+	if snapshot.Count != 100 {
+		t.Fatalf("expected 100 samples, got %d", snapshot.Count)
+	}
+	if snapshot.Min != time.Millisecond {
+		t.Fatalf("expected min 1ms, got %s", snapshot.Min)
+	}
+	if snapshot.P50 != 50*time.Millisecond {
+		t.Fatalf("expected p50 50ms, got %s", snapshot.P50)
+	}
+	if snapshot.P95 != 95*time.Millisecond {
+		t.Fatalf("expected p95 95ms, got %s", snapshot.P95)
+	}
+	if snapshot.P99 != 99*time.Millisecond {
+		t.Fatalf("expected p99 99ms, got %s", snapshot.P99)
+	}
+	if snapshot.P999 != 100*time.Millisecond {
+		t.Fatalf("expected p999 100ms, got %s", snapshot.P999)
+	}
+	if snapshot.Max != 100*time.Millisecond {
+		t.Fatalf("expected max 100ms, got %s", snapshot.Max)
+	}
+}
+
+func TestDurationRecorderSnapshotP999CapturesTail(t *testing.T) {
+	recorder := NewDurationRecorder(1000)
+	for sampleNumber := 0; sampleNumber < 998; sampleNumber++ {
+		recorder.Record(time.Millisecond)
+	}
+	recorder.Record(100 * time.Millisecond)
+	recorder.Record(time.Second)
+
+	snapshot := recorder.Snapshot()
+	if snapshot.Count != 1000 {
+		t.Fatalf("expected 1000 samples, got %d", snapshot.Count)
+	}
+	if snapshot.P99 != time.Millisecond {
+		t.Fatalf("expected p99 1ms, got %s", snapshot.P99)
+	}
+	if snapshot.P999 != 100*time.Millisecond {
+		t.Fatalf("expected p999 100ms, got %s", snapshot.P999)
+	}
+	if snapshot.P999 <= snapshot.P99 {
+		t.Fatalf("expected p999 to capture tail beyond p99, got p99=%s p999=%s", snapshot.P99, snapshot.P999)
+	}
+}
+
+func TestDurationRecorderSnapshotSortsSamplesAndResetKeepsRecorderUsable(t *testing.T) {
+	recorder := NewDurationRecorder(-10)
+	for _, sample := range []time.Duration{5 * time.Millisecond, time.Millisecond, 3 * time.Millisecond, 2 * time.Millisecond, 4 * time.Millisecond} {
+		recorder.Record(sample)
+	}
+
+	snapshot := recorder.Snapshot()
+	if snapshot.Count != 5 {
+		t.Fatalf("expected 5 samples, got %d", snapshot.Count)
+	}
+	if snapshot.Min != time.Millisecond {
+		t.Fatalf("expected min 1ms, got %s", snapshot.Min)
+	}
+	if snapshot.P50 != 3*time.Millisecond {
+		t.Fatalf("expected p50 3ms, got %s", snapshot.P50)
+	}
+	if snapshot.P95 != 5*time.Millisecond {
+		t.Fatalf("expected p95 5ms, got %s", snapshot.P95)
+	}
+	if snapshot.P99 != 5*time.Millisecond {
+		t.Fatalf("expected p99 5ms, got %s", snapshot.P99)
+	}
+	if snapshot.P999 != 5*time.Millisecond {
+		t.Fatalf("expected p999 5ms, got %s", snapshot.P999)
+	}
+	if snapshot.Max != 5*time.Millisecond {
+		t.Fatalf("expected max 5ms, got %s", snapshot.Max)
+	}
+
+	recorder.Reset()
+	resetSnapshot := recorder.Snapshot()
+	if resetSnapshot != (PercentileSnapshot{}) {
+		t.Fatalf("expected empty snapshot after reset, got %+v", resetSnapshot)
+	}
+	recorder.Record(7 * time.Millisecond)
+	postResetSnapshot := recorder.Snapshot()
+	if postResetSnapshot.Count != 1 || postResetSnapshot.P50 != 7*time.Millisecond || postResetSnapshot.Max != 7*time.Millisecond {
+		t.Fatalf("expected one 7ms sample after reset, got %+v", postResetSnapshot)
+	}
+}
+
+func TestRunMatrixInvokesEachCaseAndRecordsPercentileMetrics(t *testing.T) {
+	matrix := DimensionMatrix{
+		{Transport: TransportNetPipe, Hooks: 0, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportNetPipe, Hooks: 1, Plugins: 1, PayloadSize: 256, FanoutDepth: 1, PipelineDepth: 4},
+		{Transport: TransportAFUnix, Hooks: 16, Plugins: 4, PayloadSize: 1024, FanoutDepth: 8, PipelineDepth: 16},
+	}
+
+	var mu sync.Mutex
+	seenCases := make(map[string]BenchmarkDimensions)
+	result := testing.Benchmark(func(b *testing.B) {
+		RunMatrix(b, matrix, func(b *testing.B, dimensions BenchmarkDimensions, recorder *DurationRecorder) {
+			mu.Lock()
+			seenCases[dimensions.Name()] = dimensions
+			mu.Unlock()
+
+			for iteration := 0; iteration < b.N; iteration++ {
+				recorder.Record(time.Duration(dimensions.PayloadSize+dimensions.Hooks+dimensions.Plugins+dimensions.FanoutDepth+dimensions.PipelineDepth) * time.Nanosecond)
+			}
+		})
+	})
+
+	if result.N <= 0 {
+		t.Fatalf("expected benchmark to execute at least one iteration, got %d", result.N)
+	}
+	if len(seenCases) != len(matrix) {
+		t.Fatalf("expected %d invoked benchmark cases, got %d: %+v", len(matrix), len(seenCases), seenCases)
+	}
+	for _, expectedCase := range matrix {
+		if seenCases[expectedCase.Name()] != expectedCase {
+			t.Fatalf("expected RunMatrix to invoke case %+v, got %+v", expectedCase, seenCases[expectedCase.Name()])
+		}
+	}
+}
+
+func TestCaptureBaselineProvenanceIncludesCommitGoVersionAndDate(t *testing.T) {
+	startedAt := time.Now().UTC()
+	provenance, err := CaptureBaselineProvenance(context.Background(), "../../..")
+	if err != nil {
+		t.Fatalf("capture baseline provenance: %v", err)
+	}
+	finishedAt := time.Now().UTC()
+
+	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(provenance.CommitSHA) {
+		t.Fatalf("expected 40-character git commit SHA, got %q", provenance.CommitSHA)
+	}
+	if provenance.GoVersion != runtime.Version() {
+		t.Fatalf("expected Go version %q, got %q", runtime.Version(), provenance.GoVersion)
+	}
+	capturedAt, parseErr := time.Parse(time.RFC3339, provenance.Date)
+	if parseErr != nil {
+		t.Fatalf("expected RFC3339 provenance date, got %q: %v", provenance.Date, parseErr)
+	}
+	if capturedAt.Before(startedAt.Add(-time.Second)) || capturedAt.After(finishedAt.Add(time.Second)) {
+		t.Fatalf("expected provenance date between %s and %s, got %s", startedAt.Format(time.RFC3339), finishedAt.Format(time.RFC3339), capturedAt.Format(time.RFC3339))
+	}
+}
+
+func BenchmarkRunMatrixSample(b *testing.B) {
+	matrix := DimensionMatrix{
+		{Transport: TransportNetPipe, Hooks: 0, Plugins: 1, PayloadSize: 64, FanoutDepth: 0, PipelineDepth: 1},
+		{Transport: TransportNetPipe, Hooks: 1, Plugins: 1, PayloadSize: 256, FanoutDepth: 1, PipelineDepth: 4},
+		{Transport: TransportAFUnix, Hooks: 16, Plugins: 4, PayloadSize: 1024, FanoutDepth: 8, PipelineDepth: 16},
+	}
+
+	RunMatrix(b, matrix, func(b *testing.B, dimensions BenchmarkDimensions, recorder *DurationRecorder) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for iteration := 0; iteration < b.N; iteration++ {
+			recorder.Record(time.Duration(dimensions.PayloadSize+dimensions.Hooks+dimensions.Plugins+dimensions.FanoutDepth+dimensions.PipelineDepth) * time.Nanosecond)
+		}
+	})
+}

--- a/pkg/plugin/benchsuite/main_test.go
+++ b/pkg/plugin/benchsuite/main_test.go
@@ -1,0 +1,60 @@
+package benchsuite
+
+import (
+	"log"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"testing"
+)
+
+// TestMain keeps benchmark profiling opt-in: block and mutex profiling are
+// disabled by default in the Go runtime, GOCACHE_BENCH_BLOCK_RATE and
+// GOCACHE_BENCH_MUTEX_FRACTION enable them before benchmarks run, and normal
+// runs keep zero profiling overhead.
+func TestMain(m *testing.M) {
+	blockRateValue := os.Getenv("GOCACHE_BENCH_BLOCK_RATE")
+	if blockRateValue != "" {
+		blockRate, err := strconv.Atoi(blockRateValue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if blockRate > 0 {
+			runtime.SetBlockProfileRate(blockRate)
+		}
+	}
+
+	mutexFractionValue := os.Getenv("GOCACHE_BENCH_MUTEX_FRACTION")
+	if mutexFractionValue != "" {
+		mutexFraction, err := strconv.Atoi(mutexFractionValue)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if mutexFraction > 0 {
+			runtime.SetMutexProfileFraction(mutexFraction)
+		}
+	}
+
+	exitCode := m.Run()
+
+	goroutineProfilePath := os.Getenv("GOCACHE_BENCH_GOROUTINE_PROFILE")
+	if goroutineProfilePath != "" {
+		goroutineProfileFile, err := os.Create(goroutineProfilePath)
+		if err != nil {
+			log.Printf("write goroutine profile: create %q: %v", goroutineProfilePath, err)
+		} else {
+			goroutineProfile := pprof.Lookup("goroutine")
+			if goroutineProfile == nil {
+				log.Printf("write goroutine profile: goroutine profile unavailable")
+			} else if err := goroutineProfile.WriteTo(goroutineProfileFile, 0); err != nil {
+				log.Printf("write goroutine profile: %v", err)
+			}
+			if err := goroutineProfileFile.Close(); err != nil {
+				log.Printf("write goroutine profile: close %q: %v", goroutineProfilePath, err)
+			}
+		}
+	}
+
+	os.Exit(exitCode)
+}

--- a/pkg/plugin/benchsuite/percentile.go
+++ b/pkg/plugin/benchsuite/percentile.go
@@ -1,0 +1,110 @@
+package benchsuite
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// DurationRecorder records benchmark latency samples for percentile reporting.
+type DurationRecorder struct {
+	durations []time.Duration
+}
+
+// NewDurationRecorder creates a recorder with optional preallocated capacity.
+func NewDurationRecorder(capacity int) *DurationRecorder {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return &DurationRecorder{durations: make([]time.Duration, 0, capacity)}
+}
+
+// Record appends one latency sample.
+func (recorder *DurationRecorder) Record(duration time.Duration) {
+	recorder.durations = append(recorder.durations, duration)
+}
+
+// RecordSince appends the elapsed duration since startedAt.
+func (recorder *DurationRecorder) RecordSince(startedAt time.Time) {
+	recorder.Record(time.Since(startedAt))
+}
+
+// Reset clears recorded samples while retaining allocated storage.
+func (recorder *DurationRecorder) Reset() {
+	recorder.durations = recorder.durations[:0]
+}
+
+// Samples returns a copy of recorded duration samples.
+func (recorder *DurationRecorder) Samples() []time.Duration {
+	durationsCopy := make([]time.Duration, len(recorder.durations))
+	copy(durationsCopy, recorder.durations)
+	return durationsCopy
+}
+
+// PercentileSnapshot summarizes recorded latency samples.
+type PercentileSnapshot struct {
+	Count int
+	Min   time.Duration
+	P50   time.Duration
+	P95   time.Duration
+	P99   time.Duration
+	P999  time.Duration
+	Max   time.Duration
+}
+
+// SampleSizeWarning returns a non-empty message when the sample count is
+// insufficient for the percentiles reported in the snapshot. FR-006 requires
+// at least 1,000 samples for p99 and at least 10,000 for p999. Single-run
+// b.N output below these thresholds is an anecdote, not a measurement.
+func (snapshot PercentileSnapshot) SampleSizeWarning() string {
+	if snapshot.Count == 0 {
+		return ""
+	}
+	var parts []string
+	if snapshot.Count < 10000 {
+		parts = append(parts, "p999 needs >=10000 samples")
+	}
+	if snapshot.Count < 1000 {
+		parts = append(parts, "p99 needs >=1000 samples")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ")
+}
+
+// Snapshot computes nearest-rank percentiles from a sorted sample copy.
+func (recorder *DurationRecorder) Snapshot() PercentileSnapshot {
+	if len(recorder.durations) == 0 {
+		return PercentileSnapshot{}
+	}
+
+	sortedDurations := recorder.Samples()
+	sort.Slice(sortedDurations, func(leftIndex, rightIndex int) bool {
+		return sortedDurations[leftIndex] < sortedDurations[rightIndex]
+	})
+
+	return PercentileSnapshot{
+		Count: len(sortedDurations),
+		Min:   sortedDurations[0],
+		P50:   nearestRank(sortedDurations, 500),
+		P95:   nearestRank(sortedDurations, 950),
+		P99:   nearestRank(sortedDurations, 990),
+		P999:  nearestRank(sortedDurations, 999),
+		Max:   sortedDurations[len(sortedDurations)-1],
+	}
+}
+
+func nearestRank(sortedDurations []time.Duration, percentilePermille int) time.Duration {
+	if len(sortedDurations) == 0 {
+		return 0
+	}
+	rank := (percentilePermille*len(sortedDurations) + 999) / 1000
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(sortedDurations) {
+		rank = len(sortedDurations)
+	}
+	return sortedDurations[rank-1]
+}

--- a/pkg/plugin/benchsuite/provenance.go
+++ b/pkg/plugin/benchsuite/provenance.go
@@ -1,0 +1,93 @@
+package benchsuite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const gitRevParseTimeout = 5 * time.Second
+
+// BaselineProvenance records enough environment detail to compare benchmark runs.
+type BaselineProvenance struct {
+	CommitSHA    string `json:"commit_sha"`
+	GoVersion    string `json:"go_version"`
+	Date         string `json:"date"`
+	GOARCH       string `json:"goarch"`
+	NumCPU       int    `json:"num_cpu"`
+	Hardware     string `json:"hardware"`
+	SuiteVersion string `json:"suite_version"` // benchmark suite version (v1-pre-aof)
+	SuiteScope   string `json:"suite_scope"`   // scope of version numbers (fire-and-forget = send-cost only)
+}
+
+// CaptureBaselineProvenance captures current commit and runtime provenance.
+func CaptureBaselineProvenance(ctx context.Context, repoRoot string) (BaselineProvenance, error) {
+	commitSHA, commitErr := captureCommitSHA(ctx, repoRoot)
+	if commitErr != nil {
+		return BaselineProvenance{}, commitErr
+	}
+
+	goarch := runtime.GOARCH
+	numCPU := runtime.NumCPU()
+	return BaselineProvenance{
+		CommitSHA:    commitSHA,
+		GoVersion:    runtime.Version(),
+		Date:         time.Now().UTC().Format(time.RFC3339),
+		GOARCH:       goarch,
+		NumCPU:       numCPU,
+		Hardware:     fmt.Sprintf("%s/%dCPU", goarch, numCPU),
+		SuiteVersion: SuiteVersion,
+		SuiteScope:   SuiteScope,
+	}, nil
+}
+
+// LockBaseline writes baseline provenance under bench/results and returns the file path.
+func LockBaseline(ctx context.Context, repoRoot string) (string, BaselineProvenance, error) {
+	provenance, provenanceErr := CaptureBaselineProvenance(ctx, repoRoot)
+	if provenanceErr != nil {
+		return "", BaselineProvenance{}, provenanceErr
+	}
+
+	resultsDir := filepath.Join(repoRoot, "bench", "results")
+	if mkdirErr := os.MkdirAll(resultsDir, 0o755); mkdirErr != nil {
+		return "", BaselineProvenance{}, fmt.Errorf("create baseline results directory: %w", mkdirErr)
+	}
+
+	filenameDate := strings.NewReplacer(":", "", "-", "").Replace(provenance.Date)
+	baselinePath := filepath.Join(resultsDir, "baseline-"+filenameDate+".json")
+	encodedProvenance, marshalErr := json.MarshalIndent(provenance, "", "  ")
+	if marshalErr != nil {
+		return "", BaselineProvenance{}, fmt.Errorf("encode baseline provenance: %w", marshalErr)
+	}
+	encodedProvenance = append(encodedProvenance, '\n')
+	if writeErr := os.WriteFile(baselinePath, encodedProvenance, 0o644); writeErr != nil {
+		return "", BaselineProvenance{}, fmt.Errorf("write baseline provenance: %w", writeErr)
+	}
+	return baselinePath, provenance, nil
+}
+
+func captureCommitSHA(ctx context.Context, repoRoot string) (string, error) {
+	gitCtx, cancel := context.WithTimeout(ctx, gitRevParseTimeout)
+	defer cancel()
+
+	gitCommand := exec.CommandContext(gitCtx, "git", "-C", repoRoot, "rev-parse", "HEAD")
+	gitCommand.Stdin = nil
+	commitBytes, commandErr := gitCommand.Output()
+	if gitCtx.Err() != nil {
+		return "", fmt.Errorf("capture git commit SHA: %w", gitCtx.Err())
+	}
+	if commandErr != nil {
+		return "", fmt.Errorf("capture git commit SHA: %w", commandErr)
+	}
+	commitSHA := strings.TrimSpace(string(commitBytes))
+	if commitSHA == "" {
+		return "", fmt.Errorf("capture git commit SHA: empty output")
+	}
+	return commitSHA, nil
+}

--- a/pkg/plugin/benchsuite/sink.go
+++ b/pkg/plugin/benchsuite/sink.go
@@ -1,0 +1,32 @@
+package benchsuite
+
+// SuiteVersion marks the benchmark suite version for output metadata.
+// v1 = pre-AOF baseline. All fire-and-forget numbers are scoped as
+// "send-cost only" and become meaningless post-AOF. When AOF lands,
+// bump to v2 and re-baseline.
+const SuiteVersion = "v1-pre-aof"
+
+// SuiteScope documents the scope of v1 numbers. Fire-and-forget send-cost
+// baselines must not be cited as delivery latency after AOF implementation.
+const SuiteScope = "pre-AOF baseline; fire-and-forget numbers are send-cost only"
+
+// EventSink is the abstraction for telemetry/event delivery backends.
+// The benchmark suite targets this interface so tmpfs and future AOF
+// backends can be compared without suite redesign.
+//
+// Current implementation: TmpfsTelemetryWriter in commons/observability/
+// already satisfies this interface (Write([]byte) (int, error), Close() error).
+// When AOF is implemented, a new AOFEventSink will implement the same
+// interface, enabling before/after comparison with the same benchmark code.
+type EventSink interface {
+	// Write delivers data to the sink. Returns bytes written.
+	Write(data []byte) (int, error)
+	// Close releases sink resources.
+	Close() error
+}
+
+// Compile-time interface compliance check.
+// TmpfsTelemetryWriter already implements Write and Close, but lives in
+// commons/observability which has a linux build constraint. This check
+// is documented here for future implementors rather than enforced at
+// compile time to avoid import cycles.

--- a/pkg/plugin/router/concurrent_throughput_bench_test.go
+++ b/pkg/plugin/router/concurrent_throughput_bench_test.go
@@ -1,0 +1,175 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	gcpc "gocache/api/gcpc/v1"
+	"gocache/commons/transport"
+)
+
+// BenchmarkConcurrentCommandThroughput_Shared measures real-world contention
+// when multiple goroutines dispatch commands through a single per-plugin
+// PluginConn. The sendMu mutex, outbound channel, and single writeLoop are the
+// contention bottlenecks. This is the production model. GOMAXPROCS=1 plus
+// SetParallelism(N) ensures exactly N goroutines, isolating goroutine-count
+// effects from CPU-core scaling. ops/sec is b.N / b.Elapsed().Seconds(), where
+// b.N is total operations across all goroutines per Go testing docs.
+func BenchmarkConcurrentCommandThroughput_Shared(b *testing.B) {
+	sockPath := filepath.Join(b.TempDir(), "bench-concurrent-afunix.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		b.Fatalf("Listen unix error: %v", err)
+	}
+	defer listener.Close()
+
+	type unixDialOutcome struct {
+		conn net.Conn
+		err  error
+	}
+	unixDialCh := make(chan unixDialOutcome, 1)
+	go func() {
+		clientConn, dialErr := net.Dial("unix", sockPath)
+		unixDialCh <- unixDialOutcome{clientConn, dialErr}
+	}()
+	server, err := listener.Accept()
+	if err != nil {
+		b.Fatalf("Accept error: %v", err)
+	}
+	defer server.Close()
+	unixDial := <-unixDialCh
+	if unixDial.err != nil {
+		b.Fatalf("Dial error: %v", unixDial.err)
+	}
+	client := unixDial.conn
+	defer client.Close()
+
+	sharedPluginConn := NewPluginConn("bench-concurrent-shared", transport.NewConn(server))
+	go sharedPluginConn.StartReadLoop()
+	cancel := startMockPluginResponder(b, transport.NewConn(client))
+	defer cancel()
+	defer sharedPluginConn.Close()
+
+	ctx := context.Background()
+	cmd := &gcpc.CommandInfoV1{Name: "PING"}
+	connectionInfo := &gcpc.ConnectionInfoV1{Id: "bench-concurrent"}
+	for i := 0; i < 100; i++ {
+		reqID := NextRequestID()
+		requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+		respCh, err := sharedPluginConn.Send(ctx, requestEnvelope, reqID)
+		if err != nil {
+			b.Fatalf("warmup Send error: %v", err)
+		}
+		<-respCh
+	}
+
+	origGOMAXPROCS := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(origGOMAXPROCS)
+
+	goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64}
+	for _, goroutineCount := range goroutineCounts {
+		b.Run(fmt.Sprintf("Goroutines_%d", goroutineCount), func(b *testing.B) {
+			runtime.GOMAXPROCS(1)
+			b.SetParallelism(goroutineCount)
+
+			var requestIDCounter atomic.Uint64
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				ctx := context.Background()
+				cmd := &gcpc.CommandInfoV1{Name: "PING"}
+				connectionInfo := &gcpc.ConnectionInfoV1{Id: "bench-concurrent"}
+
+				for pb.Next() {
+					reqID := fmt.Sprintf("req-%d", requestIDCounter.Add(1))
+					requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+					respCh, err := sharedPluginConn.Send(ctx, requestEnvelope, reqID)
+					if err != nil {
+						panic(fmt.Sprintf("Send error: %v", err))
+					}
+					responseEnvelope, ok := <-respCh
+					if !ok || responseEnvelope == nil {
+						panic("Send response channel closed")
+					}
+				}
+			})
+
+			opsPerSec := float64(b.N) / b.Elapsed().Seconds()
+			b.ReportMetric(opsPerSec, "ops/s")
+		})
+	}
+}
+
+// BenchmarkConcurrentCommandThroughput_PerGoroutine measures the no-contention
+// parallelism ceiling. Each goroutine owns its own PluginConn pair, so there is
+// no shared-resource contention. The delta between Shared and PerGoroutine is
+// the lock plus fd-contention cost. GOMAXPROCS=1 plus SetParallelism(N) ensures
+// exactly N goroutines, isolating goroutine-count effects from CPU-core scaling.
+// ops/sec is b.N / b.Elapsed().Seconds(), where b.N is total operations across
+// all goroutines per Go testing docs.
+func BenchmarkConcurrentCommandThroughput_PerGoroutine(b *testing.B) {
+	origGOMAXPROCS := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(origGOMAXPROCS)
+
+	goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64}
+	for _, goroutineCount := range goroutineCounts {
+		b.Run(fmt.Sprintf("Goroutines_%d", goroutineCount), func(b *testing.B) {
+			runtime.GOMAXPROCS(1)
+			b.SetParallelism(goroutineCount)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				server, client := net.Pipe()
+				pluginConn := NewPluginConn("bench-perg", transport.NewConn(server))
+				go pluginConn.StartReadLoop()
+				cancel := startMockPluginResponder(b, transport.NewConn(client))
+				defer func() {
+					pluginConn.Close()
+					cancel()
+					_ = server.Close()
+					_ = client.Close()
+				}()
+
+				ctx := context.Background()
+				cmd := &gcpc.CommandInfoV1{Name: "PING"}
+				connectionInfo := &gcpc.ConnectionInfoV1{Id: "bench-perg"}
+				for i := 0; i < 10; i++ {
+					reqID := NextRequestID()
+					requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+					respCh, err := pluginConn.Send(ctx, requestEnvelope, reqID)
+					if err != nil {
+						panic(fmt.Sprintf("warmup Send error: %v", err))
+					}
+					responseEnvelope, ok := <-respCh
+					if !ok || responseEnvelope == nil {
+						panic("warmup Send response channel closed")
+					}
+				}
+
+				var requestIDCounter atomic.Uint64
+				for pb.Next() {
+					reqID := fmt.Sprintf("req-%d", requestIDCounter.Add(1))
+					requestEnvelope := gcpc.NewCommandRequest(reqID, cmd, connectionInfo, nil, nil)
+					respCh, err := pluginConn.Send(ctx, requestEnvelope, reqID)
+					if err != nil {
+						panic(fmt.Sprintf("Send error: %v", err))
+					}
+					responseEnvelope, ok := <-respCh
+					if !ok || responseEnvelope == nil {
+						panic("Send response channel closed")
+					}
+				}
+			})
+
+			opsPerSec := float64(b.N) / b.Elapsed().Seconds()
+			b.ReportMetric(opsPerSec, "ops/s")
+		})
+	}
+}

--- a/plugins/pubsub/publish_bench_test.go
+++ b/plugins/pubsub/publish_bench_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	gcpc "gocache/api/gcpc/v1"
+	apiplugin "gocache/api/plugin"
+	"gocache/commons/transport"
+	"gocache/sdk/pluginsdk"
+)
+
+const (
+	publishBenchChannel = "bench-channel"
+	publishBenchMessage = "hello"
+	publishBenchConnID  = "bench-conn"
+	publishBenchReqID   = "publish-request"
+)
+
+type publishBenchmarkHarness struct {
+	coreConn         *transport.Conn
+	commandResponses chan *gcpc.CommandResponseV1
+	readerDone       chan struct{}
+	cancelPlugin     context.CancelFunc
+	listener         net.Listener
+	pluginDone       chan error
+}
+
+type acceptOutcome struct {
+	conn net.Conn
+	err  error
+}
+
+// BenchmarkPluginCommandPUBLISH measures FR-005: Exercises the real pubsub
+// PUBLISH plugin command path. handlePublish calls PushToClient for each
+// matching subscriber — each is a full GCPC IPC envelope send from plugin to
+// core.
+//
+// Per-subscriber marginal cost = (RTT_N - RTT_0) / N. Delta method isolates
+// the PushToClient IPC cost from fixed handlePublish overhead.
+//
+// MUST use real draining readers. If PushToClient sends are fire-and-forget
+// into a buffer that never blocks, the benchmark measures send-enqueue cost not
+// delivery cost.
+//
+// Do NOT assume linearity — the SubscriptionManager RLock and per-subscriber
+// PushToClient contention may bend the curve.
+func BenchmarkPluginCommandPUBLISH(b *testing.B) {
+	subscriberCounts := []int{0, 1, 10, 100}
+	for _, subscriberCount := range subscriberCounts {
+		b.Run(fmt.Sprintf("Subscribers_%d", subscriberCount), func(b *testing.B) {
+			publishHarness := startPublishBenchmarkHarness(b, subscriberCount)
+			defer publishHarness.close(b)
+
+			commandInfo := &gcpc.CommandInfoV1{Name: "PUBLISH", Args: []string{publishBenchChannel, publishBenchMessage}}
+			connectionInfo := &gcpc.ConnectionInfoV1{Id: publishBenchConnID}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for iterationIndex := 0; iterationIndex < b.N; iterationIndex++ {
+				requestEnvelope := gcpc.NewCommandRequest(publishBenchReqID, commandInfo, connectionInfo, nil, nil)
+				if sendErr := publishHarness.coreConn.Send(requestEnvelope); sendErr != nil {
+					b.Fatalf("send PUBLISH request: %v", sendErr)
+				}
+
+				commandResponse := <-publishHarness.commandResponses
+				if commandResponse.RequestId != publishBenchReqID {
+					b.Fatalf("command response request_id = %q, want %q", commandResponse.RequestId, publishBenchReqID)
+				}
+			}
+			b.StopTimer()
+		})
+	}
+}
+
+func startPublishBenchmarkHarness(b *testing.B, subscriberCount int) *publishBenchmarkHarness {
+	b.Helper()
+	if runtime.GOOS == "windows" {
+		b.Skip("pubsub plugin benchmark uses the Unix socket transport required by pluginsdk.Run")
+	}
+
+	socketPath := filepath.Join(b.TempDir(), "pubsub-publish-bench.sock")
+	listener, listenErr := net.Listen("unix", socketPath)
+	if listenErr != nil {
+		b.Fatalf("listen unix socket: %v", listenErr)
+	}
+	b.Setenv(apiplugin.EnvSocketPath, socketPath)
+
+	manager := NewSubscriptionManager()
+	for subscriberIndex := 0; subscriberIndex < subscriberCount; subscriberIndex++ {
+		manager.Subscribe(fmt.Sprintf("bench-sub-%d", subscriberIndex), publishBenchChannel)
+	}
+
+	pluginCtx, cancelPlugin := context.WithCancel(context.Background())
+	pluginDone := make(chan error, 1)
+	go func() {
+		pluginDone <- pluginsdk.Run(pluginCtx, &PubSub{manager: manager})
+	}()
+
+	acceptedConns := make(chan acceptOutcome, 1)
+	go func() {
+		acceptedConn, acceptErr := listener.Accept()
+		acceptedConns <- acceptOutcome{conn: acceptedConn, err: acceptErr}
+	}()
+
+	var rawCoreConn net.Conn
+	select {
+	case acceptedConn := <-acceptedConns:
+		if acceptedConn.err != nil {
+			cancelPlugin()
+			b.Fatalf("accept plugin connection: %v", acceptedConn.err)
+		}
+		rawCoreConn = acceptedConn.conn
+	case pluginErr := <-pluginDone:
+		cancelPlugin()
+		b.Fatalf("run pubsub plugin before accept: %v", pluginErr)
+	case <-time.After(5 * time.Second):
+		cancelPlugin()
+		b.Fatal("timeout waiting for pubsub plugin connection")
+	}
+
+	coreConn := transport.NewConn(rawCoreConn)
+	registerEnvelope, recvErr := coreConn.Recv()
+	if recvErr != nil {
+		cancelPlugin()
+		closeBenchmarkConn(b, coreConn)
+		closeBenchmarkListener(b, listener)
+		b.Fatalf("receive register envelope: %v", recvErr)
+	}
+	if registerEnvelope.GetRegister() == nil {
+		cancelPlugin()
+		closeBenchmarkConn(b, coreConn)
+		closeBenchmarkListener(b, listener)
+		b.Fatalf("first plugin envelope = %T, want Register", registerEnvelope.Payload)
+	}
+	if ackErr := coreConn.Send(gcpc.NewRegisterAck(true, "", []string{"write", "hook:pre", "events"}, nil)); ackErr != nil {
+		cancelPlugin()
+		closeBenchmarkConn(b, coreConn)
+		closeBenchmarkListener(b, listener)
+		b.Fatalf("send register ack: %v", ackErr)
+	}
+
+	commandResponses := make(chan *gcpc.CommandResponseV1, 1)
+	readerDone := make(chan struct{})
+	go drainPubSubCoreEnvelopes(coreConn, commandResponses, readerDone)
+
+	return &publishBenchmarkHarness{
+		coreConn:         coreConn,
+		commandResponses: commandResponses,
+		readerDone:       readerDone,
+		cancelPlugin:     cancelPlugin,
+		listener:         listener,
+		pluginDone:       pluginDone,
+	}
+}
+
+func drainPubSubCoreEnvelopes(coreConn *transport.Conn, commandResponses chan<- *gcpc.CommandResponseV1, readerDone chan<- struct{}) {
+	defer close(readerDone)
+	for {
+		envelope, recvErr := coreConn.Recv()
+		if recvErr != nil {
+			return
+		}
+		if commandResponse := envelope.GetCommandResponse(); commandResponse != nil {
+			commandResponses <- commandResponse
+		}
+	}
+}
+
+func (h *publishBenchmarkHarness) close(b *testing.B) {
+	b.Helper()
+	closeBenchmarkConn(b, h.coreConn)
+	h.cancelPlugin()
+	closeBenchmarkListener(b, h.listener)
+	<-h.readerDone
+
+	select {
+	case pluginErr := <-h.pluginDone:
+		if pluginErr != nil && !errors.Is(pluginErr, context.Canceled) {
+			b.Logf("pubsub plugin exited during benchmark cleanup: %v", pluginErr)
+			return
+		}
+	case <-time.After(5 * time.Second):
+		b.Log("timeout waiting for pubsub plugin cleanup")
+		return
+	}
+}
+
+func closeBenchmarkConn(b *testing.B, coreConn *transport.Conn) {
+	b.Helper()
+	if closeErr := coreConn.Close(); closeErr != nil {
+		b.Logf("close benchmark transport connection: %v", closeErr)
+	}
+}
+
+func closeBenchmarkListener(b *testing.B, listener net.Listener) {
+	b.Helper()
+	if closeErr := listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+		b.Logf("close benchmark listener: %v", closeErr)
+	}
+}


### PR DESCRIPTION
Add a complete benchmark harness covering all four unmeasured dispatch paths (hooks, telemetry delivery, concurrent throughput, real workload) with statistical rigor, pprof profiling isolation, alloc-site classification, and raw-syscall kernel-floor controls. No production code modified - benchmarks and documentation only. Key findings: kernel floor is 4.8us not 9us (PR 101 wrong by 50 percent), collectBatchWithDelay is 55.8 percent of alloc bytes (reducible), PUBLISH fan-out is 2.5-3.3us per sub not 50-200ns, all allocs perfectly deterministic (0 percent variance). Delivered in 4 phases with 13 tasks. All gates passed including race detection and drift verification.